### PR TITLE
Add more vagrant hosts for multitarget testing

### DIFF
--- a/components/chef-workstation/.gitignore
+++ b/components/chef-workstation/.gitignore
@@ -1,2 +1,3 @@
 .rspec_status
 .vagrant
+*.log

--- a/components/chef-workstation/Vagrantfile
+++ b/components/chef-workstation/Vagrantfile
@@ -1,10 +1,10 @@
 Vagrant.configure("2") do |config|
   config.ssh.forward_agent = true
 
-  config.vm.define "ubuntu1" do |node|
+  def ubuntu_xenial_definition(node, name, final_octet, ssh_port)
     node.vm.box = "ubuntu/xenial64"
-    node.vm.hostname = "ubuntu1"
-    node.vm.network "private_network", ip: "192.168.33.51"
+    node.vm.hostname = "#{name}"
+    node.vm.network "private_network", ip: "192.168.33.#{final_octet}"
     node.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
     node.vm.provider "virtualbox" do |v|
       # Keep these light, we're not really using them except to
@@ -15,6 +15,22 @@ Vagrant.configure("2") do |config|
       # disk IO (such as installing chef via dpkg)
       v.customize ["storagectl", :id, "--name", "SCSI", "--hostiocache", "on"]
     end
+  end
+
+  config.vm.define "ubuntu1" do |node|
+    ubuntu_xenial_definition(node, "ubuntu1", 51, 2221)
+  end
+  config.vm.define "ubuntu2" do |node|
+    ubuntu_xenial_definition(node, "ubuntu2", 52, 2222)
+  end
+  config.vm.define "ubuntu3" do |node|
+    ubuntu_xenial_definition(node, "ubuntu3", 53, 2223)
+  end
+  config.vm.define "ubuntu4" do |node|
+    ubuntu_xenial_definition(node, "ubuntu4", 54, 2224)
+  end
+  config.vm.define "ubuntu5" do |node|
+    ubuntu_xenial_definition(node, "ubuntu2", 55, 2225)
   end
 
   config.vm.define "windows1" do |node|
@@ -28,9 +44,9 @@ Vagrant.configure("2") do |config|
     node.vm.guest = :windows
     node.windows.halt_timeout = 15
 
-    node.vm.network "private_network", ip: "192.168.33.52"
+    node.vm.network "private_network", ip: "192.168.33.61"
     node.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
-    node.vm.network :forwarded_port, guest: 22, host: 2223, id: "ssh", auto_correct: true
+    node.vm.network :forwarded_port, guest: 22, host: 2231, id: "ssh", auto_correct: true
 
     node.vm.provider :virtualbox do |v, override|
       #v.gui = true
@@ -39,21 +55,4 @@ Vagrant.configure("2") do |config|
       v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
   end
-
-  config.vm.define "ubuntu2" do |node|
-    node.vm.box = "ubuntu/xenial64"
-    node.vm.hostname = "ubuntu1"
-    node.vm.network "private_network", ip: "192.168.33.53"
-    node.vm.network :forwarded_port, guest: 22, host: 2224, id: "ssh", auto_correct: true
-    node.vm.provider "virtualbox" do |v|
-      # Keep these light, we're not really using them except to
-      # run chef client
-      v.memory = 512
-      v.cpus = 1
-      # Allow host caching - many images don't have it by default but it significantly speeds up
-      # disk IO (such as installing chef via dpkg)
-      v.customize ["storagectl", :id, "--name", "SCSI", "--hostiocache", "on"]
-    end
-  end
-
 end


### PR DESCRIPTION
This adds some Ubuntu hosts, and assigns consistent ssh ports & ips 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>