### PR TITLE
rename ChefCLI::Telemtry to ChefCLI::Telemeter

### DIFF
--- a/components/chef-cli/lib/chef-cli/action/base.rb
+++ b/components/chef-cli/lib/chef-cli/action/base.rb
@@ -1,4 +1,4 @@
-require "chef-cli/telemetry"
+require "chef-cli/telemeter"
 require "chef-cli/error"
 
 module ChefCLI
@@ -90,7 +90,7 @@ module ChefCLI
 
       def run(&block)
         @notification_handler = block
-        Telemetry.timed_action_capture(self) do
+        Telemeter.timed_action_capture(self) do
           begin
             perform_action
           rescue StandardError => e

--- a/components/chef-cli/lib/chef-cli/telemeter.rb
+++ b/components/chef-cli/lib/chef-cli/telemeter.rb
@@ -26,11 +26,11 @@ require "yaml"
 
 module ChefCLI
 
-  # This definites the Telemetry interface. Implementation thoughts for
+  # This definites the Telemeter interface. Implementation thoughts for
   # when we unstub it:
   # - let's track the call sequence; most of our calls will be nested inside
   # a main 'timed_capture', and it would be good to see ordering within nested calls.
-  class Telemetry
+  class Telemeter
     include Singleton
     class << self
       extend Forwardable
@@ -43,7 +43,7 @@ module ChefCLI
 
     def enabled?
       require "telemetry/decision"
-      ChefCLI::Config.telemetry.enable && !::Telemetry::Decision.env_opt_out?
+      ChefCLI::Config.telemetry.enable && !Telemetry::Decision.env_opt_out?
     end
 
     def initialize

--- a/components/chef-cli/lib/chef-cli/telemeter/patch.rb
+++ b/components/chef-cli/lib/chef-cli/telemeter/patch.rb
@@ -1,4 +1,4 @@
-class ::Telemetry
+class Telemetry
   class Session
     # The telemetry session data is normally kept in .chef, which we don't have.
     def session_file
@@ -7,7 +7,7 @@ class ::Telemetry
   end
 
   def deliver(data = {})
-    if ChefCLI::Telemetry.instance.enabled?
+    if ChefCLI::Telemeter.instance.enabled?
       payload = event.prepare(data)
       client.await.fire(payload)
     end

--- a/components/chef-cli/lib/chef-cli/telemeter/sender.rb
+++ b/components/chef-cli/lib/chef-cli/telemeter/sender.rb
@@ -1,10 +1,10 @@
 require "telemetry"
-require "chef-cli/telemetry/patch"
+require "chef-cli/telemeter/patch"
 require "chef-cli/log"
 require "chef-cli/version"
 
 module ChefCLI
-  class Telemetry
+  class Telemeter
     class Sender
       def run
         session_files.each { |path| process_session(path) }
@@ -30,10 +30,10 @@ module ChefCLI
         # Each run is one session, so we'll first remove remove the session file
         # to force creating a new one.
         FileUtils.rm_rf(ChefCLI::Config.telemetry_session_file)
-        telemetry = ::Telemetry.new(product: "chef-workstation-cli",
-                                    origin: "command-line",
-                                    product_version: ChefCLI::VERSION,
-                                    install_context: "omnibus")
+        telemetry = Telemetry.new(product: "chef-workstation-cli",
+                                  origin: "command-line",
+                                  product_version: ChefCLI::VERSION,
+                                  install_context: "omnibus")
         entries = content["entries"]
         total = entries.length
         entries.each_with_index do |entry, x|

--- a/components/chef-cli/spec/unit/action/base_spec.rb
+++ b/components/chef-cli/spec/unit/action/base_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 require "chef-cli/action/base"
-require "chef-cli/telemetry"
+require "chef-cli/telemeter"
 require "chef-cli/target_host"
 
 RSpec.describe ChefCLI::Action::Base do
@@ -23,7 +23,7 @@ RSpec.describe ChefCLI::Action::Base do
 
   context "#run" do
     it "runs the underlying action, capturing timing via telemetry" do
-      expect(ChefCLI::Telemetry).to receive(:timed_action_capture).with(subject).and_yield
+      expect(ChefCLI::Telemeter).to receive(:timed_action_capture).with(subject).and_yield
       expect(action).to receive(:perform_action)
       action.run
     end
@@ -31,7 +31,7 @@ RSpec.describe ChefCLI::Action::Base do
     it "invokes an action handler when actions occur and a handler is provided" do
       @run_action = nil
       @args = nil
-      expect(ChefCLI::Telemetry).to receive(:timed_action_capture).with(subject).and_yield
+      expect(ChefCLI::Telemeter).to receive(:timed_action_capture).with(subject).and_yield
       expect(action).to receive(:perform_action) { action.notify(:test_success, "some arg", "some other arg") }
       action.run { |action, args| @run_action = action; @args = args }
       expect(@run_action).to eq :test_success

--- a/components/chef-cli/spec/unit/cli_spec.rb
+++ b/components/chef-cli/spec/unit/cli_spec.rb
@@ -16,7 +16,7 @@
 
 require "spec_helper"
 require "chef-cli/cli"
-require "chef-cli/telemetry"
+require "chef-cli/telemeter"
 require "chef-cli/error"
 require "chef-cli/text"
 require "chef-cli/ui/terminal"
@@ -27,7 +27,7 @@ RSpec.describe ChefCLI::CLI do
   subject(:cli) do
     ChefCLI::CLI.new(argv)
   end
-  let(:telemetry) { ChefCLI::Telemetry.instance }
+  let(:telemetry) { ChefCLI::Telemeter.instance }
 
   context "run" do
     before do

--- a/components/chef-cli/spec/unit/telemeter/sender_spec.rb
+++ b/components/chef-cli/spec/unit/telemeter/sender_spec.rb
@@ -15,11 +15,11 @@
 #
 
 require "spec_helper"
-require "chef-cli/telemetry"
+require "chef-cli/telemeter"
 require "chef-cli/config"
 
-RSpec.describe ChefCLI::Telemetry::Sender do
-  let(:subject) { ChefCLI::Telemetry::Sender.new }
+RSpec.describe ChefCLI::Telemeter::Sender do
+  let(:subject) { ChefCLI::Telemeter::Sender.new }
   describe "#run" do
     let(:session_files) { %w{file1 file2} }
     it "submits the session capture for each session file found" do
@@ -52,7 +52,7 @@ RSpec.describe ChefCLI::Telemetry::Sender do
     it "removes the telemetry session file and starts a new session, then submits each entry in the session" do
       expect(ChefCLI::Config).to receive(:telemetry_session_file).and_return("/tmp/SESSION_ID")
       expect(FileUtils).to receive(:rm_rf).with("/tmp/SESSION_ID")
-      expect(::Telemetry).to receive(:new).and_return telemetry
+      expect(Telemetry).to receive(:new).and_return telemetry
       expect(subject).to receive(:submit_entry).with(telemetry, { "event" => "action1" }, 1, 2)
       expect(subject).to receive(:submit_entry).with(telemetry, { "event" => "action2" }, 2, 2)
       subject.submit_session( { "entries" => [ { "event" => "action1" }, { "event" => "action2" } ] } )

--- a/components/chef-cli/spec/unit/telemeter_spec.rb
+++ b/components/chef-cli/spec/unit/telemeter_spec.rb
@@ -15,10 +15,10 @@
 #
 
 require "spec_helper"
-require "chef-cli/telemetry"
+require "chef-cli/telemeter"
 
-RSpec.describe ChefCLI::Telemetry do
-  subject { ChefCLI::Telemetry.instance }
+RSpec.describe ChefCLI::Telemeter do
+  subject { ChefCLI::Telemeter.instance }
   let(:dev_mode) { true }
   let(:config) { double("config") }
   let(:host_platform) { "linux" }


### PR DESCRIPTION
This naming is more accurage - telemeter is the thing that captures
data, while telemetry is the external service it reports to.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>