### PR TITLE
Enable simplecov coverage reporting

### DIFF
--- a/components/chef-workstation/.gitignore
+++ b/components/chef-workstation/.gitignore
@@ -1,3 +1,4 @@
 .rspec_status
 .vagrant
 *.log
+coverage/

--- a/components/chef-workstation/Gemfile.lock
+++ b/components/chef-workstation/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       paint (>= 0.9, < 3.0)
     did_you_mean (1.2.1)
     diff-lcs (1.3)
+    docile (1.3.0)
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
@@ -323,6 +324,11 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     solve (4.0.0)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 3.0)
@@ -397,6 +403,7 @@ DEPENDENCIES
   rake
   rspec
   rspec_junit_formatter
+  simplecov
 
 BUNDLED WITH
    1.16.1

--- a/components/chef-workstation/chef-workstation.gemspec
+++ b/components/chef-workstation/chef-workstation.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "pry-stack_explorer"
   spec.add_development_dependency "rspec_junit_formatter"

--- a/components/chef-workstation/spec/spec_helper.rb
+++ b/components/chef-workstation/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 require "bundler/setup"
+require "simplecov"
 require "chef-workstation/text"
 require "chef-workstation/log"
 require "chef-workstation/ui/terminal"
 require "rspec/expectations"
 require "support/matchers/output_to_terminal"
-
 require "r18n-desktop"
 
 RSpec.shared_context "Global helpers" do
@@ -70,3 +70,9 @@ RSpec.configure do |config|
     ChefWorkstation::UI::Terminal.init(File.open("/dev/null", "w"))
   end
 end
+
+if ENV["CIRCLE_ARTIFACTS"]
+  dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
+  SimpleCov.coverage_dir(dir)
+end
+SimpleCov.start


### PR DESCRIPTION
Local builds will capture to 'components/chef-workstation/coverage'
while CircleCI builds will capture to $CIRCLE_ARTIFACTS/coverage

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>