### PR TITLE
Fix wrong module name in version output

### DIFF
--- a/components/chef-workstation/lib/chef-workstation/main.rb
+++ b/components/chef-workstation/lib/chef-workstation/main.rb
@@ -10,7 +10,7 @@ module ChefWorkstation
       @config = CLIConfig.new
       parse_cli_params!
 
-      puts "Version #{Chef::VERSION}" if config.version
+      puts "Version #{ChefWorkstation::VERSION}" if config.version
       puts @parser if config.help
       if !config.version && !config.help
         puts short_banner


### PR DESCRIPTION
This was missed in the module rename. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>