### PR TITLE
[SHACK-165] include a more complete collection of tooling from DK

### DIFF
--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -34,18 +34,74 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-
 build_version Omnibus::BuildVersion.semver
 build_iteration 1
 
 override :bundler,        version: "1.16.1"
 override :rubygems,       version: "2.7.6"
 override :ruby,           version: "2.5.1"
+override :"chef-dk",      version: "master"
+
+# DK's overrides; god have mercy on my soul
+# This comes from DK's ./omnibus_overrides.rb
+# If this stays, may need to duplicate that file and the rake
+# tasks for updating dependencies
+override :rubygems, version: "2.7.6"
+override :bundler, version: "1.16.1"
+override "libffi", version: "3.2.1"
+override "libiconv", version: "1.15"
+override "liblzma", version: "5.2.3"
+override "libtool", version: "2.4.2"
+override "libxml2", version: "2.9.7"
+override "libxslt", version: "1.1.30"
+override "libyaml", version: "0.1.7"
+override "makedepend", version: "1.0.5"
+override "ncurses", version: "5.9"
+override "pkg-config-lite", version: "0.28-1"
+override "ruby", version: "2.5.1"
+override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
+override "util-macros", version: "1.19.0"
+override "xproto", version: "7.0.28"
+override "zlib", version: "1.2.11"
+override "libzmq", version: "4.0.7"
+override "openssl", version: "1.0.2o"
 
 dependency "preparation"
+
+if windows?
+  dependency "git-windows"
+else
+  dependency "git-custom-bindir"
+end
+
+# For the Delivery build nodes
+dependency "delivery-cli"
+# This is a build-time dependency, so we won't leave it behind:
+dependency "rust-uninstall"
+
 dependency "chef-workstation"
+
+dependency "gem-permissions"
+dependency "rubygems-customization"
+
+if windows?
+  dependency "chef-dk-env-customization"
+  dependency "chef-dk-powershell-scripts"
+end
+
 dependency "version-manifest"
 dependency "clean-static-libs"
+dependency "openssl-customization"
+
+dependency "stunnel" if fips_mode?
+
+# This *has* to be last, as it mutates the build environment and causes all
+# compilations that use ./configure et all (the msys env) to break
+if windows?
+  dependency "ruby-windows-devkit"
+  dependency "ruby-windows-devkit-bash"
+  dependency "ruby-windows-system-libraries"
+end
 
 exclude "**/.git"
 exclude "**/bundler/git"

--- a/omnibus/config/software/chef-dk-env-customization.rb
+++ b/omnibus/config/software/chef-dk-env-customization.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: Copyright (c) 2015-2018, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is a windows only dependency
+
+name "chef-dk-env-customization"
+
+skip_transitive_dependency_licensing true
+license :project_license
+
+source path: "#{project.files_path}/#{name}"
+
+dependency "ruby"
+
+build do
+  # lazied because we need ruby to get installed first
+  block "Add chefdk_env_customization file" do
+    source_customization_file = "#{project_dir}/windows/chefdk_env_customization.rb"
+
+    site_ruby = Bundler.with_clean_env do
+      ruby = windows_safe_path("#{install_dir}/embedded/bin/ruby")
+      `#{ruby} -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']"`.strip
+    end
+
+    if site_ruby.nil? || site_ruby.empty?
+      raise "Could not determine embedded Ruby's site directory, aborting!"
+    end
+
+    create_directory site_ruby
+    copy_file source_customization_file, site_ruby
+  end
+end

--- a/omnibus/config/software/chef-dk-powershell-scripts.rb
+++ b/omnibus/config/software/chef-dk-powershell-scripts.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: Copyright (c) 2015-2018, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is a windows only dependency
+
+name "chef-dk-powershell-scripts"
+
+skip_transitive_dependency_licensing true
+license :project_license
+
+build do
+  block "Install windows powershell scripts" do
+    # Copy the chef gem's distro stuff over
+    chef_gem_path = File.expand_path("../..", shellout!("#{install_dir}/embedded/bin/gem which chef").stdout.chomp)
+
+    chef_module_dir = "#{install_dir}/modules/chef"
+    create_directory(chef_module_dir)
+    Dir.glob("#{chef_gem_path}/distro/powershell/chef/*").each do |file|
+      copy_file(file, chef_module_dir)
+    end
+  end
+end

--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -1,0 +1,125 @@
+#
+# Copyright 2014-2018, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOTE - This is a straight copy of the git.rb definition in omnibus-software
+# EXCEPT we specify a custom bindir when running make. We do this because
+# we only want to include the Git binaries at the end of a user's path
+# when they run `chef shell-init`. This is a temporary solution until we
+# shave the yak of moving ruby into /opt/chefdk/bin and putting
+# /opt/chefdk/embedded/bin at the end of the user's path.
+# TODO - when deleting this, also delete omnibus/config/templates/git-custom-bindir
+
+name "git-custom-bindir"
+default_version "2.14.1"
+
+license "LGPL-2.1"
+license_file "LGPL-2.1"
+
+dependency "curl"
+dependency "zlib"
+dependency "openssl"
+dependency "pcre"
+dependency "libiconv" # FIXME: can we figure out how to remove this?
+dependency "expat"
+
+relative_path "git-#{version}"
+
+version "2.14.1" do
+  source md5: "b767f0b21aa41d10268b2075078d334e"
+end
+
+source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # We do a distclean so we ensure that the autoconf files are not trying to be
+  # clever.
+  make "distclean", env: env
+
+  # AIX needs /opt/freeware/bin only for patch
+  if aix?
+    patch_env = env.dup
+    patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
+
+    # But only needs the below for 1.9.5
+    if version == "1.9.5"
+      patch source: "aix-strcmp-in-dirc.patch", plevel: 1, env: patch_env
+    end
+  end
+
+  config_hash = {
+    # Universal options
+    NO_GETTEXT: "YesPlease",
+    NEEDS_LIBICONV: "YesPlease",
+    NO_INSTALL_HARDLINKS: "YesPlease",
+    NO_PERL: "YesPlease",
+    NO_PYTHON: "YesPlease",
+    NO_TCLTK: "YesPlease",
+  }
+
+  if freebsd?
+    config_hash["CHARSET_LIB"] = "-lcharset"
+    config_hash["FREAD_READS_DIRECTORIES"] = "UnfortunatelyYes"
+    config_hash["HAVE_CLOCK_GETTIME"] = "YesPlease"
+    config_hash["HAVE_CLOCK_MONOTONIC"] = "YesPlease"
+    config_hash["HAVE_GETDELIM"] = "YesPlease"
+    config_hash["HAVE_PATHS_H"] = "YesPlease"
+    config_hash["HAVE_STRINGS_H"] = "YesPlease"
+    config_hash["PTHREAD_LIBS"] = "-pthread"
+    config_hash["USE_ST_TIMESPEC"] = "YesPlease"
+    config_hash["HAVE_BSD_SYSCTL"] = "YesPlease"
+    config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
+  elsif solaris?
+    env["CC"] = "gcc"
+    env["SHELL_PATH"] = "#{install_dir}/embedded/bin/bash"
+    config_hash["NEEDS_SOCKET"] = "YesPlease"
+    config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
+  elsif aix?
+    env["CC"] = "xlc_r"
+    env["INSTALL"] = "/opt/freeware/bin/install"
+    # xlc doesn't understand the '-Wl,-rpath' syntax at all so... we don't enable
+    # the NO_R_TO_GCC_LINKER flag. This means that it will try to use the
+    # old style -R for libraries and as a result, xlc will ignore it. In this case, we
+    # we want that to happen because we explicitly set the libpath with the correct
+    # command line argument in omnibus itself.
+  else
+    # Linux things!
+    config_hash["HAVE_PATHS_H"] = "YesPlease"
+    config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
+  end
+
+  erb source: "config.mak.erb",
+      dest: "#{project_dir}/config.mak",
+      mode: 0755,
+      vars: {
+               cc: env["CC"],
+               ld: env["LD"],
+               cflags: env["CFLAGS"],
+               cppflags: env["CPPFLAGS"],
+               install: env["INSTALL"],
+               install_dir: install_dir,
+               ldflags: env["LDFLAGS"],
+               shell_path: env["SHELL_PATH"],
+               config_hash: config_hash,
+             }
+
+  # NOTE - If you run ./configure the environment variables set above will not be
+  # used and only the command line args will be used. The issue with this is you
+  # cannot specify everything on the command line that you can with the env vars.
+  make "prefix=#{install_dir}/embedded bindir=#{install_dir}/gitbin -j #{workers}", env: env
+  make "prefix=#{install_dir}/embedded bindir=#{install_dir}/gitbin install", env: env
+end

--- a/omnibus/config/software/hitimes-git.rb
+++ b/omnibus/config/software/hitimes-git.rb
@@ -1,0 +1,38 @@
+# Copyright 2012-2018, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "hitimes-git"
+
+license "ISC"
+license_file "https://github.com/copiousfreetime/hitimes/blob/master/LICENSE"
+skip_transitive_dependency_licensing true
+
+dependency "ruby"
+
+dependency "rubygems"
+dependency "bundler"
+
+source git: "https://github.com/copiousfreetime/hitimes"
+default_version "master"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  gemfile = windows? ? "hitimes-1.2.4-x86-mingw32.gem" : "hitimes-1.2.4.gem"
+
+  rake "gem", env: env
+
+  gem "install pkg/#{gemfile}", env: env
+end

--- a/omnibus/config/software/preparation.rb
+++ b/omnibus/config/software/preparation.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2012-2018, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "preparation"
+description "the steps required to preprare the build"
+default_version "1.0.0"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+# dirty preparation
+
+build do
+  block do
+    touch "#{install_dir}/embedded/lib/.gitkeep"
+    touch "#{install_dir}/embedded/bin/.gitkeep"
+    touch "#{install_dir}/bin/.gitkeep"
+  end
+end

--- a/omnibus/config/software/ruby-windows-system-libraries.rb
+++ b/omnibus/config/software/ruby-windows-system-libraries.rb
@@ -1,0 +1,37 @@
+name "ruby-windows-system-libraries"
+
+default_version "0.0.1"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+dependency "ruby"
+
+build do
+  if windows?
+    # Needed now that we switched to msys2 and have not figured out how to tell
+    # it how to statically link yet
+    dlls = [
+      "libwinpthread-1",
+      "libstdc++-6",
+      "libgcc_s_seh-1",
+    ]
+    dlls.each do |dll|
+      mingw = ENV["MSYSTEM"].downcase
+      msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
+      windows_path = "#{msys_path}/#{mingw}/bin/#{dll}.dll"
+      if File.exist?(windows_path)
+        copy windows_path, "#{install_dir}/embedded/bin/#{dll}.dll"
+      else
+        raise "Cannot find required DLL needed for dynamic linking: #{windows_path}"
+      end
+    end
+
+    if version.satisfies?(">= 2.4")
+      %w{ erb gem irb rdoc ri }.each do |cmd|
+        copy "#{project_dir}/bin/#{cmd}", "#{install_dir}/embedded/bin/#{cmd}"
+      end
+    end
+
+  end
+end

--- a/omnibus/config/software/rubygems-customization.rb
+++ b/omnibus/config/software/rubygems-customization.rb
@@ -1,0 +1,50 @@
+#
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rubygems-customization"
+
+skip_transitive_dependency_licensing true
+license :project_license
+
+source path: "#{project.files_path}/#{name}"
+
+dependency "ruby"
+dependency "rubygems"
+
+build do
+  block "Add Rubygems customization file" do
+    source_customization_file = if windows?
+                                  "#{project_dir}/windows/operating_system.rb"
+                                else
+                                  "#{project_dir}/default/operating_system.rb"
+                                end
+
+    site_ruby = Bundler.with_clean_env do
+      ruby = windows_safe_path("#{install_dir}/embedded/bin/ruby")
+      `#{ruby} -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']"`.strip
+    end
+
+    if site_ruby.nil? || site_ruby.empty?
+      raise "Could not determine embedded Ruby's site directory, aborting!"
+    end
+
+    destination = "#{site_ruby}/rubygems/defaults"
+
+    FileUtils.mkdir_p destination
+    FileUtils.cp source_customization_file, destination
+  end
+end

--- a/omnibus/config/templates/git-custom-bindir/config.mak.erb
+++ b/omnibus/config/templates/git-custom-bindir/config.mak.erb
@@ -1,0 +1,31 @@
+<%- if cc -%>
+CC=<%= cc %>
+<%-  end -%>
+<%- if ld -%>
+LD=<%= ld %>
+<%-  end -%>
+<%- if cflags -%>
+CFLAGS=<%= cflags %>
+<%-  end -%>
+<%- if cppflags -%>
+CPPFLAGS=<%= cppflags %>
+<%-  end -%>
+<%- if ldflags -%>
+LDFLAGS=<%= ldflags %>
+<%-  end -%>
+<%- if install -%>
+INSTALL=<%= install %>
+<%-  end -%>
+<%- if shell_path -%>
+SHELL_PATH=<%= shell_path %>
+<%-  end -%>
+CURLDIR=<%= install_dir %>/embedded
+EXPATDIR=<%= install_dir %>/embedded
+ICONVDIR=<%= install_dir %>/embedded
+LIBPCREDIR=<%= install_dir %>/embedded
+OPENSSLDIR=<%= install_dir %>/embedded
+ZLIB_PATH=<%= install_dir %>/embedded
+
+<%- config_hash.each_pair do |k, v| -%>
+<%= k.to_s %>=<%= v %>
+<%- end -%>

--- a/omnibus/files/chef-dk-env-customization/windows/chefdk_env_customization.rb
+++ b/omnibus/files/chef-dk-env-customization/windows/chefdk_env_customization.rb
@@ -1,0 +1,54 @@
+## Environment hacks for running Ruby with ChefDK ##
+# ENV['HOME'] is not set by default on Windows. We need to set this to
+# something sensible since a lot of Ruby code depends on it. It is important
+# for this directory to exist and be available, so we are introducing logic
+# here to pick a working HOME
+#
+# You can find this file in the repo at https://github.com/chef/omnibus-chef
+
+if !ENV["HOME"] || !File.exists?(ENV["HOME"])
+  old_home = ENV["HOME"]
+  found = false
+  alternate_homes = []
+  alternate_homes << "#{ENV['HOMEDRIVE']}#{ENV['HOMEPATH']}" if ENV["HOMEDRIVE"]
+  alternate_homes << "#{ENV['USERPROFILE']}" if ENV["USERPROFILE"]
+
+  alternate_homes.each do |path|
+    if File.exists?(path)
+      ENV["HOME"] = path
+      found = true
+      break
+    end
+  end
+
+  STDERR.puts <<-EOF
+The HOME (#{old_home}) environment variable was not set, or was set to
+an inaccessible location. Because this can prevent you from running many
+of the programs included with ChefDK, we will attempt to find another
+suitable location.
+
+  EOF
+
+  if found
+    STDERR.puts <<-EOF
+Falling back to using #{ENV['HOME']} as the home directory. If you would like
+to use another directory as HOME, please set the HOME environment variable.
+    EOF
+  else
+    STDERR.puts <<-EOF
+Could not find a suitable HOME directory. Tried:
+#{alternate_homes.join("\n")}
+
+Some Ruby binaries may not function correctly. You can set the HOME
+environment variable to a directory that exists to try to solve this.
+    EOF
+  end
+
+  STDERR.puts <<-EOF
+
+If you would not like ChefDK to try to fix the HOME environment variable,
+check the CHEFDK_ENV_FIX environment variable. Setting this value to 0
+prevent this modification to your HOME environment variable.
+
+  EOF
+end

--- a/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
+++ b/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script sets the SSL_CERT_FILE environment variable to the CA cert bundle
+# that ships with omnibus packages of Chef and Chef DK. If this environment
+# variable is already configured, this script is a no-op.
+#
+# This is required to make Chef tools use https URLs out of the box.
+
+unless ENV.key?("SSL_CERT_FILE")
+  base_dirs = File.dirname(__FILE__).split(File::SEPARATOR)
+
+  (base_dirs.length - 1).downto(0) do |i|
+    candidate_ca_bundle = File.join(base_dirs[0..i] + [ "ssl/certs/cacert.pem" ])
+    if File.exist?(candidate_ca_bundle)
+      ENV["SSL_CERT_FILE"] = candidate_ca_bundle
+      break
+    end
+  end
+end

--- a/omnibus/files/rubygems-customization/default/operating_system.rb
+++ b/omnibus/files/rubygems-customization/default/operating_system.rb
@@ -1,0 +1,26 @@
+## Rubygems Customization ##
+# Customize rubygems install behavior and locations to keep user gems isolated
+# from the stuff we bundle with omnibus and any other ruby installations on the
+# system.
+
+# Always install and update new gems in "user install mode"
+Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["install"] = "--user --no-document"
+Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["update"] = "--user --no-document"
+
+module Gem
+
+  ##
+  # Override user_dir to live inside of ~/.chefdk
+
+  class << self
+    # Remove method before redefining so we avoid a ruby warning
+    remove_method :user_dir
+
+    def user_dir
+      parts = [Gem.user_home, ".chefdk", "gem", ruby_engine]
+      parts << RbConfig::CONFIG["ruby_version"] unless RbConfig::CONFIG["ruby_version"].empty?
+      File.join parts
+    end
+  end
+
+end

--- a/omnibus/files/rubygems-customization/windows/operating_system.rb
+++ b/omnibus/files/rubygems-customization/windows/operating_system.rb
@@ -1,0 +1,73 @@
+## Rubygems Customization ##
+# Customize rubygems install behavior and locations to keep user gems isolated
+# from the stuff we bundle with omnibus and any other ruby installations on the
+# system.
+
+# Always install and update new gems in "user install mode"
+Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["install"] = "--user"
+Gem::ConfigFile::OPERATING_SYSTEM_DEFAULTS["update"] = "--user"
+
+# We will inject our hacks in if the user will allow it.
+begin
+  if (ENV["CHEFDK_ENV_FIX"] || "0").to_i != 0
+    require "chefdk_env_customization"
+  end
+rescue
+  nil
+end
+
+module Gem
+
+  ##
+  # Override user_dir to live inside of ~/.chefdk
+
+  def self.user_dir
+    chefdk_home_set = !([nil, ""].include? ENV["CHEFDK_HOME"])
+    # We call expand_path here because it converts \ -> /
+    # Rubygems seems to require that we not use \
+    default_home = File.join(File.expand_path(ENV["LOCALAPPDATA"]), "chefdk")
+
+    chefdk_home = if chefdk_home_set
+                    ENV["CHEFDK_HOME"]
+                  else
+                    old_home = File.join(Gem.user_home, ".chefdk")
+                    if File.exists?(old_home)
+                      Gem.ui.alert_warning <<-EOF
+
+        Chef Workstation now defaults to using #{default_home} instead of #{old_home}.
+        Since #{old_home} exists on your machine, Chef Workstation will continue
+        to make use of it. Please set the environment variable CHEFDK_HOME (yea, sorry about that)
+        to #{old_home} to remove this warning. This warning will be removed
+        in the next major version bump of Chef Workstation.
+                      EOF
+                      old_home
+                    else
+                      default_home
+                    end
+                  end
+
+    # Prevents multiple warnings
+    ENV["CHEFDK_HOME"] = chefdk_home
+
+    parts = [chefdk_home, "gem", ruby_engine]
+    parts << RbConfig::CONFIG["ruby_version"] unless RbConfig::CONFIG["ruby_version"].empty?
+    File.join parts
+  end
+
+end
+
+# :DK-BEG: override 'gem install' to enable RubyInstaller DevKit usage
+Gem.pre_install do |gem_installer|
+  win_install_dir = 'C:\\opscode\\chef-workstation'
+  unless gem_installer.spec.extensions.empty?
+    unless ENV["PATH"].include?("#{win_install_dir}\\embedded\\mingw\\bin")
+      Gem.ui.say "Temporarily enhancing PATH to include DevKit..." if Gem.configuration.verbose
+      ENV["PATH"] = "#{win_install_dir}\\embedded\\bin;#{win_install_dir}\\embedded\\mingw\\bin;#{ENV['PATH']}"
+    end
+    ENV["RI_DEVKIT"] = "#{win_install_dir}\\embedded"
+    ENV["CC"] = "gcc"
+    ENV["CXX"] = "g++"
+    ENV["CPP"] = "cpp"
+  end
+end
+# :DK-END:

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -26,7 +26,9 @@ else
 fi
 
 # TODO - pull from components/*/bin/*?
-binaries="chef"
+# We test for the presence of /usr/bin/chef-client to know if this script succeeds,
+# so chef-client must appear as the last item here.
+binaries="berks chef chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
 
 for binary in $binaries; do
   ln -sf $INSTALLER_DIR/bin/$binary $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -12,7 +12,7 @@ is_darwin()
 cleanup_symlinks() {
   # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
   # leftovers from older versions.
-  binaries="chef"
+  binaries="berks chef chef-apply chef-shell chef-solo chef-vault chef-zero delivery fauxhai foodcritic kitchen knife ohai push-apply pushy-client pushy-service-manager cookstyle chef-client"
   for binary in $binaries; do
     rm -f $PREFIX/bin/$binary
   done


### PR DESCRIPTION
Copying the software definitions from Chef DK and the fiddly bits they depend on so that Workstation can install all the tooling that DK installs. Copying code is bad, m'kay, but seemed to be the simplest for the moment to (1) avoid needing to move the software definitions themselves in the DK repo (to `config/software/`) or (2) changing omnibus to include `omnibus/config/software/` in definition search paths.
