### PR TITLE
Use library for loading user-facing text

### DIFF
--- a/components/chef-workstation/Gemfile.lock
+++ b/components/chef-workstation/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/chef/mixlib-config.git
+  remote: git://github.com/chef/mixlib-config.git
   revision: 8f6a1ffb91d946dc396dff2599431016afa10feb
   branch: master
   specs:
@@ -12,6 +12,7 @@ PATH
     chef-workstation (0.1.0)
       awesome_print
       mixlib-config
+      r18n-desktop
 
 GEM
   remote: https://rubygems.org/
@@ -40,6 +41,9 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    r18n-core (3.0.1)
+    r18n-desktop (3.0.1)
+      r18n-core (= 3.0.1)
     rainbow (3.0.0)
     rake (10.5.0)
     rspec (3.7.0)

--- a/components/chef-workstation/chef-workstation.gemspec
+++ b/components/chef-workstation/chef-workstation.gemspec
@@ -26,13 +26,17 @@ Gem::Specification.new do |spec|
   spec.files = %w{Rakefile LICENSE.txt README.md} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks
     Dir.glob("*.gemspec") +
-    Dir.glob("{lib,spec,bin,vendor}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+    Dir.glob("{lib,bin,vendor,i18n}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mixlib-config"
   spec.add_dependency "awesome_print"
+
+  spec.add_dependency "mixlib-config" # shared chef configuration library that
+                                      # simplifies managing a configuration file
+  spec.add_dependency "r18n-desktop" # easy path to message text management via
+                                     # localization gem...
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -1,0 +1,30 @@
+
+# Used only by the CLI class
+cli:
+  # CLI option, banner, and usage text
+  config: Location of config file. Defaults to %1
+  version: "Show the current version of this tool"
+  help: "Show usage information for the chef command"
+  short_banner: "Usage:  chef COMMAND [options...]"
+  version_msg: "Version %1"
+  creating_config: "Creating config file in %1."
+  banner: |
+    Congratulations! You are using chef: your gateway
+    to managing everything from a single node to an entire Chef
+    infrastructure.
+
+    Required Arguments:
+      COMMAND - the command to execute, one of:
+        help - show command help
+
+    Flags:
+
+# Text specific to each command
+show_config:
+  source: "Config loaded from %1path %2"
+
+# Error definitions, usage Text.e.ERR888
+e:
+  ERR888: |
+    This is just a sample error definition
+

--- a/components/chef-workstation/lib/chef-workstation/command/show_config.rb
+++ b/components/chef-workstation/lib/chef-workstation/command/show_config.rb
@@ -1,14 +1,13 @@
 # TODO eventually when we have more commands we will want to do something closer to Shake Shack where we have a commands map and all the commands inherit from a base class. But thats too much scope creep for the current PR
 require "awesome_print"
 require "chef-workstation/config"
-
 module ChefWorkstation
   module Command
     class ShowConfig
 
       def run
         d = Config.using_default_location? ? "default " : ""
-        puts "Config loaded from #{d}path #{Config.location}"
+        puts Text.show_config.source(d, Config.location)
         ap Config.to_hash, {
           indent: 2,
           plain: true,

--- a/components/chef-workstation/lib/chef-workstation/text.rb
+++ b/components/chef-workstation/lib/chef-workstation/text.rb
@@ -1,0 +1,17 @@
+require "r18n-desktop"
+
+# A very thin wrapper around R18n, the idea being that we're likely to replace r18n
+# down the road and don't want to have to change all of our commands.
+module ChefWorkstation
+  class Text
+    class << self
+      def load
+        R18n.from_env("i18n/")
+      end
+
+      def method_missing(n, *p)
+        R18n.get.send(n, *p)
+      end
+    end
+  end
+end

--- a/components/chef-workstation/spec/spec_helper.rb
+++ b/components/chef-workstation/spec/spec_helper.rb
@@ -1,10 +1,15 @@
 require "bundler/setup"
+require "chef-workstation/text"
+RSpec.shared_context "Global helpers" do
+  let(:t) { ChefWorkstation::Text }
+end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+  config.include_context "Global helpers"
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/components/chef-workstation/spec/unit/cli_spec.rb
+++ b/components/chef-workstation/spec/unit/cli_spec.rb
@@ -17,6 +17,7 @@
 require "spec_helper"
 require "chef-workstation/cli"
 require "chef-workstation/telemetry"
+require "chef-workstation/text"
 
 RSpec.describe ChefWorkstation::Cli do
   let(:argv) { [] }
@@ -70,7 +71,7 @@ RSpec.describe ChefWorkstation::Cli do
 
     context "no cli_options" do
       it "prints the short_banner" do
-        expect(STDOUT).to receive(:puts).with(cli.short_banner)
+        expect(STDOUT).to receive(:puts).with(t.cli.short_banner)
         cli.perform_command
       end
     end
@@ -129,15 +130,6 @@ RSpec.describe ChefWorkstation::Cli do
       end
     end
 
-    context "given 'help'" do
-      let(:argv) { %w{help} }
-
-      it "should set cli_options.help true" do
-        cli.parse_cli_options!
-        expect(cli.cli_options.help).to eq(true)
-      end
-    end
-
     context "given an invalid option" do
       let(:argv) { %w{--invalid} }
 
@@ -145,31 +137,6 @@ RSpec.describe ChefWorkstation::Cli do
         expect { cli.parse_cli_options! }
           .to raise_error(OptionParser::InvalidOption)
       end
-    end
-  end
-
-  context "short_banner" do
-    it "should return a short banner" do
-      expect(cli.short_banner).to eq("Usage:  chef COMMAND [options...]")
-    end
-  end
-
-  context "banner" do
-    # We are testing the usage text becuase ux has sugned off on this wording.
-    it "should return a banner" do
-      expect(cli.banner).to eq <<EOM
-Usage:  chef COMMAND [options...]
-
-Congratulations! You are using chef: your gateway
-to managing everything from a single node to an entire Chef
-infrastructure.
-
-Required Arguments:
-    COMMAND - the command to execute, one of:
-       help - show command help
-
-Flags:
-EOM
     end
   end
 


### PR DESCRIPTION
This allows us to maintain text separately from the code,
opening the path to sharing (such as with the web site for error
messages, or other tools/components included with chef) and 
multi-language support in the future .