### PR TITLE
Telemetry product name is 'chef-workstation'

### DIFF
--- a/components/chef-run/lib/chef-run/telemeter/sender.rb
+++ b/components/chef-run/lib/chef-run/telemeter/sender.rb
@@ -80,7 +80,7 @@ module ChefRun
         entries = content["entries"]
         cli_version = content["version"]
         total = entries.length
-        telemetry = Telemetry.new(product: "chef-workstation-cli",
+        telemetry = Telemetry.new(product: "chef-workstation",
                                   origin: "command-line",
                                   product_version: cli_version,
                                   install_context: "omnibus")


### PR DESCRIPTION
This is enumerated in the schema[1] - so chef-workstation-cli is not a
valid product name.

[1] https://github.com/chef/es-telemetry-pipeline/commits/master/schema/event.schema.json