### PR TITLE
Use  instead of ~/Development/Chef/chef-workstation/components/chef-w…

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -9,9 +9,9 @@ set -evx
 sed -i -r "s/VERSION = \".*\"/VERSION = \"$(cat VERSION)\"/"  components/chef-workstation/lib/chef-workstation/version.rb
 
 # Ensure our Gemfile.lock reflects the new version
-pushd components/chef-workstation
+cd components/chef-workstation
 bundle update chef-workstation
-popd
+cd ../..
 
 # run readme update script.
 # TODO: Remove this when expeditor issue requiring mixlib install definition


### PR DESCRIPTION
…orkstation ~ since expeditor doesn't support them.

Signed-off-by: Jon Morrow <jmorrow@chef.io>