### PR TITLE
Rename attributes -> properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Chef Workstation installs everything you need to get started using Chef on Windo
 
    * Want to perform an ad-hoc task? Try
     
-    `chef target converge <Target host|IP|SSH|WinRM> <Resource> <Resource Name> [attributes] [flags]`
+    `chef target converge <Target host|IP|SSH|WinRM> <Resource> <Resource Name> [properties] [flags]`
     
     `chef target converge user@hostname user timmy`
     

--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -147,11 +147,11 @@ errors:
       https://docs.chef.io/resource_reference.html#%4
 
   CHEFCCR004: |
-    An attribute value you provided is not valid:
+    A property value you provided is not valid:
 
       %1
 
-    Please consult the documentation for attributes
+    Please consult the documentation for properties
     supported by %2 and their valid values:
 
       https://docs.chef.io/resource_reference.html#%2
@@ -164,10 +164,10 @@ errors:
       https://docs.chef.io/resource_reference.html
 
   CHEFCCR006: |
-    '%1' is not an attribute of '%2'.
+    '%1' is not a property of '%2'.
 
     Please consult the documentation for %2 for a list of
-    valid attributes:
+    valid properties:
 
       https://docs.chef.io/resource_reference.html#%3
 

--- a/components/chef-workstation/lib/chef-workstation/action/converge_target.rb
+++ b/components/chef-workstation/lib/chef-workstation/action/converge_target.rb
@@ -3,17 +3,17 @@ require "chef-workstation/text"
 
 module ChefWorkstation::Action
   class ConvergeTarget < Base
-    attr_reader :resource_type, :resource_name, :attributes
+    attr_reader :resource_type, :resource_name, :properties
     def initialize(config)
       super(config)
       @resource_type = @config.delete :resource_type
       @resource_name = @config.delete :resource_name
-      @attributes = @config.delete(:attributes) || []
+      @properties = @config.delete(:properties) || []
     end
 
     def perform_action
       apply_args = create_apply_args
-      ChefWorkstation::Log.debug("Converging  #{resource_type} #{resource_name} with attributes #{attributes}")
+      ChefWorkstation::Log.debug("Converging  #{resource_type} #{resource_name} with properties #{properties}")
       c = connection.run_command("#{chef_apply} --no-color -e #{apply_args}")
       if c.exit_status == 0
         ChefWorkstation::Log.debug(c.stdout)
@@ -50,10 +50,10 @@ module ChefWorkstation::Action
 
     def create_apply_args
       apply_args = "\"#{resource_type} '#{resource_name}'"
-      # lets format the attributes into the correct syntax Chef expects
-      unless attributes.empty?
+      # lets format the properties into the correct syntax Chef expects
+      unless properties.empty?
         apply_args += " do; "
-        attributes.each do |k, v|
+        properties.each do |k, v|
           v = "'#{v}'" if v.is_a? String
           apply_args += "#{k} #{v}; "
         end

--- a/components/chef-workstation/lib/chef-workstation/errors/ccr_failure_mapper.rb
+++ b/components/chef-workstation/lib/chef-workstation/errors/ccr_failure_mapper.rb
@@ -32,19 +32,19 @@ module ChefWorkstation::Errors
       # cases of things that will match more general tests further down.
       case @cause_line
       when /.*had an error:(.*:)\s+(.*$)/
-        # Some invalid attribute value cases, among others.
+        # Some invalid property value cases, among others.
         ["CHEFCCR002", $2, resource_doc_anchor]
       when /.*Chef::Exceptions::ValidationFailed:\s+Option action must be equal to one of:\s+(.*). You passed :(.*)\./
-        # Invalid action - specialization of invalid attribute value, below
+        # Invalid action - specialization of invalid property value, below
         ["CHEFCCR003", params[:resource], $2, $1, resource_doc_anchor()]
       when /.*Chef::Exceptions::ValidationFailed:\s+(.*)/
-        # Invalid resource attribute value
+        # Invalid resource property value
         ["CHEFCCR004", $1, params[:resource], resource_doc_anchor()]
       when /.*NoMethodError: undefined method `#{params[:resource]}'.*/
         # Invalid resource type in most cases
         ["CHEFCCR005", params[:resource]]
       when /.*undefined method `(.*)'.*for Chef::Resource.*/
-        # Unknown resource attribute
+        # Unknown resource property
         ["CHEFCCR006", $1, params[:resource], resource_doc_anchor()]
 
       # Below would catch the general form of most errors, but the

--- a/components/chef-workstation/spec/unit/action/base_spec.rb
+++ b/components/chef-workstation/spec/unit/action/base_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ChefWorkstation::Action::Base do
   subject(:action) { ChefWorkstation::Action::Base.new(opts) }
 
   context "#initialize" do
-    it "properly initializes exposed attribute readers" do
+    it "properly initializes exposed attr readers" do
       expect(action.connection).to eq connection
       expect(action.config).to eq({ other: "something-else" })
     end

--- a/components/chef-workstation/spec/unit/action/converge_target_spec.rb
+++ b/components/chef-workstation/spec/unit/action/converge_target_spec.rb
@@ -12,26 +12,26 @@ RSpec.describe ChefWorkstation::Action::ConvergeTarget do
   end
   let(:r1) { "directory" }
   let(:r2) { "/tmp" }
-  let(:attrs) { nil }
-  let(:opts) { { reporter: reporter, connection: connection, resource_type: r1, resource_name: r2, attributes: attrs } }
+  let(:props) { nil }
+  let(:opts) { { reporter: reporter, connection: connection, resource_type: r1, resource_name: r2, properties: props } }
   subject(:action) { ChefWorkstation::Action::ConvergeTarget.new(opts) }
 
   describe "#initialize" do
-    it "properly initializes exposed attribute readers" do
+    it "properly initializes exposed attr readers" do
       expect(action.resource_type).to eq r1
       expect(action.resource_name).to eq r2
     end
   end
 
   describe "#create_apply_args" do
-    context "when no attributes are provided" do
+    context "when no properties are provided" do
       it "it creates a simple resource" do
         expect(action.create_apply_args).to eq("\"directory '/tmp'\"")
       end
     end
 
-    context "when attributes are provided" do
-      let(:attrs) do
+    context "when properties are provided" do
+      let(:props) do
         {
           "key1" => "value",
           "key2" => 0.1,
@@ -41,7 +41,7 @@ RSpec.describe ChefWorkstation::Action::ConvergeTarget do
         }
       end
 
-      it "convertes the attributes to chef-apply args" do
+      it "converts the properties to chef-apply args" do
         expect(action.create_apply_args).to eq(
           "\"directory '/tmp' do; " \
           "key1 'value'; " \

--- a/components/chef-workstation/spec/unit/command/target/converge_spec.rb
+++ b/components/chef-workstation/spec/unit/command/target/converge_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ChefWorkstation::Command::Target::Converge do
       end
     end
 
-    it "raises an error if attributes are not specified as key value pairs" do
+    it "raises an error if properties are not specified as key value pairs" do
       params = [
         %w{one two three four},
         %w{one two three four=value five six=value},
@@ -52,8 +52,8 @@ RSpec.describe ChefWorkstation::Command::Target::Converge do
     end
   end
 
-  describe "#format_attributes" do
-    it "parses attributes into a hash" do
+  describe "#format_properties" do
+    it "parses properties into a hash" do
       provided = %w{key1=value key2=1 key3=true key4=FaLsE key5=0777 key6=https://some.website}
       expected = {
         "key1" => "value",
@@ -63,7 +63,7 @@ RSpec.describe ChefWorkstation::Command::Target::Converge do
         "key5" => "0777",
         "key6" => "https://some.website",
       }
-      expect(cmd.format_attributes(provided)).to eq(expected)
+      expect(cmd.format_properties(provided)).to eq(expected)
     end
 
   end

--- a/components/chef-workstation/spec/unit/commands_map_spec.rb
+++ b/components/chef-workstation/spec/unit/commands_map_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ChefWorkstation::CommandsMap do
     parent_cmd
   end
 
-  it "defines the attributes correctly" do
+  it "defines the properties correctly" do
     expect(mapping.have_command_or_alias?("example")).to be true
     e = mapping.command_specs["example"]
     expect(e.require_path).to eq("unit/fixtures/command/cli_test_command")

--- a/components/chef-workstation/spec/unit/errors/ccr_failure_mapper_spec.rb
+++ b/components/chef-workstation/spec/unit/errors/ccr_failure_mapper_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ChefWorkstation::Errors::CCRFailureMapper do
   subject { ChefWorkstation::Errors::CCRFailureMapper.new(stack, params) }
 
   describe "#exception_args_from_cause" do
-    context "when resource attributes have valid names but invalid values" do
-      context "and the attribute is 'action'" do
+    context "when resource properties have valid names but invalid values" do
+      context "and the property is 'action'" do
         let(:cause_line) { "Chef::Exceptions::ValidationFailed: Option action must be equal to one of: nothing, install, upgrade, remove, purge, reconfig, lock, unlock!  You passed :marve." }
         it "returns a correct CHEFCCR003" do
           expect(subject.exception_args_from_cause).to eq(
@@ -25,7 +25,7 @@ RSpec.describe ChefWorkstation::Errors::CCRFailureMapper do
         end
       end
 
-      context "and the attribute is something else" do
+      context "and the property is something else" do
         context "and details are available" do
           let(:cause_line) { "Chef::Exceptions::ValidationFailed: Option force must be a kind of [TrueClass, FalseClass]!  You passed \"purle\"." }
           it "returns a correct CHEFCCR004 when details are available" do
@@ -55,12 +55,12 @@ RSpec.describe ChefWorkstation::Errors::CCRFailureMapper do
       end
     end
 
-    context "when a resource attribute does not exist for the given resource" do
-      let(:cause_line) { "NoMethodError: undefined method `badresourceattr' for Chef::Resource::User::LinuxUser" }
+    context "when a resource property does not exist for the given resource" do
+      let(:cause_line) { "NoMethodError: undefined method `badresourceprop' for Chef::Resource::User::LinuxUser" }
       it "returns a correct CHEFCCR006 " do
         expect(subject.exception_args_from_cause).to eq(
           ["CHEFCCR006",
-            "badresourceattr",
+            "badresourceprop",
             "apt_package", "apt-package" ])
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe ChefWorkstation::Errors::CCRFailureMapper do
       end
 
       context "and can resolve the cause" do
-        let(:cause_line) { "NoMethodError: undefined method `badresourceattr' for Chef::Resource::User::LinuxUser" }
+        let(:cause_line) { "NoMethodError: undefined method `badresourceprop' for Chef::Resource::User::LinuxUser" }
         it "raises a RemoteChefClientRunFailed" do
           expect { subject.raise_mapped_exception! }.to raise_error(ChefWorkstation::Errors::CCRFailureMapper::RemoteChefClientRunFailed)
         end

--- a/docs/clibuddy/inline-target-converge-resource.bdy
+++ b/docs/clibuddy/inline-target-converge-resource.bdy
@@ -2,8 +2,8 @@ commands
   chef
     flow
       for show resource package
-        .description Show the commonly used attributes for the resource given.
-        .show-text The package resource supports the following attributes:
+        .description Show the commonly used properties for the resource given.
+        .show-text The package resource supports the following properties:
         .table Attribute|Description|Env Var
           action|action to perform|package_action
           version|package version to install|package_version
@@ -13,10 +13,10 @@ commands
         .description Show additional helpful hints for 'show package'.
         .use show resource package
         .show-text You can set these options on the command line in the
-        .show-text form attr=VALUE after other options/arguments:
+        .show-text form prop=VALUE after other options/arguments:
         .show-text .t CMD target converge /TARGET package nginx version=1.0
         .show-text .n
-        .show-text You can set the environment variable shown in 'Env Var' for each attribute.
+        .show-text You can set the environment variable shown in 'Env Var' for each property.
         .show-text This can be either preceding the command:
         .show-text .t version=1.0 CMD target converge /TARGET package nginx
         .show-text .n
@@ -46,11 +46,11 @@ commands
           .success after 1s [TARGET] RESOURCE[RS_NAME] applied successfully!
 
       for target converge * package * action=remove version=9.2
-        .description Custom action and additional attribute
+        .description Custom action and additional property
         .use target converge * package * action=remove
 
       for target converge * with package nginx using version=9.2 action=install
-        .description  Optional 'with' and 'using' keywords and action+attributes
+        .description  Optional 'with' and 'using' keywords and action+properties
         .use target converge TARGET package nginx
 
       for target converge * with package nginx version=9.2
@@ -85,7 +85,7 @@ commands
       RS_NAME
        the name property to supply to the resource
       [ATTRIBUTES]
-        one or more cookbook attributes in the form name=value,
+        one or more cookbook properties in the form name=value,
         separated by spaces. This must be the final argument.
       --*help
         shows usage details for this command
@@ -101,7 +101,7 @@ commands
         will be presented to you before applying to the remote node, and an
         opportunity to stop the run will be given before any change is applied.
       --extended-help
-        Used with 'show', provides examples of how resource attributes can be set.
+        Used with 'show', provides examples of how resource properties can be set.
     usage
       short
         Apply RESOURCE to TARGET


### PR DESCRIPTION
In order to maintain consistency with Chef terminology, rename `attributes` to `properties` where Resources are concerned.

Signed-off-by: Seth Thomas <sthomas@chef.io>