### PR TITLE
[SHACK-145] Introduce TargetResolver

### DIFF
--- a/components/chef-workstation/lib/chef-workstation/target_resolver.rb
+++ b/components/chef-workstation/lib/chef-workstation/target_resolver.rb
@@ -1,0 +1,16 @@
+require "chef-workstation/remote_connection"
+
+module ChefWorkstation
+  class TargetResolver
+    def initialize(unparsed_target, conn_options)
+      @unparsed_target = unparsed_target
+      @conn_options = conn_options
+    end
+
+    def targets
+      @targets ||= @unparsed_target.split(",").map do |target|
+        RemoteConnection.new(target, @conn_options)
+      end
+    end
+  end
+end

--- a/components/chef-workstation/spec/target_resolver_spec.rb
+++ b/components/chef-workstation/spec/target_resolver_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "chef-workstation/target_resolver"
+
+RSpec.describe ChefWorkstation::TargetResolver do
+  let(:target_string) { "" }
+  subject { ChefWorkstation::TargetResolver.new(target_string, {}) }
+
+  context "#targets" do
+    context "when no target is provided" do
+      let(:target_string) { "" }
+      it "returns an empty array" do
+        expect(subject.targets).to eq []
+      end
+    end
+
+    context "when a single target is provided" do
+      let(:target_string) { "ssh://localhost" }
+      it "returns any array with one target" do
+        actual_targets = subject.targets
+        expect(actual_targets[0].config[:host]).to eq "localhost"
+      end
+    end
+
+    context "when a comma-separated list of targets is provided" do
+      let(:target_string) { "ssh://node1.example.com,winrm://node2.example.com" }
+      it "returns an array with correct RemoteConnection instances" do
+        actual_targets = subject.targets
+        expect(actual_targets[0].config[:host]).to eq "node1.example.com"
+        expect(actual_targets[1].config[:host]).to eq "node2.example.com"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just a simple implementation for now, it will split a comma-separated
list into multiple RemoteConnections (to be renamed TargetHost)

This is only the TargetResolver implementation; `converge` does not yet make use of this. 