### PR TITLE
[SHACK-143] set the omnibus kitchen config to perform the omnibus build during converge

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -13,27 +13,17 @@ driver:
 provisioner:
   name: chef_zero
 
+# only run one of these at a time if you are interested in using the
+# omnibus package produced; the build process begins by cleaning up
+# prior built artifacts in pkg/ which is shared across VMs
 platforms:
-  - name: centos-7.1
-    run_list: yum-epel::default
-  - name: centos-6.6
-    run_list: yum-epel::default
-  - name: centos-5.11
-    run_list: yum-epel::default
-  - name: debian-7.8
-    run_list: apt::default
-  - name: debian-6.0.10
-    run_list: apt::default
-  - name: freebsd-10.1
-    run_list: freebsd::portsnap
-  - name: freebsd-9.3
-    run_list:
-      - freebsd::portsnap
-      - freebsd::pkgng
+  - name: centos-7
+  - name: centos-6
+  - name: debian-9
+  - name: debian-8
+  - name: debian-7
+  - name: ubuntu-16.04
   - name: ubuntu-14.04
-    run_list: apt::default
-  - name: ubuntu-12.04
-    run_list: apt::default
 
 suites:
   - name: default

--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -5,9 +5,3 @@ cookbook "chef-workstation-builder",
 
 # Uncomment to use the latest version of the Omnibus cookbook from GitHub
 # cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'
-
-group :integration do
-  cookbook "apt",      "~> 2.8"
-  cookbook "freebsd",  "~> 0.3"
-  cookbook "yum-epel", "~> 0.6"
-end

--- a/omnibus/cookbooks/chef-workstation-builder/attributes/default.rb
+++ b/omnibus/cookbooks/chef-workstation-builder/attributes/default.rb
@@ -1,0 +1,2 @@
+default['chef-workstation-builder']['log_level'] = 'info'
+default['chef-workstation-builder']['live_stream'] = true

--- a/omnibus/cookbooks/chef-workstation-builder/metadata.rb
+++ b/omnibus/cookbooks/chef-workstation-builder/metadata.rb
@@ -6,4 +6,6 @@ description      'Builds a Chef Workstation package'
 long_description 'Builds a Chef Workstation package'
 version          '1.0.0'
 
-depends          'omnibus'
+depends 'omnibus'
+depends 'apt',      '~> 2.8'
+depends 'yum-epel', '~> 0.6'

--- a/omnibus/cookbooks/chef-workstation-builder/recipes/default.rb
+++ b/omnibus/cookbooks/chef-workstation-builder/recipes/default.rb
@@ -1,14 +1,23 @@
+# ensure packages available up-to-date
+case node['platform_family']
+when 'debian'
+  include_recipe 'apt::default'
+when 'rhel'
+  include_recipe 'yum-epel::default'
+end
+
 include_recipe 'omnibus::default'
 
 execute 'fix bundler directory permissions' do
   command "chown -R #{node['omnibus']['build_user']} #{node['omnibus']['build_user_home']}/.bundle"
+  only_if { Dir.exist? "#{node['omnibus']['build_user_home']}/.bundle" }
 end
 
 omnibus_build 'chef-workstation' do
   environment 'HOME' => node['omnibus']['build_user_home']
   project_dir node['omnibus']['build_dir']
-  log_level :internal
-  live_stream true
+  log_level node['chef-workstation-builder']['log_level'].to_sym
+  live_stream node['chef-workstation-builder']['live_stream']
   config_overrides(
     append_timestamp: true
   )


### PR DESCRIPTION
This add's a new cookbook that handles the omnibus install requirements and then perform the build in a single `kitchen test <platform>` or `kitchen converge <platform>`.

Also:

* update platforms for linuxes and versions we intend to support
* move the apt/yum default updating to the new builder cookbook default recipe where it can be handled with a case statement for platform
* make the log level and build output configurable via attributes in the builder cookbook
* I think IDE is the default controller type in Vagrant/Virtualbox, so use that.