### PR TITLE
Pass correct config value for protocol

### DIFF
--- a/components/chef-run/lib/chef-run/cli.rb
+++ b/components/chef-run/lib/chef-run/cli.rb
@@ -95,7 +95,7 @@ module ChefRun
       default: ChefRun::Config.connection.winrm.ssl_verify
 
     option :protocol,
-      long: "--protocol",
+      long: "--protocol <PROTOCOL>",
       short: "-p",
       description: T.protocol_description(ChefRun::Config::SUPPORTED_PROTOCOLS.join(" "),
                                           ChefRun::Config.connection.default_protocol),
@@ -196,7 +196,7 @@ module ChefRun
         validate_params(cli_arguments)
         configure_chef
         target_hosts = TargetResolver.new(cli_arguments.shift,
-                                          config.delete(:default_protocol),
+                                          config.delete(:protocol),
                                           config).targets
         temp_cookbook, initial_status_msg = generate_temp_cookbook(cli_arguments)
         local_policy_path = create_local_policy(temp_cookbook)

--- a/components/chef-run/spec/integration/fixtures/chef_help.out
+++ b/components/chef-run/spec/integration/fixtures/chef_help.out
@@ -49,7 +49,7 @@ FLAGS:
                                        if there is no Chef client on the target(s).
         --password <PASSWORD>          Password to use for authentication to the target(s). The same
                                        password will be used for all targets.
-    -p, --protocol                     The protocol to use for connecting to targets.
+    -p, --protocol <PROTOCOL>          The protocol to use for connecting to targets.
                                        The default is 'ssh', and it can be changed in config.toml by
                                        setting 'connection.default_protocol' to a supported option.
     -s, --[no-]ssl                     Use SSL for WinRM. Current default: false


### PR DESCRIPTION

### Description

We were incorrectly passing the config value for
'default_protocol' into TargetResolver, but it we capture it
under the key 'protocol'

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Check List

- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>