### PR TITLE
Add a custom train and google-protobuf definition

### DIFF
--- a/omnibus/config/software/chef-cli.rb
+++ b/omnibus/config/software/chef-cli.rb
@@ -36,6 +36,7 @@ dependency "bundler"
 dependency "ruby"
 dependency "appbundler"
 dependency "chef-dk"
+dependency "train"
 
 relative_path "components/chef-cli"
 

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -41,6 +41,9 @@ dependency "ruby"
 dependency "rubygems"
 dependency "appbundler"
 
+# For inspec et all
+dependency "train"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/omnibus/config/software/google-protobuf.rb
+++ b/omnibus/config/software/google-protobuf.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2018 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+### NOTE ###
+# We build this definition from source rather than installing from the
+# gem so the native extension builds against the correct ruby rather than shipping
+# a vendored library for each 2.x version of ruby, which is what is packaged
+# with the gem.
+
+name 'google-protobuf'
+default_version 'v3.5.2'
+
+dependency 'ruby'
+dependency 'rubygems'
+
+source git: "https://github.com/google/protobuf.git"
+
+license :project_license
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  gem "build google-protobuf.gemspec", env: env, cwd: "#{project_dir}/ruby"
+  gem "install google-protobuf-*.gem", env: env, cwd: "#{project_dir}/ruby"
+end

--- a/omnibus/config/software/train.rb
+++ b/omnibus/config/software/train.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "train"
+default_version "master"
+
+source git: "https://github.com/chef/train.git"
+
+license "Apache-2.0"
+license_file "LICENSE"
+
+dependency "ruby"
+dependency "rubygems"
+dependency "google-protobuf"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development test integration tools", env: env
+
+  gem "build train.gemspec", env: env
+  gem "install train-*.gem --no-ri --no-rdoc", env: env
+end


### PR DESCRIPTION
This is so the ruby library is only generated for the correct ruby version.

Unfortunately, google hasn't tagged (in github) when they release to rubygems, so there isn't a 1:1 mapping. When we need to update this gem in the future, we'll have to verify that the pinning in train (and anywhere else) corresponds with a github tag or release (or at least a sha).

The whole point of this is to avoid including precompiled native extensions that have been packaged with the gem, which include versions for Ruby 2.0, 2.1, 2.3, etc. This causes issues with the load library path, and causes omnibus to flag the offending libraries in the healthcheck, since they are not linked at build time.

Signed-off-by: Scott Hain <shain@chef.io>