### PR TITLE
[SHACK-213] [GH-178] Add --protocol flag

### DIFF
--- a/components/chef-run/i18n/en.yml
+++ b/components/chef-run/i18n/en.yml
@@ -52,6 +52,10 @@ cli:
   password_description: |
     Password to use for authentication to the target(s). The same
     password will be used for all targets.
+  protocol_description: |
+    The protocol to use for connecting to targets.
+    The default is '%2', and it can be changed in config.toml by
+    setting 'connection.default_protocol' to a supported option.
   sudo:
     flag_description:
       sudo: "Whether to use root permissions on the target. Default: true"
@@ -354,6 +358,13 @@ errors:
 
       Available flags are:
     %2
+
+  CHEFVAL011: |
+    The protocol '%1' is not supported.
+
+    Currently supported remote access protocols are:
+
+      %2
 
   # General errors/unknown errors are handled with CHEFINT
   CHEFINT001: |

--- a/components/chef-run/lib/chef-run/cli.rb
+++ b/components/chef-run/lib/chef-run/cli.rb
@@ -195,7 +195,9 @@ module ChefRun
       else
         validate_params(cli_arguments)
         configure_chef
-        target_hosts = TargetResolver.new(cli_arguments.shift, config).targets
+        target_hosts = TargetResolver.new(cli_arguments.shift,
+                                          config.delete(:default_protocol),
+                                          config).targets
         temp_cookbook, initial_status_msg = generate_temp_cookbook(cli_arguments)
         local_policy_path = create_local_policy(temp_cookbook)
         if target_hosts.length == 1

--- a/components/chef-run/lib/chef-run/cli.rb
+++ b/components/chef-run/lib/chef-run/cli.rb
@@ -94,6 +94,13 @@ module ChefRun
       boolean: true,
       default: ChefRun::Config.connection.winrm.ssl_verify
 
+    option :protocol,
+      long: "--protocol",
+      short: "-p",
+      description: T.protocol_description(ChefRun::Config::SUPPORTED_PROTOCOLS.join(" "),
+                                          ChefRun::Config.connection.default_protocol),
+      default: ChefRun::Config.connection.default_protocol
+
     option :user,
       long: "--user <USER>",
       description: T.user_description,

--- a/components/chef-run/lib/chef-run/config.rb
+++ b/components/chef-run/lib/chef-run/config.rb
@@ -24,6 +24,7 @@ require "chef-config/workstation_config_loader"
 module ChefRun
   class Config
     WS_BASE_PATH = File.join(Dir.home, ".chef-workstation/")
+    SUPPORTED_PROTOCOLS = %w{ssh winrm}
 
     class << self
       @custom_location = nil
@@ -114,6 +115,9 @@ module ChefRun
     end
 
     config_context :connection do
+      default(:default_protocol, "ssh")
+      default(:default_user, "root")
+
       config_context :winrm do
         default(:ssl, false)
         default(:ssl_verify, true)

--- a/components/chef-run/lib/chef-run/target_resolver.rb
+++ b/components/chef-run/lib/chef-run/target_resolver.rb
@@ -22,13 +22,13 @@ module ChefRun
   class TargetResolver
     MAX_EXPANDED_TARGETS = 24
 
-    def initialize(unparsed_target, conn_options)
-      @unparsed_target = unparsed_target
-      @split_targets = unparsed_target.split(",")
+    def initialize(target, default_protocol, conn_options)
+      @default_proto = default_protocol
+      @unparsed_target = target
+      @split_targets = @unparsed_target.split(",")
       @conn_options = conn_options.dup
       @default_password = @conn_options.delete(:password)
       @default_user = @conn_options.delete(:user)
-      @default_proto = @conn_options.delete(:protocol) || ChefRun::Config.connection.default_protocol
     end
 
     # Returns the list of targets as an array of strings, after expanding

--- a/components/chef-run/spec/integration/fixtures/chef_help.out
+++ b/components/chef-run/spec/integration/fixtures/chef_help.out
@@ -49,6 +49,9 @@ FLAGS:
                                        if there is no Chef client on the target(s).
         --password <PASSWORD>          Password to use for authentication to the target(s). The same
                                        password will be used for all targets.
+    -p, --protocol                     The protocol to use for connecting to targets.
+                                       The default is 'ssh', and it can be changed in config.toml by
+                                       setting 'connection.default_protocol' to a supported option.
     -s, --[no-]ssl                     Use SSL for WinRM. Current default: false
     -s, --[no-]ssl-verify              Verify peer certificate when using SSL for WinRM
                                        Use --ssl-no-verify when using SSL for WinRM and

--- a/components/chef-run/spec/unit/target_resolver_spec.rb
+++ b/components/chef-run/spec/unit/target_resolver_spec.rb
@@ -20,8 +20,9 @@ require "chef-run/target_resolver"
 
 RSpec.describe ChefRun::TargetResolver do
   let(:target_string) { "" }
+  let(:default_protocol) { "ssh" }
   let(:connection_options) { {} }
-  subject { ChefRun::TargetResolver.new(target_string, connection_options) }
+  subject { ChefRun::TargetResolver.new(target_string, default_protocol, connection_options) }
 
   context "#targets" do
     context "when no target is provided" do
@@ -182,7 +183,7 @@ RSpec.describe ChefRun::TargetResolver do
       opts = {}
       opts[:user] = default_user unless default_user.nil?
       opts[:password] = default_password unless default_password.nil?
-      resolver = ChefRun::TargetResolver.new("", opts)
+      resolver = ChefRun::TargetResolver.new("", default_protocol, opts)
       Proc.new { resolver.make_url_credentials(inline_user, inline_password) }
     end
 
@@ -357,13 +358,9 @@ RSpec.describe ChefRun::TargetResolver do
   end
 
   context "#prefix_from_target" do
-    after do
-      ChefRun::Config.reset
-    end
-
     context "when no protocol is provided" do
+      let(:default_protocol) { "badproto" }
       it "uses the default from configuration" do
-        ChefRun::Config.connection.default_protocol = "badproto"
         expect(subject.prefix_from_target("host.com")).to eq %w{badproto:// host.com}
       end
     end


### PR DESCRIPTION
### Description
Not all customers use ssh for the majority of their hosts.
Currently, the only alternative we give is to require
the 'winrm://' prefix for each target.  This change adds
the flag --protocol to apply to all targets, and adds the
connection.default_protocol option

NOTE: the command line flag will work with this PR, but the configuration option 
will not work before #180 is fixed and merged. 

### Issues Resolved

Fixes #178 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
