### PR TITLE
Ensure that we return the path of the cached file.

### DIFF
--- a/components/chef-workstation/lib/chef-workstation/file_fetcher.rb
+++ b/components/chef-workstation/lib/chef-workstation/file_fetcher.rb
@@ -5,37 +5,46 @@ require "chef-workstation/log"
 
 module ChefWorkstation
   class FileFetcher
-    def self.fetch(path)
-      cache_path = ChefWorkstation::Config.cache.path
-      FileUtils.mkdir_p(cache_path)
-      url = URI.parse(path)
-      name = File.basename(url.path)
-      local_path = File.join(cache_path, name)
+    class << self
+      # Simple fetcher of an http(s) url. Returns the local path
+      # of the downloaded file.
+      def fetch(path)
+        cache_path = ChefWorkstation::Config.cache.path
+        FileUtils.mkdir_p(cache_path)
+        url = URI.parse(path)
+        name = File.basename(url.path)
+        local_path = File.join(cache_path, name)
 
-      # TODO header check for size or checksum?
-      return local_path if File.exist?(local_path)
+        # TODO header check for size or checksum?
+        return local_path if File.exist?(local_path)
 
-      temp_path = "#{local_path}.downloading"
-      file = open(temp_path, "wb")
-      ChefWorkstation::Log.debug "Downloading: #{temp_path}"
-      Net::HTTP.start(url.host) do |http|
-        begin
-          http.request_get(url.path) do |resp|
-            resp.read_body do |segment|
-              file.write(segment)
+        download_file(url, local_path)
+        local_path
+      end
+
+      def download_file(url, local_path)
+        temp_path = "#{local_path}.downloading"
+        file = open(temp_path, "wb")
+        ChefWorkstation::Log.debug "Downloading: #{temp_path}"
+        Net::HTTP.start(url.host) do |http|
+          begin
+            http.request_get(url.path) do |resp|
+              resp.read_body do |segment|
+                file.write(segment)
+              end
             end
-          end
-        rescue e
-          @error = true
-          raise
-        ensure
-          file.close()
-          # If any failures occurred, don't risk keeping
-          # an incomplete download that we'll see as 'cached'
-          if @error
-            FileUtils.rm_f(temp_path)
-          else
-            FileUtils.mv(temp_path, local_path)
+          rescue e
+            @error = true
+            raise
+          ensure
+            file.close()
+            # If any failures occurred, don't risk keeping
+            # an incomplete download that we'll see as 'cached'
+            if @error
+              FileUtils.rm_f(temp_path)
+            else
+              FileUtils.mv(temp_path, local_path)
+            end
           end
         end
       end

--- a/components/chef-workstation/spec/unit/file_fetcher_spec.rb
+++ b/components/chef-workstation/spec/unit/file_fetcher_spec.rb
@@ -1,0 +1,23 @@
+require "chef-workstation/file_fetcher"
+require "spec_helper"
+
+RSpec.describe ChefWorkstation::FileFetcher do
+  let(:expected_local_location) { File.join(ChefWorkstation::Config.cache.path, "example.txt") }
+  subject { ChefWorkstation::FileFetcher }
+  describe ".fetch" do
+    it "returns the local path when the file is cached" do
+      allow(FileUtils).to receive(:mkdir)
+      expect(File).to receive(:exist?).with(expected_local_location).and_return(true)
+      result = subject.fetch("https://example.com/example.txt")
+      expect(result).to eq expected_local_location
+    end
+
+    it "returns the local path when the file is fetched" do
+      allow(FileUtils).to receive(:mkdir)
+      expect(File).to receive(:exist?).with(expected_local_location).and_return(false)
+      expect(subject).to receive(:download_file)
+      result = subject.fetch("https://example.com/example.txt")
+      expect(result).to eq expected_local_location
+    end
+  end
+end


### PR DESCRIPTION
Previously when the file was downloaded (vs already cached)
we were returning the http status string by not being explicit.

Added some test coverage here, and split up FileFetcher for better testability.