### PR TITLE
Fix telemetry race condition

### DIFF
--- a/components/chef-run/lib/chef-run/telemeter/sender.rb
+++ b/components/chef-run/lib/chef-run/telemeter/sender.rb
@@ -23,10 +23,27 @@ require "chef-run/version"
 module ChefRun
   class Telemeter
     class Sender
+      attr_reader :session_files
 
       def self.start_upload_thread
-        sender = Sender.new
+        # Find the files before we spawn the thread - otherwise
+        # we may accidentally pick up the current run's session file if it
+        # finishes before the thread scans for new files
+        session_files = Sender.find_session_files
+        sender = Sender.new(session_files)
         Thread.new { sender.run }
+      end
+
+      def self.find_session_files
+        ChefRun::Log.info("Looking for telemetry data to submit")
+        session_search = File.join(ChefRun::Config.telemetry_path, "telemetry-payload-*.yml")
+        session_files = Dir.glob(session_search)
+        ChefRun::Log.info("Found #{session_files.length} sessions to submit")
+        session_files
+      end
+
+      def initialize(session_files)
+        @session_files = session_files
       end
 
       def run
@@ -46,14 +63,6 @@ module ChefRun
         end
         FileUtils.rm_rf(ChefRun::Config.telemetry_session_file)
         ChefRun::Log.info("Terminating, nothing more to do.")
-      end
-
-      def session_files
-        ChefRun::Log.info("Looking for telemetry data to submit")
-        session_search = File.join(ChefRun::Config.telemetry_path, "telemetry-payload-*.yml")
-        files = Dir.glob(session_search)
-        ChefRun::Log.info("Found #{files.length} sessions to submit")
-        files
       end
 
       def process_session(path)

--- a/components/chef-run/spec/unit/telemeter/sender_spec.rb
+++ b/components/chef-run/spec/unit/telemeter/sender_spec.rb
@@ -21,10 +21,12 @@ require "chef-run/telemeter/sender"
 require "chef-run/config"
 
 RSpec.describe ChefRun::Telemeter::Sender do
-  let(:subject) { ChefRun::Telemeter::Sender.new }
+  let(:session_files) { %w{file1 file2} }
   let(:enabled_flag) { true }
   let(:dev_mode) { false }
   let(:config) { double("config") }
+
+  let(:subject) { ChefRun::Telemeter::Sender.new(session_files) }
 
   before do
     allow(config).to receive(:dev).and_return dev_mode
@@ -37,7 +39,8 @@ RSpec.describe ChefRun::Telemeter::Sender do
   describe "::start_upload_thread" do
     let(:sender_mock) { instance_double(ChefRun::Telemeter::Sender) }
     it "spawns a thread to run the send" do
-      expect(ChefRun::Telemeter::Sender).to receive(:new).and_return sender_mock
+      expect(ChefRun::Telemeter::Sender).to receive(:find_session_files).and_return session_files
+      expect(ChefRun::Telemeter::Sender).to receive(:new).with(session_files).and_return sender_mock
       expect(sender_mock).to receive(:run)
       expect(::Thread).to receive(:new).and_yield
       ChefRun::Telemeter::Sender.start_upload_thread
@@ -45,7 +48,6 @@ RSpec.describe ChefRun::Telemeter::Sender do
   end
 
   describe "#run" do
-    let(:session_files) { %w{file1 file2} }
     before do
       expect(subject).to receive(:session_files).and_return session_files
     end
@@ -92,11 +94,11 @@ RSpec.describe ChefRun::Telemeter::Sender do
     end
   end
 
-  describe "#session_files" do
+  describe "::find_session_files" do
     it "finds all telemetry-payload-*.yml files in the telemetry directory" do
       expect(ChefRun::Config).to receive(:telemetry_path).and_return("/tmp")
       expect(Dir).to receive(:glob).with("/tmp/telemetry-payload-*.yml").and_return []
-      subject.session_files
+      ChefRun::Telemeter::Sender.find_session_files
     end
   end
 


### PR DESCRIPTION
This fixes a telemetry race condition where the current session
may initialize and finish writing its file to telemetry before
the sender has scanned for files - resulting in sender including the
current run's session data.

This runs contrary to whta we tell customers - telemetry will only send
the previous session run(s), not the current.

Fixed by loading the session file list before we spawn the sender
thread.