### PR TITLE
[SHACK-195] Handle bad configuration errors gracefully.

### DIFF
--- a/components/chef-run/i18n/en.yml
+++ b/components/chef-run/i18n/en.yml
@@ -129,6 +129,26 @@ cli:
 
         --config-path /home/user1/.chef-workstation/config.toml
 
+    invalid_config_key: |
+
+      Invalid configuration entry.
+
+      When loading '%2',
+      the configuration entry '%1' was not recognized.
+
+      Please check the spelling and ensure that the value is correct.
+
+    unknown_config_error: |
+
+      Error in configuration file.
+
+      When loading '%2',
+      the following error occurred:
+        %1
+
+      Please verify that the configuration file is correct. If the
+      problem continues, contact beta@chef.io for further assistance.
+
   version:
     description: Show the current version of Chef Run.
     show: "chef-run: %1"


### PR DESCRIPTION


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Description

When an invalid configuration option is set in the config toml, an error spews forth: 

```
bundler: failed to load command: chef-run (/home/marc/.gem/ruby/2.5.0/bin/chef-run)
Mixlib::Config::UnknownConfigOptionError: Cannot set unsupported config value bob.
  /home/marc/.gem/ruby/2.5.0/gems/mixlib-config-2.2.6/lib/mixlib/config.rb:597:in `internal_set'
  /home/marc/.gem/ruby/2.5.0/gems/mixlib-config-2.2.6/lib/mixlib/config.rb:626:in `internal_get_or_set'
  /home/marc/.gem/ruby/2.5.0/gems/mixlib-config-2.2.6/lib/mixlib/config.rb:556:in `method_missing'
  --snip--
```
This shows something more helpful, and more inline with our UX requirements: 
```

Invalid configuration entry.

When loading '/home/marc/.chef-workstation/config.toml',
the configuration entry 'bob' was not recognized.

Please check the spelling and ensure that the value is correct.
```
### Issues Resolved
Internal tracker:  SHACK-195 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] During testing I noticed that there are other classes of config-related errors that can come out, particularly for bad TOML formatting. Will update for that. 