### PR TITLE
Slight cleanups to error handling

### DIFF
--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -144,8 +144,8 @@ errors:
 
       %1
 
-    Please verify the host is named correctly and is reachable
-    then try again.
+    Please verify the host name or address is correct and that the host is
+    reachable before trying again.
 
   footer:
     both: |
@@ -168,4 +168,4 @@ errors:
 
     neither:  |
       If you are not able to resolve this issue, please contact Chef support
-      at support@chef.io.
+      at support@chef.io

--- a/components/chef-workstation/lib/chef-workstation/command/base.rb
+++ b/components/chef-workstation/lib/chef-workstation/command/base.rb
@@ -130,7 +130,7 @@ module ChefWorkstation
         @command_spec.subcommands
       end
 
-      class OptionValidationError < ChefWorkstation::Error
+      class OptionValidationError < ChefWorkstation::ErrorNoLogs
         def initialize(id, *args); super(id, *args); end
       end
 

--- a/components/chef-workstation/lib/chef-workstation/error.rb
+++ b/components/chef-workstation/lib/chef-workstation/error.rb
@@ -42,29 +42,30 @@ module ChefWorkstation
       @conn = connection
     end
   end
+
   # Provides mappings of common errors that we don't explicitly
   # handle, but can offer expanded help text around.
   class StandardErrorResolver
     def self.unwrap_exception(wrapper)
-      id = "CHEFINT001"
-      do_convert = true
+      deps
       show_log = true
       show_stack = true
-      # This is going to be a common pattern
       case wrapper.contained_exception
-      when SocketError
-        id = "CHEFNET001"; show_log = false; show_stack = false
-      else
-        do_convert = false
+      when SocketError then id = "CHEFNET001"; show_log = false; show_stack = false
       end
-      if do_convert
+      if id.nil?
+        wrapper.contained_exception
+      else
         e = ChefWorkstation::Error.new(id, wrapper.contained_exception.message)
         e.show_log = show_log
         e.show_stack = show_stack
         e
-      else
-        wrapper.contained_exception
       end
+    end
+
+    def self.deps
+      # Avoid loading additional includes until they're needed
+      require "socket"
     end
   end
 

--- a/components/chef-workstation/spec/unit/cli_spec.rb
+++ b/components/chef-workstation/spec/unit/cli_spec.rb
@@ -1,4 +1,4 @@
-# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,7 +105,7 @@ RSpec.describe ChefWorkstation::CLI do
       expect(cli).to receive(:init)
       expect(cli).to receive(:have_command?).with("unknown").and_return(false)
       expect(cli).to receive(:capture_exception_backtrace)
-      expect_any_instance_of(ChefWorkstation::UI::ErrorPrinter).to receive(:show_error)
+      expect(ChefWorkstation::UI::ErrorPrinter).to receive(:show_error)
       expect { cli.run }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
     end
   end

--- a/components/chef-workstation/spec/unit/ui/error_printer_spec.rb
+++ b/components/chef-workstation/spec/unit/ui/error_printer_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe ChefWorkstation::UI::ErrorPrinter do
   let(:wrapped_exception) { ChefWorkstation::WrappedError.new(orig_exception, conn) }
   subject(:printer) { ChefWorkstation::UI::ErrorPrinter.new(wrapped_exception, nil) }
 
-  context "#show_error" do
-    it "creates and renders the message" do
-      expect(subject).to receive(:format_header).and_return "1"
-      expect(subject).to receive(:format_body).and_return "2"
-      expect(subject).to receive(:format_footer).and_return "3"
-      expect(ChefWorkstation::UI::Terminal).to receive(:output).with "1\n2\n3\n"
-      subject.show_error
+  context "#format_error" do
+    it "formats the message" do
+      expect(subject).to receive(:format_header).and_return "header"
+      expect(subject).to receive(:format_body).and_return "body"
+      expect(subject).to receive(:format_footer).and_return "footer"
+      expect(subject.format_error).to eq "\nheader\n\nbody\nfooter\n"
     end
   end
 
@@ -28,6 +27,7 @@ RSpec.describe ChefWorkstation::UI::ErrorPrinter do
         subject.format_body
       end
     end
+
     context "when exception is a Train::Error" do
       # These may expand as we find error-specific messaging we can provide to customers
       # for more specific train exceptions
@@ -90,13 +90,18 @@ RSpec.describe ChefWorkstation::UI::ErrorPrinter do
     end
   end
 
-  context "#write_backtrace" do
+  context ".write_backtrace" do
+    let(:inst) { double(ChefWorkstation::UI::ErrorPrinter) }
+    before do
+      allow(ChefWorkstation::UI::ErrorPrinter).to receive(:new).and_return inst
+    end
+
     let(:orig_args) { %w{test} }
     it "formats and saves the backtrace" do
-      expect(subject).to receive(:add_backtrace_header).with(anything(), orig_args)
-      expect(subject).to receive(:add_formatted_backtrace)
-      expect(subject).to receive(:save_backtrace)
-      subject.write_backtrace(orig_args)
+      expect(inst).to receive(:add_backtrace_header).with(anything(), orig_args)
+      expect(inst).to receive(:add_formatted_backtrace)
+      expect(inst).to receive(:save_backtrace)
+      ChefWorkstation::UI::ErrorPrinter.write_backtrace(wrapped_exception, orig_args)
     end
   end
 end


### PR DESCRIPTION
This consolidates the interface behind a singleton method so that 
callers don't have to do an extra 'unwrap' step prior to invoking.  

This also adds a common dump_unexpected_error class method to ensure 
that we always show an error, even when things go wrong enough 
that our error handling itself fails.
