### PR TITLE
Removing thread ability to print exception information to stdout

### DIFF
--- a/components/chef-workstation/lib/chef-workstation/ui/terminal.rb
+++ b/components/chef-workstation/lib/chef-workstation/ui/terminal.rb
@@ -13,6 +13,11 @@ module ChefWorkstation
 
         def init(location)
           @location = location
+          # In Ruby 2.5+ threads print out to stdout when they raise an exception. This is an agressive
+          # attempt to ensure debugging information is not lost, but in our case it is not necessary
+          # because we handle all the errors ourself. So we disable this to keep output clean.
+          # See https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
+          Thread.report_on_exception = false
         end
 
         def write(msg)


### PR DESCRIPTION
```
[chef-workstation]$ be chef converge vagrant@192.168.33.51 foo bar
[✔] [192.168.33.51] Connected.
[✔] [192.168.33.51] Client already present on system.
[✖] [192.168.33.51] Failed to converge target.
#<Thread:0x00007f808baf17f8@/Users/tball/.rvm/gems/ruby-2.5.1@chef-workstation/gems/tty-spinner-0.8.0/lib/tty/spinner.rb:290 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	13: from /Users/tball/.rvm/gems/ruby-2.5.1@chef-workstation/gems/tty-spinner-0.8.0/lib/tty/spinner.rb:290:in `block in run'
	12: from /Users/tball/.rvm/gems/ruby-2.5.1@chef-workstation/gems/tty-spinner-0.8.0/lib/tty/spinner.rb:208:in `execute_job'
	11: from /Users/tball/.rvm/gems/ruby-2.5.1@chef-workstation/gems/tty-spinner-0.8.0/lib/tty/spinner.rb:208:in `instance_eval'
	10: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/ui/terminal.rb:35:in `block in spinner'
	 9: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/command/target/converge.rb:89:in `block in run'
	 8: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/command/target/converge.rb:227:in `converge'
	 7: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/action/base.rb:74:in `run'
	 6: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/telemetry.rb:49:in `timed_capture'
	 5: from /Users/tball/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
	 4: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/telemetry.rb:49:in `block in timed_capture'
	 3: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/action/base.rb:75:in `block in run'
	 2: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/action/converge_target.rb:23:in `perform_action'
	 1: from /Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/action/converge_target.rb:99:in `handle_ccr_error'
/Users/tball/github/chef-workstation/components/chef-workstation/lib/chef-workstation/errors/ccr_failure_mapper.rb:20:in `raise_mapped_exception!': ChefWorkstation::Errors::CCRFailureMapper::RemoteChefClientRunFailed (ChefWorkstation::Errors::CCRFailureMapper::RemoteChefClientRunFailed)

CHEFCCR005

'foo' is not a valid Chef resource.

Please consult the documentation for a list of valid resources:

  https://docs.chef.io/resource_reference.html

If you are not able to resolve this issue, please contact Chef support
at beta@chef.io
```