### PR TITLE
[SHACK-158] Add basic custom handler

### DIFF
--- a/components/chef-workstation/i18n/en.yml
+++ b/components/chef-workstation/i18n/en.yml
@@ -300,6 +300,9 @@ errors:
 
   CHEFUPL003: |
     Uploading config to target failed.
+  
+  CHEFUPL004: |
+    Uploading handler to target failed.
 
   # Maps to: SSL::SSLError with message text indicating verification failure
   CHEFNET002: |

--- a/components/chef-workstation/lib/chef-workstation/action/base.rb
+++ b/components/chef-workstation/lib/chef-workstation/action/base.rb
@@ -30,13 +30,13 @@ module ChefWorkstation
           windows: '#{ENV[\'APPDATA\']}/chef-workstation',
           other: "/var/chef-workstation",
         },
-        read_chef_stacktrace: {
-          windows: "type $env:APPDATA/chef-workstation/cache/chef-stacktrace.out",
-          other: "cat /var/chef-workstation/cache/chef-stacktrace.out",
+        read_chef_report: {
+          windows: "type $env:APPDATA/chef-workstation/cache/run-report.json",
+          other: "cat /var/chef-workstation/cache/run-report.json",
         },
-        delete_chef_stacktrace: {
-          windows: "del /f $env:APPDATA/chef-workstation/chef-stacktrace.out",
-          other: "rm -f /var/chef-workstation/cache/chef-stacktrace.out",
+        delete_chef_report: {
+          windows: "del /f $env:APPDATA/chef-workstation/run-report.json",
+          other: "rm -f /var/chef-workstation/cache/run-report.json",
         },
         tempdir: {
           windows: "%TEMP%",

--- a/components/chef-workstation/lib/chef-workstation/action/reporter.rb
+++ b/components/chef-workstation/lib/chef-workstation/action/reporter.rb
@@ -1,0 +1,22 @@
+require "chef/handler"
+require "chef/resource/directory"
+
+module ChefWorkstation
+  class Reporter < ::Chef::Handler
+
+    def report
+      if exception
+        Chef::Log.error("Creating exception report")
+      else
+        Chef::Log.info("Creating run report")
+      end
+
+      #ensure start time and end time are output in the json properly in the event activesupport happens to be on the system
+      run_data = data
+      run_data[:start_time] = run_data[:start_time].to_s
+      run_data[:end_time] = run_data[:end_time].to_s
+
+      Chef::FileCache.store("run-report.json", Chef::JSONCompat.to_json_pretty(run_data), 0640)
+    end
+  end
+end

--- a/components/chef-workstation/lib/chef-workstation/errors/ccr_failure_mapper.rb
+++ b/components/chef-workstation/lib/chef-workstation/errors/ccr_failure_mapper.rb
@@ -4,9 +4,9 @@ module ChefWorkstation::Errors
   class CCRFailureMapper
     attr_reader :params
 
-    def initialize(stack, params)
+    def initialize(exception, params)
       @params = params
-      @cause_line = stack[1]
+      @cause_line = exception
     end
 
     def raise_mapped_exception!

--- a/components/chef-workstation/spec/unit/action/base_spec.rb
+++ b/components/chef-workstation/spec/unit/action/base_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ChefWorkstation::Action::Base do
   end
 
   shared_examples "check path fetching" do
-    [:chef_client, :read_chef_stacktrace].each do |path|
+    [:chef_client, :read_chef_report].each do |path|
       it "correctly returns path #{path}" do
         expect(action.send(path)).to be_a(String)
       end

--- a/components/chef-workstation/spec/unit/errors/ccr_failure_mapper_spec.rb
+++ b/components/chef-workstation/spec/unit/errors/ccr_failure_mapper_spec.rb
@@ -5,12 +5,11 @@ require "chef-workstation/errors/ccr_failure_mapper"
 RSpec.describe ChefWorkstation::Errors::CCRFailureMapper do
   let(:cause_line) { nil }
   let(:resource) { "apt_package" }
-  let(:stack) { ["", cause_line] }
   let(:params) do
     { resource: resource, resource_name: "a-test-thing",
       stderr: "an error", stdout: "other output" }
   end
-  subject { ChefWorkstation::Errors::CCRFailureMapper.new(stack, params) }
+  subject { ChefWorkstation::Errors::CCRFailureMapper.new(cause_line, params) }
 
   describe "#exception_args_from_cause" do
     context "when resource properties have valid names but invalid values" do


### PR DESCRIPTION
- Add a basic report handler (error and success)
- parse handler generated file instead of chef-stacktrace.out

Right now this is minimally invasive and re-uses the existing parsing code.

Signed-off-by: Seth Thomas <sthomas@chef.io>