### PR TITLE
[SHACK-182] support special password characters in targets via www-form encoding

### DIFF
--- a/components/chef-workstation/Gemfile
+++ b/components/chef-workstation/Gemfile
@@ -4,6 +4,9 @@ gemspec
 # TODO when chef-dk 3.0 is released to Rubygems as 3.0 we can get rid of this
 gem "chef-dk", git: "https://github.com/chef/chef-dk.git", branch: "master"
 
+# Remove this once train 1.4.6 or later is released:
+gem "train", git: "https://github.com/chef/train.git", branch: "master"
+
 group :localdev do
   gem "irbtools-more", require: "irbtools/binding"
 end

--- a/components/chef-workstation/Gemfile.lock
+++ b/components/chef-workstation/Gemfile.lock
@@ -16,6 +16,23 @@ GIT
       paint (~> 1.0)
       solve (> 2.0, < 5.0)
 
+GIT
+  remote: https://github.com/chef/train.git
+  revision: 182d985c427f6b6734ef167f3a4d93351a1aa8a6
+  branch: master
+  specs:
+    train (1.4.6)
+      aws-sdk (~> 2)
+      azure_mgmt_resources (~> 0.15)
+      docker-api (~> 1.26)
+      inifile
+      json (>= 1.8, < 3.0)
+      mixlib-shellout (~> 2.0)
+      net-scp (~> 1.2)
+      net-ssh (>= 2.9, < 5.0)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
+
 PATH
   remote: .
   specs:
@@ -347,17 +364,6 @@ GEM
     toml-rb (1.1.1)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.6)
-    train (1.4.4)
-      aws-sdk (~> 2)
-      azure_mgmt_resources (~> 0.15)
-      docker-api (~> 1.26)
-      inifile
-      json (>= 1.8, < 3.0)
-      mixlib-shellout (~> 2.0)
-      net-scp (~> 1.2)
-      net-ssh (>= 2.9, < 5.0)
-      winrm (~> 2.0)
-      winrm-fs (~> 1.0)
     tty-color (0.4.2)
     tty-cursor (0.5.0)
     tty-spinner (0.8.0)
@@ -405,6 +411,7 @@ DEPENDENCIES
   rspec
   rspec_junit_formatter
   simplecov
+  train!
 
 BUNDLED WITH
    1.16.1

--- a/components/chef-workstation/lib/chef-workstation/target_host.rb
+++ b/components/chef-workstation/lib/chef-workstation/target_host.rb
@@ -29,9 +29,9 @@ module ChefWorkstation
     end
 
     def initialize(host_url, opts = {}, logger = nil)
-      target_url = maybe_add_default_scheme(host_url)
-      cfg = { target: target_url,
+      cfg = { target: host_url,
               sudo: opts.has_key?(:root) ? opts[:root] : true,
+              www_form_encoded_password: true,
               key_files: opts[:identity_file],
               logger: ChefWorkstation::Log }
       if opts.has_key? :ssl
@@ -76,13 +76,6 @@ module ChefWorkstation
       backend.upload(local_path, remote_path)
     end
 
-    def maybe_add_default_scheme(url)
-      if url =~ /^ssh|winrm|mock:\/\//
-        url
-      else
-        "ssh://#{url}"
-      end
-    end
     class RemoteExecutionFailed < ChefWorkstation::ErrorNoLogs
       attr_reader :stdout, :stderr
       def initialize(host, command, result)

--- a/components/chef-workstation/spec/unit/target_host_spec.rb
+++ b/components/chef-workstation/spec/unit/target_host_spec.rb
@@ -3,24 +3,10 @@ require "ostruct"
 require "chef-workstation/target_host"
 
 RSpec.describe ChefWorkstation::TargetHost do
-  let(:host) { "example.com" }
+  let(:host) { "mock://example.com" }
   let(:sudo) { true }
   let(:logger) { nil }
   subject(:subject) { ChefWorkstation::TargetHost.new(host, sudo: sudo, logger: logger) }
-
-  context "#maybe_add_default_scheme" do
-    it "prefixes a non-prefixed host with ssh://" do
-      expect(subject.maybe_add_default_scheme(host)).to eq "ssh://#{host}"
-    end
-    it "does not change prefix when ssh is present" do
-      original = "ssh://#{host}"
-      expect(subject.maybe_add_default_scheme(original)).to eq original
-    end
-    it "does not change prefix when winrm is present" do
-      original = "winrm://#{host}"
-      expect(subject.maybe_add_default_scheme(original)).to eq original
-    end
-  end
 
   context "#run_command!" do
     let(:backend) { double("backend") }


### PR DESCRIPTION
This parses out the host/credentials/target given and assembles it into a
correct URL, first www-form encoding the password portion of credentials
if present.

It consolidates the target URL prefixing into TargetResolver as well,
so that we don't split URL parsing/fixing between `TargetResolver#target_to_valid_url`
and `TargetHost#maybe_add_default_scheme`


```
be chef converge 'vagrant:)(*&^%$#@!@192.168.33.51' user test9999  
[ - ] [192.168.33.51] Connecting...
[ - ] [192.168.33.51] Connected.
[ - ] [192.168.33.51] Verifying Chef client installation.
[ - ] [192.168.33.51] Client already present on system.
[ - ] [192.168.33.51] Converging user[test9999] on target...
[ - ] [192.168.33.51] Successfully converged target!
```

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>