### PR TITLE
[SHACK-101] alias support

### DIFF
--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -1,14 +1,6 @@
-# Used only by the CLI class
+# Shared and top-level CLI output text.
 cli:
-
   # CLI option, banner, and usage text
-  config: Location of config file. Defaults to %1
-  version: "Show the current version of this tool"
-  print_version: "Chef Workstation Version: %1\n\n"
-  help: "Show usage information"
-  short_banner: "Usage:  chef COMMAND [options...]"
-  version_msg: "Version %1"
-  creating_config: "Creating config file in %1."
   banner: |
     Congratulations! You are using chef: your gateway
     to managing everything from a single node to an entire Chef
@@ -16,8 +8,19 @@ cli:
 
     USAGE:
       chef [SUBCOMMAND]
-  target: ""
   aborted: Canceling request due to interrupt.
+  alias_for: "Alias for: "
+  aliases: "ALIASES:"
+  config: Location of config file. Defaults to %1
+  creating_config: "Creating config file in %1."
+  help: "Show usage information"
+  print_version: "Chef Workstation Version: %1\n\n"
+  short_banner: "Usage:  chef COMMAND [options...]"
+  subcommands: "SUBCOMMANDS:"
+  target: ""
+  version: "Show the current version of this tool"
+  version_msg: "Version %1"
+
 # Text specific to each command
 commands:
   config:

--- a/components/chef-workstation/lib/chef-workstation/builtin_commands.rb
+++ b/components/chef-workstation/lib/chef-workstation/builtin_commands.rb
@@ -17,15 +17,15 @@
 require "chef-workstation/commands_map"
 require "chef-workstation/text"
 
-cmds = ChefWorkstation::Text.commands
+text = ChefWorkstation::Text.commands
 
 ChefWorkstation.commands do |c|
   # TODO must be a better API we can do than `top_level` and `create`
-  c.top_level("target", :Target, cmds.target, "chef-workstation/command/target", subcommands: [
-    c.create("converge", [:Target, :Converge], cmds.target.converge, "chef-workstation/command/target/converge"),
+  c.top_level("target", :Target, text.target, "chef-workstation/command/target", subcommands: [
+    c.create("converge", [:Target, :Converge], text.target.converge, "chef-workstation/command/target/converge", cmd_alias: "converge" ),
   ])
 
-  c.top_level("config", :Config, cmds.config, "chef-workstation/command/config", subcommands: [
-    c.create("show", [:Config, :Show], cmds.config.show, "chef-workstation/command/config/show"),
+  c.top_level("config", :Config, text.config, "chef-workstation/command/config", subcommands: [
+    c.create("show", [:Config, :Show], text.config.show, "chef-workstation/command/config/show"),
   ])
 end

--- a/components/chef-workstation/spec/unit/commands_map_spec.rb
+++ b/components/chef-workstation/spec/unit/commands_map_spec.rb
@@ -21,16 +21,20 @@ require "chef-workstation/commands_map"
 RSpec.describe ChefWorkstation::CommandsMap do
   subject(:mapping) { ChefWorkstation::CommandsMap.new }
   let(:example_text) { double("text", description: "description", usage: "USAGE:\n") }
+  let(:example_cmd) { mapping.top_level("example", :TestCommand, example_text, "unit/fixtures/command/cli_test_command") }
+  let(:subcmd1) { mapping.create("subcommand1", [:TopLevel, :Subcommand], example_text, "unit/fixtures/command/cli_test_command") }
+  let(:subcmd2) { mapping.create("subcommand2", :AliasedCommand, example_text, "unit/fixtures/command/cli_test_command", cmd_alias: "subby") }
+  let(:subcommands) { [subcmd1, subcmd2] }
+  let(:parent_cmd) { mapping.top_level("top-level", :TopLevel, example_text, "", subcommands: subcommands) }
 
   before do
-    mapping.top_level("example", :TestCommand, example_text, "unit/fixtures/command/cli_test_command")
-    mapping.top_level("top-level", :TopLevel, example_text, "", subcommands: [
-      mapping.create("subcommand", [:TopLevel, :Subcommand], example_text, ""),
-    ])
+    # Referencing these will cause themt o be instantiated and added to the map:
+    example_cmd
+    parent_cmd
   end
 
   it "defines the attributes correctly" do
-    expect(mapping.have_command?("example")).to be true
+    expect(mapping.have_command_or_alias?("example")).to be true
     e = mapping.command_specs["example"]
     expect(e.require_path).to eq("unit/fixtures/command/cli_test_command")
     expect(e.make_banner).to eq("description\n\nUSAGE:\n")
@@ -41,11 +45,24 @@ RSpec.describe ChefWorkstation::CommandsMap do
   end
 
   it "correctly stores a subcommand" do
-    expect(mapping.command_specs["top-level"].subcommands.size).to eq(1)
-    expect(mapping.command_specs["top-level"].subcommands.values[0].name).to eq("subcommand")
+    expect(mapping.command_specs["top-level"].subcommands.size).to eq(2)
+    expect(mapping.command_specs["top-level"].subcommands.values[0]).to eq subcmd1
   end
 
   it "creates an instance of a command" do
     expect(mapping.instantiate("example")[0]).to be_an_instance_of(ChefWorkstation::Command::TestCommand)
   end
+
+  it "creates an instance of the correct command when an alias is used" do
+    expect(mapping.instantiate("subby")[0]).to be_an_instance_of(ChefWorkstation::Command::AliasedCommand)
+  end
+
+  it "assigns qualified names to commands correctly" do
+    ChefWorkstation.assign_parentage!(mapping.command_specs)
+    expect(subcmd1.qualified_name).to eq "top-level subcommand1"
+    expect(subcmd2.qualified_name).to eq "top-level subcommand2"
+    expect(example_cmd.qualified_name).to eq "example"
+    expect(parent_cmd.qualified_name).to eq "top-level"
+  end
+
 end

--- a/components/chef-workstation/spec/unit/fixtures/command/cli_test_command.rb
+++ b/components/chef-workstation/spec/unit/fixtures/command/cli_test_command.rb
@@ -38,5 +38,7 @@ module ChefWorkstation
         23
       end
     end
+    class AliasedCommand < TestCommand
+    end
   end
 end


### PR DESCRIPTION
Add alias support.

Aliases can be declared as part of a command definition,
eg:
```
commands.do |c|
 c.top_level("test", :Test, "test-text", 'commands/test', subcommands: [
    c.create("subtest", [:Test, :Sub], "subtest-text",
    "commands/subtest", cmd_alias: "subby")
    ])
end
```
This will allow the command to be instantiated via
CommandMap#instantiate  by passing in the alias as the command name.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
NOTE:  #this is built atop #72, the extra changes to cli.rb and cli_spec.rb will clear up once that lands.