### PR TITLE
SHACK-191 Basic Automate 2 Reporting

### DIFF
--- a/components/chef-cli/lib/chef-cli/action/converge_target.rb
+++ b/components/chef-cli/lib/chef-cli/action/converge_target.rb
@@ -60,6 +60,17 @@ module ChefCLI::Action
         exception_handlers << reporter
       EOM
 
+      # Maybe add data collector endpoint.
+      dc = ChefCLI::Config.data_collector
+      if !dc.url.nil? && !dc.token.nil?
+        workstation_rb << <<~EOM
+          data_collector.server_url "#{dc.url}"
+          data_collector.token "#{dc.token}"
+          data_collector.mode :solo
+          data_collector.organization "Chef Workstation"
+        EOM
+      end
+
       begin
         config_file = Tempfile.new
         config_file.write(workstation_rb)

--- a/components/chef-cli/lib/chef-cli/config.rb
+++ b/components/chef-cli/lib/chef-cli/config.rb
@@ -103,5 +103,9 @@ module ChefCLI
       default(:cookbook_repo_paths, ChefConfig::Config[:cookbook_path])
     end
 
+    config_context :data_collector do
+      default :url, nil
+      default :token, nil
+    end
   end
 end


### PR DESCRIPTION
This changes adds config values for data_collector url and
token. If set in the Chef Workstation config these values will
be written on the target node so it will report run details into
Automate 2.