### PR TITLE
bump irbtools version

### DIFF
--- a/components/chef-cli/Gemfile.lock
+++ b/components/chef-cli/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     interactive_editor (0.0.11)
       spoon (>= 0.0.1)
     ipaddress (0.8.3)
-    irbtools (2.2.0)
+    irbtools (2.2.1)
       binding.repl (~> 3.0)
       clipboard (~> 1.1)
       code (~> 0.9)
@@ -200,7 +200,7 @@ GEM
       method_locator (~> 0.0, >= 0.0.4)
       methodfinder (~> 2.0)
       ori (~> 0.1.0)
-      os (~> 1.0)
+      os
       paint (>= 0.9, < 3.0)
       ruby_engine (~> 1.0)
       ruby_info (~> 1.0)
@@ -224,7 +224,7 @@ GEM
     looksee (4.0.0)
     method_locator (0.0.4)
     method_source (0.9.0)
-    methodfinder (2.1.1)
+    methodfinder (2.2.1)
     minitar (0.6.1)
     mixlib-archive (0.4.6)
       mixlib-log


### PR DESCRIPTION
[irbtools 2.2.1 is more permissive](https://github.com/janlelis/irbtools/commit/5ac11fa672b76c36d670791a1bc90f2ea4796353) on the version of the os gem it requires. Otherwise, it conflicts with [the latest train that has brought in Google libraries](https://github.com/chef/train/commit/d991228629bf772f51250c898b53a62a1a8f6eac#diff-b87ab7fc919b5f707a5b409e31c504efR39), one of which (googleauth) had a pessimistic dependency on os "~> 0.9".

Error from the expeditor log:

    + bundle update chef-cli
    Fetching https://github.com/chef/train.git
    Fetching https://github.com/chef/chef-dk.git
    Fetching gem metadata from https://rubygems.org/........
    Fetching gem metadata from https://rubygems.org/.
    Resolving dependencies...
    Bundler could not find compatible versions for gem "os":
      In snapshot (Gemfile.lock):
        os (= 1.0.0)

      In Gemfile:
        chef-cli was resolved to 0.1.86, which depends on
          train was resolved to 1.4.8, which depends on
            googleauth (~> 0.6.2) was resolved to 0.6.2, which depends on
              os (~> 0.9)

        irbtools-more was resolved to 2.2.1, which depends on
          irbtools (~> 2.0) was resolved to 2.2.0, which depends on
            os (~> 1.0)
