### PR TITLE
Fix error that occurs when config file deleted.

### DIFF
--- a/components/chef-run/lib/chef-run/config.rb
+++ b/components/chef-run/lib/chef-run/config.rb
@@ -79,7 +79,9 @@ module ChefRun
       end
 
       def load
-        from_file(location)
+        if exist?
+          from_file(location)
+        end
       end
 
       def exist?

--- a/components/chef-run/spec/unit/config_spec.rb
+++ b/components/chef-run/spec/unit/config_spec.rb
@@ -46,4 +46,25 @@ RSpec.describe ChefRun::Config do
       expect(config.telemetry.dev).to eq(true)
     end
   end
+  describe "#load" do
+    before do
+      expect(subject).to receive(:exist?).and_return(exists)
+    end
+
+    context "when the config file exists" do
+      let(:exists) { true }
+      it "loads the file" do
+        expect(subject).to receive(:from_file)
+        subject.load
+      end
+    end
+
+    context "when the config file does not exist" do
+      let(:exists) { false }
+      it "does not try to load the file" do
+        expect(subject).to_not receive(:from_file)
+        subject.load
+      end
+    end
+  end
 end


### PR DESCRIPTION


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Description

When the default configuration file is deleted, and
a custom file is not specified, chef-run emits a stack trace
due to failure loading the missing file.

This can happen when the customer deletes or removes the default
config.toml. chef-run creates the file only on first-run, so if it's
removed after that point it stays gone.

Because we have to assume the customer had a reason for deleting the
configuration file, we can't recreate a new empty file.  Instead,
this fix changes it so that if the config file is missing, we don't try
to load it. This will leave configuration defaults in place.

### Issues Resolved

* n/a
### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>