### PR TITLE
Update readme urls before change log

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -27,13 +27,13 @@ merge_actions:
         - "Expeditor: Skip All"
   - bash:.expeditor/update_version.sh:
       only_if: built_in:bump_version
+  - bash:.expeditor/update_readme_download_urls.sh:
+      only_if: built_in:bump_version
   - built_in:update_changelog:
       ignore_labels:
         - "Meta: Exclude From Changelog"
         - "Expeditor: Exclude From Changelog"
         - "Expeditor: Skip All"
-  - bash:.expeditor/update_readme_download_urls.sh:
-      only_if: built_in:bump_version
   - built_in:trigger_omnibus_release_build:
       ignore_labels:
         - "Omnibus: Skip Build"


### PR DESCRIPTION
It seems update_changelog is where the commit to master happens so we need to update the readme before.

Signed-off-by: Jon Morrow jmorrow@chef.io