### PR TITLE
[SHACK-137] given a bad flag, display an invalid flag error instead of an invalid command error

### DIFF
--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -205,6 +205,11 @@ errors:
 
       Available commands are: %2
 
+  CHEFCLI002: |
+    '%1' is not a valid flag.
+
+      Available options are: %2
+
   # CLI Validation errors are prefixed with CHEFVAL
   CHEFVAL001: |
     No identity file at '%1'

--- a/components/chef-workstation/lib/chef-workstation/cli.rb
+++ b/components/chef-workstation/lib/chef-workstation/cli.rb
@@ -112,6 +112,10 @@ module ChefWorkstation
       elsif %w{version --version -v}.include?(command_name.downcase)
         UI::Terminal.output ChefWorkstation::VERSION
         return
+      elsif command_name.start_with?("-")
+        # with the known flags for the root chef command handled by this point,
+        # if it's still a flag we don't know what to do with it
+        raise UnknownFlag.new(command_name, options.each_value.map { |o| o[:long] })
       end
       run_command!(command_name, command_params)
     rescue => e
@@ -210,6 +214,12 @@ module ChefWorkstation
     class UnknownCommand < ErrorNoLogs
       def initialize(command_name, avail_commands)
         super("CHEFCLI001", command_name, avail_commands)
+      end
+    end
+
+    class UnknownFlag < ErrorNoLogs
+      def initialize(option, avail_options)
+        super("CHEFCLI002", option, avail_options)
       end
     end
   end


### PR DESCRIPTION
This adds an invalid flag error to the root chef command. Instead of telling the user that the flag they used is an invalid _command_, tell them that it is an invalid _flag_.

Before:

    > chef --nope

    CHEFCLI001

    The command '--nope' does not exist.

    Available commands are: target config

After:

    > chef --nope

    CHEFCLI002

    '--nope' is not a valid flag.

      Available options are: ["--version", "--help"]

Totally open to word-smithing and maybe improving the display of those available options.