### PR TITLE
Make plain-text spinner element avaialble via config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test_results/
+tags

--- a/components/chef-workstation/lib/chef-workstation/config.rb
+++ b/components/chef-workstation/lib/chef-workstation/config.rb
@@ -26,6 +26,9 @@ module ChefWorkstation
     config_context :cache do
       default(:path, File.join(WS_BASE_PATH, "cache"))
     end
+    config_context :dev do
+      default(:spinner, "TTY::Spinner")
+    end
 
     class << self
       @custom_location = nil

--- a/components/chef-workstation/lib/chef-workstation/ui/plain_text_element.rb
+++ b/components/chef-workstation/lib/chef-workstation/ui/plain_text_element.rb
@@ -1,0 +1,58 @@
+module ChefWorkstation
+  module UI
+    class PlainTextElement
+      def initialize(format, opts)
+        @orig_format = format
+        @format = format
+        @output = opts[:output]
+      end
+
+      def run(&block)
+        yield
+      end
+
+      def update(params)
+        # SOme of this is particular to our usage -
+        # prefix does not cause a text update, but does
+        # change the prefix for future messages.
+        if params.has_key?(:prefix)
+          @format = @orig_format.gsub(":prefix", params[:prefix])
+          return
+        end
+
+        if @succ
+          ind = "OK"
+          @succ = false
+          log_method = :info
+        elsif @err
+          ind = "ERR"
+          @err = false
+          log_method = :error
+        else
+          log_method = :debug
+          ind = " - "
+        end
+
+        # Since this is a generic type, we can replace any component
+        # name in this regex - but for now :spinner is the only component
+        # we're standing in for.
+        msg = @format.gsub(/:spinner/, ind)
+        params.each_pair do |k, v|
+          msg.gsub!(/:#{k}/, v)
+        end
+        ChefWorkstation::Log.send(log_method, msg)
+        @output.puts(msg)
+      end
+
+      def error
+        @err = true
+        @succ = false
+      end
+
+      def success
+        @succ = true
+        @err = false
+      end
+    end
+  end
+end

--- a/components/chef-workstation/lib/chef-workstation/ui/terminal.rb
+++ b/components/chef-workstation/lib/chef-workstation/ui/terminal.rb
@@ -1,5 +1,8 @@
-require "chef-workstation/status_reporter"
 require "tty-spinner"
+require "chef-workstation/status_reporter"
+require "chef-workstation/config"
+require "chef-workstation/log"
+require "chef-workstation/ui/plain_text_element"
 
 module ChefWorkstation
   module UI
@@ -12,17 +15,21 @@ module ChefWorkstation
           @location = location
         end
 
+        def write(msg)
+          @location.write(msg)
+        end
+
         def output(msg)
           @location.puts msg
         end
 
         def spinner(msg, prefix: "", &block)
-          spinner = TTY::Spinner.new("[:spinner] :prefix :status", output: @location)
+          klass = Object.const_get("ChefWorkstation::UI::#{ChefWorkstation::Config.dev.spinner}")
+          spinner = klass.new("[:spinner] :prefix :status", output: @location)
           reporter = StatusReporter.new(spinner, prefix: prefix, key: :status)
           reporter.update(msg)
           spinner.run { yield(reporter) }
         end
-
       end
     end
   end


### PR DESCRIPTION
This adds a PlainTextElement that has an interface like a TTY::Spinner
but provides update-per-line plain text output.

This is useful when debugging with pry while a spinner
is running; without it, the spinner refreshes interfere
with the IRB session.

To enable this, add the following to config.toml:
```
[dev]
spinner="PlainTextElement"
```

Output example: 

…ts/chef-workstation$ be chef target converge winrm://user:password@192.168.1.204 user user1
[ - ] [192.168.1.204] Connecting...
[ - ] [192.168.1.204] Connected.
[ - ] [192.168.1.204] Verifying Chef client installation.
[ - ] [192.168.1.204] Downloading Chef client installer.
[ - ] [192.168.1.204] Uploading Chef client installer.
[ - ] [192.168.1.204] Installing Chef client.
[ - ] [192.168.1.204] Chef client installation completed!
[ - ] [192.168.1.204] Converging user[user1]...
[ - ] [192.168.1.204] Successfully converged user[user1]!

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>