### PR TITLE
re-add lost openssl require

### DIFF
--- a/components/chef-workstation/lib/chef-workstation/error.rb
+++ b/components/chef-workstation/lib/chef-workstation/error.rb
@@ -80,6 +80,7 @@ module ChefWorkstation
     def self.deps
       # Avoid loading additional includes until they're needed
       require "socket"
+      require "openssl"
     end
   end
 


### PR DESCRIPTION
This seems to have been lost in a merge. 