### PR TITLE
Support for connecting to winrm over ssl

### DIFF
--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -57,6 +57,13 @@ commands:
                             the name of the user you wanted to create.
       root_description: "Whether to use root permissions on the target. Defaults to true."
       identity_file: "SSH identity file to use when connecting."
+      ssl:
+        desc: "Use SSL for WinRM. Current default: %1"
+        verify_desc: |
+          Verify peer certificate when using SSL for WinRM
+          Use --ssl-no-verify when using SSL for WinRM and
+          the remote host is using a self-signed certificate.
+          Current default: %1
       status:
         verifying: Verifying Chef client installation.
         converging: Converging %1...
@@ -210,6 +217,20 @@ errors:
 
     Please verify the host name or address is correct and that the host is
     reachable before trying again.
+
+  # Maps to: SSL::SSLError with message text indicating verification failure
+  CHEFNET002: |
+    SSL host verification failed.
+
+    I could not verify the identity of the remote host.
+
+    If you are certain that you are connecting to the correct host,
+    you can specify the '--no-ssl-verify' option for this command, or
+    make it the default by setting the following in your configuration:
+
+      [connection.winrm]
+      ssl_verify=false
+
   footer:
     both: |
       If you are not able to resolve this issue, please contact Chef support

--- a/components/chef-workstation/lib/chef-workstation/config.rb
+++ b/components/chef-workstation/lib/chef-workstation/config.rb
@@ -26,6 +26,14 @@ module ChefWorkstation
     config_context :cache do
       default(:path, File.join(WS_BASE_PATH, "cache"))
     end
+
+    config_context :connection do
+      config_context :winrm do
+        default(:ssl, false)
+        default(:ssl_verify, true)
+      end
+    end
+
     config_context :dev do
       default(:spinner, "TTY::Spinner")
     end

--- a/components/chef-workstation/lib/chef-workstation/error.rb
+++ b/components/chef-workstation/lib/chef-workstation/error.rb
@@ -59,6 +59,12 @@ module ChefWorkstation
       show_log = true
       show_stack = true
       case wrapper.contained_exception
+      when OpenSSL::SSL::SSLError
+        if wrapper.contained_exception.message =~ /SSL.*verify failed.*/
+          id = "CHEFNET002"
+          show_log = false
+          show_stack = false
+        end
       when SocketError then id = "CHEFNET001"; show_log = false; show_stack = false
       end
       if id.nil?

--- a/components/chef-workstation/lib/chef-workstation/remote_connection.rb
+++ b/components/chef-workstation/lib/chef-workstation/remote_connection.rb
@@ -28,11 +28,16 @@ class ChefWorkstation::RemoteConnection
 
   def initialize(host_url, opts = {}, logger = nil)
     target_url = maybe_add_default_scheme(host_url)
-    conn_opts = { sudo: opts.has_key?(:sudo) ? opts[:sudo] : false,
-                  target: target_url,
-                  key_files: opts[:key_file],
-                  logger: ChefWorkstation::Log }
-    @config = Train.target_config(conn_opts)
+    cfg = { target: target_url,
+            sudo: opts.has_key?(:root) ? opts[:root] : true,
+            key_files: opts[:identity_file],
+            logger: ChefWorkstation::Log }
+    if opts.has_key? :ssl
+      cfg[:ssl] = opts[:ssl]
+      cfg[:self_signed] = opts[:ssl_verify] == false ? true : false
+    end
+
+    @config = Train.target_config(cfg)
     @type = Train.validate_backend(@config)
     @train_connection = Train.create(@type, config)
   end

--- a/components/chef-workstation/lib/chef-workstation/ui/error_printer.rb
+++ b/components/chef-workstation/lib/chef-workstation/ui/error_printer.rb
@@ -46,8 +46,8 @@ module ChefWorkstation::UI
       formatter.add_backtrace_header(out, args)
       formatter.add_formatted_backtrace(out)
       formatter.save_backtrace(out)
-    rescue => e
-      dump_unexpected_error(e)
+    rescue => ex
+      dump_unexpected_error(ex)
     end
 
     # Use this to dump an an exception to output. useful


### PR DESCRIPTION
Small PR to enable ssl connections for WinRM. 

This still needs validation against a running WinRM instance with SSL enabled, and a minor update to `Target::Converge#perform_command` in order to make connection parameters testsable. 


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>