### PR TITLE
[SHACK-210] [GH #180] Perform startup tasks outside of main CLI handling

### DIFF
--- a/components/chef-run/bin/chef-run
+++ b/components/chef-run/bin/chef-run
@@ -9,14 +9,15 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require "chef-run/startup"
 
-require "chef-run/cli"
-
-ChefRun::CLI.new(ARGV.clone).run
+# Perform initialization tasks then hand off control to
+# CLI to run the command.
+ChefRun::Startup.new(ARGV).run

--- a/components/chef-run/i18n/en.yml
+++ b/components/chef-run/i18n/en.yml
@@ -108,6 +108,23 @@ cli:
                            cookbook is found we run the default recipe.
                         3. This behaves similarly to 'cookbook name' above, but it also allows
                            you to specify which recipe to use from the cookbook.
+  error:
+    bad_config_file: |
+
+      The path '%1' is not a valid file, or it cannot be read.
+
+      Please verify that the path is correct, and that permissions
+      on the file allow it to be read by your user account.
+
+    missing_config_path: |
+
+      Missing configuration file.
+
+      Please provide the path to a valid chef-run configuration file
+      as an argument to --config-path. For example:
+
+        --config-path /home/user1/.chef-workstation/config.toml
+
   version:
     description: Show the current version of Chef Run.
     show: "chef-run: %1"

--- a/components/chef-run/lib/chef-run/config.rb
+++ b/components/chef-run/lib/chef-run/config.rb
@@ -56,12 +56,17 @@ module ChefRun
         File.join(WS_BASE_PATH, "installation_id")
       end
 
+      def base_log_directory
+        File.dirname(log.location)
+      end
+
+      # These paths are relative to the log output path, which is user-configurable.
       def error_output_path
-        File.join(File.dirname(log.location), "errors.txt")
+        File.join(base_log_directory, "errors.txt")
       end
 
       def stack_trace_path
-        File.join(File.dirname(log.location), "stack-trace.log")
+        File.join(base_log_directory, "stack-trace.log")
       end
 
       def using_default_location?
@@ -78,16 +83,6 @@ module ChefRun
 
       def exist?
         File.exist? location
-      end
-
-      def create_directory_tree
-        FileUtils.mkdir_p(File.dirname(default_location))
-        FileUtils.mkdir_p(File.dirname(stack_trace_path))
-        FileUtils.mkdir_p(telemetry_path)
-      end
-
-      def create_default_config_file
-        FileUtils.touch(default_location)
       end
 
       def reset

--- a/components/chef-run/lib/chef-run/startup.rb
+++ b/components/chef-run/lib/chef-run/startup.rb
@@ -1,0 +1,144 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "chef-run/config"
+require "chef-run/text"
+require "chef-run/ui/terminal"
+require "chef-run/telemeter/sender"
+module ChefRun
+  class Startup
+    attr_reader :argv
+    T = ChefRun::Text.cli
+
+    def initialize(argv)
+      @term_init = false
+      @argv = argv.clone
+    end
+
+    def run
+      # Enable CLI output via Terminal. This comes first because we want to supply
+      # status output about reading and creating config files
+      init_terminal
+
+      # Some tasks we do only once in an installation:
+      first_run_tasks
+
+      # Call this every time, so that if we add or change ~/.chef-workstation
+      # directory structure, we can be sure that it exists. Even with a
+      # custom configuration, the .chef-workstation directory and subdirs
+      # are required.
+      setup_workstation_user_directories
+
+      # Startup tasks that may change behavior based on configuration value
+      # must be run after load_config
+      load_config
+
+      # Init logging using log level out of config
+      setup_logging
+
+      # Begin upload of previous session telemetry. (If telemetry is not enabled,
+      # in config the uploader will clean up previous session(s) without sending)
+      start_telemeter_upload
+
+      # Launch the actual chef-run behavior
+      start_chef_run
+    rescue ConfigPathInvalid => e
+      init_terminal
+      UI::Terminal.output(T.error.bad_config_file(e.path))
+    rescue ConfigPathNotProvided
+      init_terminal
+      UI::Terminal.output(T.error.missing_config_path)
+    end
+
+    def init_terminal
+      UI::Terminal.init($stdout)
+    end
+
+    def first_run_tasks
+      return if Dir.exist?(Config::WS_BASE_PATH)
+      create_default_config
+      setup_telemetry
+    end
+
+    def create_default_config
+      UI::Terminal.output T.creating_config(Config.default_location)
+      UI::Terminal.output ""
+      FileUtils.touch(Config.default_location)
+    end
+
+    def setup_telemetry
+      require "securerandom"
+      installation_id = SecureRandom.uuid
+      File.write(Config.telemetry_installation_identifier_file, installation_id)
+
+      # Tell the user we're anonymously tracking, give brief opt-out
+      # and a link to detailed information.
+      UI::Terminal.output T.telemetry_enabled(Config.location)
+      UI::Terminal.output ""
+    end
+
+    def start_telemeter_upload
+      ChefRun::Telemeter::Sender.start_upload_thread()
+    end
+
+    def setup_workstation_user_directories
+      # Note that none of  these paths are customizable in config, so
+      # it's safe to do before we load config.
+      FileUtils.mkdir_p(Config::WS_BASE_PATH)
+      FileUtils.mkdir_p(Config.base_log_directory)
+      FileUtils.mkdir_p(Config.telemetry_path)
+    end
+
+    def load_config
+      path = determine_config_path
+      Config.custom_location(path)
+      Config.load
+    end
+
+    # Look for a user-supplied config path by  manually parsing the option.
+    # Note that we can't use Mixlib::CLI for this.
+    # To ensure that ChefRun::CLI initializes with correct
+    # option defaults, we need to have configuraton loaded before initializing it.
+    def determine_config_path
+      argv.each_with_index do |arg, index|
+        if arg == "--config-path" || arg == "-c"
+          next_arg = argv[index + 1]
+          raise ConfigPathNotProvided.new if next_arg.nil?
+          raise ConfigPathInvalid.new(next_arg) unless File.file?(next_arg) && File.readable?(next_arg)
+          return next_arg
+        end
+      end
+      Config.default_location
+    end
+
+    def setup_logging
+      ChefRun::Log.setup(Config.log.location, Config.log.level.to_sym)
+      ChefRun::Log.info("Initialized logger")
+    end
+
+    def start_chef_run
+      require "chef-run/cli"
+      ChefRun::CLI.new(@argv).run
+    end
+    class ConfigPathNotProvided < StandardError; end
+    class ConfigPathInvalid < StandardError
+      attr_reader :path
+      def initialize(path)
+        @path = path
+      end
+    end
+  end
+end

--- a/components/chef-run/lib/chef-run/startup.rb
+++ b/components/chef-run/lib/chef-run/startup.rb
@@ -103,8 +103,8 @@ module ChefRun
     end
 
     def load_config
-      path = determine_config_path
-      Config.custom_location(path)
+      path = custom_config_path
+      Config.custom_location(path) unless path.nil?
       Config.load
     end
 
@@ -112,7 +112,7 @@ module ChefRun
     # Note that we can't use Mixlib::CLI for this.
     # To ensure that ChefRun::CLI initializes with correct
     # option defaults, we need to have configuraton loaded before initializing it.
-    def determine_config_path
+    def custom_config_path
       argv.each_with_index do |arg, index|
         if arg == "--config-path" || arg == "-c"
           next_arg = argv[index + 1]
@@ -121,7 +121,7 @@ module ChefRun
           return next_arg
         end
       end
-      Config.default_location
+      nil
     end
 
     def setup_logging

--- a/components/chef-run/lib/chef-run/startup.rb
+++ b/components/chef-run/lib/chef-run/startup.rb
@@ -26,13 +26,12 @@ module ChefRun
     def initialize(argv)
       @term_init = false
       @argv = argv.clone
+      # Enable CLI output via Terminal. This comes first because other startup steps may
+      # need to output to the terminal.
+      init_terminal
     end
 
     def run
-      # Enable CLI output via Terminal. This comes first because we want to supply
-      # status output about reading and creating config files
-      init_terminal
-
       # Some tasks we do only once in an installation:
       first_run_tasks
 
@@ -56,10 +55,8 @@ module ChefRun
       # Launch the actual chef-run behavior
       start_chef_run
     rescue ConfigPathInvalid => e
-      init_terminal
       UI::Terminal.output(T.error.bad_config_file(e.path))
     rescue ConfigPathNotProvided
-      init_terminal
       UI::Terminal.output(T.error.missing_config_path)
     end
 

--- a/components/chef-run/spec/integration/spec_helper.rb
+++ b/components/chef-run/spec/integration/spec_helper.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "chef-run/cli"
+require "chef-run/startup"
 require "chef-run/version"
 
 # Create the chef configuration directory and touch the config
@@ -41,7 +41,7 @@ FileUtils.touch(conf) unless File.exist?(conf)
 # usage:
 #   expect {run_with_cli("blah")}.to output("blah").to_stdout
 def run_cli_with(args)
-  ChefRun::CLI.new(args.split(" ")).run
+  ChefRun::Startup.new(args.split(" ")).run
 rescue SystemExit
 end
 

--- a/components/chef-run/spec/unit/startup_spec.rb
+++ b/components/chef-run/spec/unit/startup_spec.rb
@@ -94,11 +94,11 @@ RSpec.describe ChefRun::Startup do
     end
   end
 
-  describe "#determine_config_path" do
+  describe "#custom_config_path" do
     context "when a custom config path is not provided as an option" do
       let(:args) { [] }
-      it "returns the default configuration path" do
-        expect(subject.determine_config_path).to eq ChefRun::Config.default_location
+      it "returns nil" do
+        expect(subject.custom_config_path).to be_nil
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe ChefRun::Startup do
       context "but the actual path parameter is not provided" do
         let(:argv) { %w{--config-path} }
         it "raises ConfigPathNotProvided" do
-          expect { subject.determine_config_path }.to raise_error(ChefRun::Startup::ConfigPathNotProvided)
+          expect { subject.custom_config_path }.to raise_error(ChefRun::Startup::ConfigPathNotProvided)
         end
       end
 
@@ -119,7 +119,7 @@ RSpec.describe ChefRun::Startup do
             allow(File).to receive(:file?).with(path).and_return false
           end
           it "raises an error ConfigPathInvalid" do
-            expect { subject.determine_config_path }.to raise_error(ChefRun::Startup::ConfigPathInvalid)
+            expect { subject.custom_config_path }.to raise_error(ChefRun::Startup::ConfigPathInvalid)
           end
         end
 
@@ -133,7 +133,7 @@ RSpec.describe ChefRun::Startup do
               allow(File).to receive(:readable?).with(path).and_return false
             end
             it "raises an error ConfigPathInvalid" do
-              expect { subject.determine_config_path }.to raise_error(ChefRun::Startup::ConfigPathInvalid)
+              expect { subject.custom_config_path }.to raise_error(ChefRun::Startup::ConfigPathInvalid)
             end
 
           end
@@ -143,7 +143,7 @@ RSpec.describe ChefRun::Startup do
               allow(File).to receive(:readable?).with(path).and_return true
             end
             it "returns the custom path" do
-              expect(subject.determine_config_path).to eq path
+              expect(subject.custom_config_path).to eq path
             end
           end
         end
@@ -154,7 +154,7 @@ RSpec.describe ChefRun::Startup do
   describe "#load_config" do
     it "finds the config path, initializes it, and loads config" do
       mock_path = "/tmp/path.file"
-      expect(subject).to receive(:determine_config_path).and_return mock_path
+      expect(subject).to receive(:custom_config_path).and_return mock_path
       expect(ChefRun::Config).to receive(:custom_location).with mock_path
       expect(ChefRun::Config).to receive(:load)
       subject.load_config

--- a/components/chef-run/spec/unit/startup_spec.rb
+++ b/components/chef-run/spec/unit/startup_spec.rb
@@ -1,0 +1,192 @@
+require "chef-run/startup"
+
+RSpec.describe ChefRun::Startup do
+  let(:argv) { [] }
+  let(:telemetry) { ChefRun::Telemeter.instance }
+  subject do
+    ChefRun::Startup.new(argv)
+  end
+
+  describe "#run" do
+    it "performs ordered startup tasks and invokes the CLI" do
+      ordered_messages = [:init_terminal,
+                          :first_run_tasks,
+                          :setup_workstation_user_directories,
+                          :load_config,
+                          :setup_logging,
+                          :start_telemeter_upload,
+                          :start_chef_run]
+      ordered_messages.each do |msg|
+        expect(subject).to receive(msg).ordered
+      end
+
+      subject.run()
+    end
+  end
+  describe "#init_terminal" do
+    it "initializees the terminal for stdout" do
+      expect(ChefRun::UI::Terminal).to receive(:init).with($stdout)
+      subject.init_terminal
+    end
+  end
+  describe "#first_run_tasks" do
+    let(:first_run_complete) { true }
+    before do
+      allow(Dir).to receive(:exist?).with(ChefRun::Config::WS_BASE_PATH).and_return first_run_complete
+    end
+
+    context "when first run has already occurred" do
+      let(:first_run_complete) { true }
+      it "returns without taking action" do
+        expect(subject).to_not receive(:create_default_config)
+        expect(subject).to_not receive(:setup_telemetry)
+        subject.first_run_tasks
+      end
+    end
+    context "when first run has not already occurred" do
+      let(:first_run_complete) { false }
+      it "Performs required first-run tasks" do
+        expect(subject).to receive(:create_default_config)
+        expect(subject).to receive(:setup_telemetry)
+        subject.first_run_tasks
+      end
+    end
+  end
+
+  describe "#create_default_config" do
+    it "touches the configuration file to create it and notifies that it has done so" do
+      expected_config_path = ChefRun::Config.default_location
+      expected_message = ChefRun::Text.cli.creating_config(expected_config_path)
+      expect(ChefRun::UI::Terminal).to receive(:output).
+        with(expected_message)
+      expect(ChefRun::UI::Terminal).to receive(:output).
+        with("")
+      expect(FileUtils).to receive(:touch).
+        with(expected_config_path)
+      subject.create_default_config
+
+    end
+  end
+
+  describe "#setup_telemetry" do
+    let(:mock_guid) { "1234" }
+    it "sets up a telemetry installation id and notifies the operator that telemetry is enabled" do
+      expect(SecureRandom).to receive(:uuid).and_return(mock_guid)
+      expect(File).to receive(:write).
+        with(ChefRun::Config.telemetry_installation_identifier_file, mock_guid)
+      subject.setup_telemetry
+    end
+  end
+
+  describe "#start_telemeter_upload" do
+    it "launches telemetry uploads" do
+      expect(ChefRun::Telemeter::Sender).to receive(:start_upload_thread)
+      subject.start_telemeter_upload
+    end
+  end
+
+  describe "setup_workstation_user_directories" do
+    it "creates the required chef-workstation directories in HOME" do
+      expect(FileUtils).to receive(:mkdir_p).with(ChefRun::Config::WS_BASE_PATH)
+      expect(FileUtils).to receive(:mkdir_p).with(ChefRun::Config.base_log_directory)
+      expect(FileUtils).to receive(:mkdir_p).with(ChefRun::Config.telemetry_path)
+      subject.setup_workstation_user_directories
+    end
+  end
+
+  describe "#determine_config_path" do
+    context "when a custom config path is not provided as an option" do
+      let(:args) { [] }
+      it "returns the default configuration path" do
+        expect(subject.determine_config_path).to eq ChefRun::Config.default_location
+      end
+    end
+
+    context "when a --config-path is provided" do
+      context "but the actual path parameter is not provided" do
+        let(:argv) { %w{--config-path} }
+        it "raises ConfigPathNotProvided" do
+          expect { subject.determine_config_path }.to raise_error(ChefRun::Startup::ConfigPathNotProvided)
+        end
+      end
+
+      context "and the path is provided" do
+        let(:path) { "/mock/file.toml" }
+        let(:argv) { ["--config-path", path] }
+
+        context "but the path is not a file" do
+          before do
+            allow(File).to receive(:file?).with(path).and_return false
+          end
+          it "raises an error ConfigPathInvalid" do
+            expect { subject.determine_config_path }.to raise_error(ChefRun::Startup::ConfigPathInvalid)
+          end
+        end
+
+        context "and the path exists and is a fvalid" do
+          before do
+            allow(File).to receive(:file?).with(path).and_return true
+          end
+
+          context "but it is not readable" do
+            before do
+              allow(File).to receive(:readable?).with(path).and_return false
+            end
+            it "raises an error ConfigPathInvalid" do
+              expect { subject.determine_config_path }.to raise_error(ChefRun::Startup::ConfigPathInvalid)
+            end
+
+          end
+
+          context "and it is readable" do
+            before do
+              allow(File).to receive(:readable?).with(path).and_return true
+            end
+            it "returns the custom path" do
+              expect(subject.determine_config_path).to eq path
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#load_config" do
+    it "finds the config path, initializes it, and loads config" do
+      mock_path = "/tmp/path.file"
+      expect(subject).to receive(:determine_config_path).and_return mock_path
+      expect(ChefRun::Config).to receive(:custom_location).with mock_path
+      expect(ChefRun::Config).to receive(:load)
+      subject.load_config
+    end
+  end
+
+  describe "#setup_logging" do
+    let(:log_path) { "/tmp/logs" }
+    let(:log_level) { :debug }
+    before do
+      ChefRun::Config.log.location = log_path
+      ChefRun::Config.log.level = log_level
+    end
+
+    after do
+      ChefRun::Config.reset
+    end
+
+    it "sets up the logger with the correct log path" do
+      expect(ChefRun::Log).to receive(:setup).
+        with(log_path, log_level)
+      subject.setup_logging
+    end
+  end
+
+  describe "#start_chef_run" do
+    let(:argv) { %w{some arguments} }
+    it "runs ChefRun::CLI and passes along arguments it received" do
+      run_double = instance_double(ChefRun::CLI)
+      expect(ChefRun::CLI).to receive(:new).with(argv).and_return(run_double)
+      expect(run_double).to receive(:run)
+      subject.start_chef_run
+    end
+  end
+end


### PR DESCRIPTION
In order to ensure that all configuration is loaded before we populate CLI options via Mixlib::CLI, 
this change separtes o

This resolves #180, in which changed configuration values were not recognized by the CLI when they were referenced before loading configuration - resulting in default values being propagated through the system. 

Changes: 
- Move tasks related to setup or initialization into a new Startup class
- chef-run executable now invokes Startup.run, which hands off control to CLI after all startup tasks are complete.

