### PR TITLE
Raise an exception when remote CCR fails

### DIFF
--- a/components/chef-workstation/Gemfile.lock
+++ b/components/chef-workstation/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: .
   specs:
-    chef-workstation (0.1.19)
+    chef-workstation (0.1.21)
       mixlib-cli
       mixlib-config
       mixlib-install

--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -147,6 +147,12 @@ errors:
     Please verify the host name or address is correct and that the host is
     reachable before trying again.
 
+  # Remote chef client run failure start here.
+  CHEFCCR001: |
+    The converge of the remote host failed.
+
+    Please examine the log file below for a detailed cause of failure.
+
   footer:
     both: |
       If you are not able to resolve this issue, please contact Chef support

--- a/components/chef-workstation/lib/chef-workstation/action/converge_target.rb
+++ b/components/chef-workstation/lib/chef-workstation/action/converge_target.rb
@@ -40,6 +40,7 @@ module ChefWorkstation::Action
           ChefWorkstation::Log.error("stdout: #{c.stdout}")
           ChefWorkstation::Log.error("stderr: #{c.stderr}")
         end
+        raise RemoteChefClientRunFailed.new
       end
     end
 
@@ -57,5 +58,8 @@ module ChefWorkstation::Action
       apply_args += "\""
     end
 
+    class RemoteChefClientRunFailed < ChefWorkstation::Error
+      def initialize(); super("CHEFCCR001"); end
+    end
   end
 end

--- a/components/chef-workstation/spec/unit/action/converge_target_spec.rb
+++ b/components/chef-workstation/spec/unit/action/converge_target_spec.rb
@@ -70,19 +70,19 @@ RSpec.describe ChefWorkstation::Action::ConvergeTarget do
       let(:result) { double("command result", exit_status: 1) }
       let(:stacktrace_result) { double("stacktrace scrape result", exit_status: 0, stdout: "") }
 
-      it "scrapes the remote log" do
+      it "scrapes the remote log and raises" do
         expect(reporter).to receive(:error).with(/converge/)
         expect(connection).to receive(:run_command).with(/chef-stacktrace/).and_return(stacktrace_result)
         expect(connection).to receive(:run_command).with(/del/).and_return(stacktrace_result)
-        action.perform_action
+        expect { action.perform_action }.to raise_error ChefWorkstation::Action::ConvergeTarget::RemoteChefClientRunFailed
       end
 
       context "when remote log cannot be retrieved" do
         let(:stacktrace_result) { double("stacktrace scrape result", exit_status: 1, stdout: "", stderr: "") }
-        it "logs results from the attempt" do
+        it "logs results from the attempt and raises" do
           expect(reporter).to receive(:error).with(/converge/)
           expect(connection).to receive(:run_command).with(/chef-stacktrace/).and_return(stacktrace_result)
-          action.perform_action
+          expect { action.perform_action }.to raise_error ChefWorkstation::Action::ConvergeTarget::RemoteChefClientRunFailed
         end
       end
     end


### PR DESCRIPTION


This will help be ensuring the location of log files
that we refer to in the task failure message is quickly
available when a remote CCR fails.

before: 
![before](https://user-images.githubusercontent.com/1130204/38204143-a64df13a-366f-11e8-86bc-f521469e95df.png)

after:
![after](https://user-images.githubusercontent.com/1130204/38204151-af8535ba-366f-11e8-8ac7-52b7ca105b81.png)


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>