### PR TITLE
Specify repo path to prevent cheffs content from publishing to user home

### DIFF
--- a/components/chef-workstation/lib/chef-workstation/action/converge_target.rb
+++ b/components/chef-workstation/lib/chef-workstation/action/converge_target.rb
@@ -59,6 +59,7 @@ module ChefWorkstation::Action
         local_mode true
         color false
         cache_path "#{cache_path}"
+        chef_repo_path "#{cache_path}"
       EOM
 
       begin


### PR DESCRIPTION
This ensures we don't write out  a `nodes` dir to chef's assumed default repo location of /home/$USER. 
