### PR TITLE
Quick bugfix

### DIFF
--- a/components/chef-workstation/lib/chef-workstation/command/base.rb
+++ b/components/chef-workstation/lib/chef-workstation/command/base.rb
@@ -81,7 +81,7 @@ module ChefWorkstation
       # while providing visual feedback via the Terminal API.
       def connect_target(target_host, reporter = nil)
         if reporter.nil?
-          UI::Terminal.spinner(T.status.connecting, prefix: "[#{target_host.config[:host]}]") do |rep|
+          UI::Terminal.render_action(T.status.connecting, prefix: "[#{target_host.config[:host]}]") do |rep|
             target_host.connect!
             rep.success(T.status.connected)
           end


### PR DESCRIPTION
Missed in https://github.com/chef/chef-workstation/pull/97/files. We got rid of the `.spinner` api, renamed it to `render_action`