### PR TITLE
We should be loading default config using workstation config loader

### DIFF
--- a/components/chef-run/lib/chef-run/config.rb
+++ b/components/chef-run/lib/chef-run/config.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+require "chef-run/log"
 require "mixlib/config"
 require "fileutils"
 require "pathname"
@@ -131,7 +132,12 @@ module ChefRun
     end
 
     config_context :chef do
-      default(:cookbook_repo_paths, ChefConfig::Config[:cookbook_path])
+      # We want to use any configured chef repo paths in ~/.chef/knife.rb on the user's
+      # workstation. But because they could have config that could mess up our Policyfile
+      # creation later we reset the ChefConfig back to default after loading that.
+      ChefConfig::WorkstationConfigLoader.new(nil, ChefRun::Log).load
+      default(:cookbook_repo_paths, [ChefConfig::Config[:cookbook_path]].flatten)
+      ChefConfig::Config.reset
     end
 
     config_context :data_collector do


### PR DESCRIPTION
This must have gotten deleted at some point. Adding it back ensures we load any local `~/.chef/knife.rb` or `/etc/chef/client.rb` on user's workstation