### PR TITLE
standard error handling

### DIFF
--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -137,6 +137,16 @@ errors:
     An unexpected error has occurred:
 
       %1
+
+  # Maps to: NameError
+  CHEFNET001: |
+    A network error occurred:
+
+      %1
+
+    Please verify the host is named correctly and is reachable
+    then try again.
+
   footer:
     both: |
       If you are not able to resolve this issue, please contact Chef support

--- a/components/chef-workstation/lib/chef-workstation/error.rb
+++ b/components/chef-workstation/lib/chef-workstation/error.rb
@@ -42,4 +42,30 @@ module ChefWorkstation
       @conn = connection
     end
   end
+  # Provides mappings of common errors that we don't explicitly
+  # handle, but can offer expanded help text around.
+  class StandardErrorResolver
+    def self.unwrap_exception(wrapper)
+      id = "CHEFINT001"
+      do_convert = true
+      show_log = true
+      show_stack = true
+      # This is going to be a common pattern
+      case wrapper.contained_exception
+      when SocketError
+        id = "CHEFNET001"; show_log = false; show_stack = false
+      else
+        do_convert = false
+      end
+      if do_convert
+        e = ChefWorkstation::Error.new(id, wrapper.contained_exception.message)
+        e.show_log = show_log
+        e.show_stack = show_stack
+        e
+      else
+        wrapper.contained_exception
+      end
+    end
+  end
+
 end

--- a/components/chef-workstation/lib/chef-workstation/ui/error_printer.rb
+++ b/components/chef-workstation/lib/chef-workstation/ui/error_printer.rb
@@ -33,9 +33,9 @@ module ChefWorkstation::UI
 
     DEFAULT_ERROR_NO = "CHEFINT001"
 
-    def initialize(wrapped_exception, conn = nil)
-      @wrapper = wrapped_exception
-      @exception = wrapped_exception.contained_exception
+    def initialize(wrapper, conn = nil)
+      @wrapper = wrapper
+      @exception = ChefWorkstation::StandardErrorResolver.unwrap_exception(wrapper)
       @conn = conn
       @pastel = Pastel.new
       @show_log = exception.respond_to?(:show_log) ? exception.show_log : true


### PR DESCRIPTION
Proposed change that provide a simple way to map standard errors to helpful descriptions, and customized 'show log/show stack'. 

We could probably do it with less code if we maintain a simple mappings file of type -> new message code+flags for showing logs. 

Before:
![before](https://user-images.githubusercontent.com/1130204/38114025-d5876c54-3374-11e8-88c9-e72b7b7482e9.png)

After:
![after](https://user-images.githubusercontent.com/1130204/38114040-dc080d54-3374-11e8-8e7c-ecedb3af5425.png)

