### PR TITLE
[SHACK-233] Do not overwrite existing Policyfile

### DIFF
--- a/components/chef-run/i18n/en.yml
+++ b/components/chef-run/i18n/en.yml
@@ -158,6 +158,9 @@ cli:
     connection_failed: "Connection failed: %1"
 
 status:
+  generate_policyfile:
+    generating:  Generating local policyfile...
+    success: Generated local policyfile
   install_chef:
     installing: Installing Chef client version %1.
     checking_for_client: Checking for Chef client.
@@ -206,6 +209,14 @@ errors:
     requires a minimum version of %2.
 
     Please upgrade the Chef client on this node to version %2 or later.
+
+  # Local errors trying to create policy to send to target
+  CHEFPOLICY001: |
+    Could not create local Policyfile bundle.
+
+    The following error was reported:
+
+      %1
 
   # Remote execution and file operation errors are prefixed CHEFRMT
   CHEFRMT001: |
@@ -333,6 +344,7 @@ errors:
 
     %1
 
+  # CLI argument validation errors
   CHEFVAL002: |
     You must supply <TARGET[S]> and either <RESOURCE> and <RESOURCE_NAME> or <RECIPE>
 
@@ -424,6 +436,7 @@ errors:
       [connection.winrm]
       ssl_verify=false
 
+  # Errors specifying target ranges
   CHEFRANGE001: |
     The target '%1' contains an invalid range.
 
@@ -445,6 +458,7 @@ errors:
 
       At this time there is a limit of %2 hosts in a single operation.
 
+  # Errors related to multi-target execution
   CHEFMULTI001: |
     One or more actions has failed.
 

--- a/components/chef-run/lib/chef-run/temp_cookbook.rb
+++ b/components/chef-run/lib/chef-run/temp_cookbook.rb
@@ -115,11 +115,21 @@ module ChefRun
 
     def generate_policyfile(name, recipe_name)
       policy_file = File.join(path, "Policyfile.rb")
-      File.open(policy_file, "w+") do |f|
-        f.print("name \"#{name}_policy\"\n")
-        f.print("default_source :supermarket\n")
-        f.print("run_list \"#{name}::#{recipe_name}\"\n")
-        f.print("cookbook \"#{name}\", path: \".\"\n")
+      if File.exist?(policy_file)
+        File.open(policy_file, "a") do |f|
+          # We override the specified run_list with the run_list we want.
+          # We append and put this at the end of the file so it overrides
+          # any specified run_list.
+          f.print("\n# Overriding run_list with command line specified value\n")
+          f.print("run_list \"#{name}::#{recipe_name}\"\n")
+        end
+      else
+        File.open(policy_file, "w+") do |f|
+          f.print("name \"#{name}_policy\"\n")
+          f.print("default_source :supermarket\n")
+          f.print("run_list \"#{name}::#{recipe_name}\"\n")
+          f.print("cookbook \"#{name}\", path: \".\"\n")
+        end
       end
       policy_file
     end

--- a/components/chef-run/lib/chef-run/ui/error_printer.rb
+++ b/components/chef-run/lib/chef-run/ui/error_printer.rb
@@ -236,6 +236,7 @@ module ChefRun::UI
         if backtrace_length > cause_trace.length
           out.print "\t... #{backtrace_length - cause_trace.length} more"
         end
+        out.print "\n"
         current_backtrace = cause.backtrace
         cause = cause.cause
       end

--- a/components/chef-run/lib/chef-run/ui/terminal.rb
+++ b/components/chef-run/lib/chef-run/ui/terminal.rb
@@ -65,7 +65,7 @@ module ChefRun
         def render_parallel_jobs(header, actions, prefix: "")
           multispinner = TTY::Spinner::Multi.new("[:spinner] #{header}")
           actions.each do |a|
-            multispinner.register(":spinner #{a.prefix} :status") do |spinner|
+            multispinner.register(spinner_prefix(prefix)) do |spinner|
               reporter = StatusReporter.new(spinner, prefix: prefix, key: :status)
               a.run(reporter)
             end
@@ -77,10 +77,16 @@ module ChefRun
         #      between render_job and render_parallel
         def render_job(msg, prefix: "", &block)
           klass = ChefRun::UI.const_get(ChefRun::Config.dev.spinner)
-          spinner = klass.new("[:spinner] :prefix :status", output: @location)
+          spinner = klass.new(spinner_prefix(prefix), output: @location)
           reporter = StatusReporter.new(spinner, prefix: prefix, key: :status)
           reporter.update(msg)
           spinner.run { yield(reporter) }
+        end
+
+        def spinner_prefix(prefix)
+          spinner_msg = "[:spinner] "
+          spinner_msg += ":prefix " unless prefix.empty?
+          spinner_msg + ":status"
         end
       end
     end

--- a/components/chef-run/spec/unit/temp_cookbook_spec.rb
+++ b/components/chef-run/spec/unit/temp_cookbook_spec.rb
@@ -111,14 +111,32 @@ RSpec.describe ChefRun::TempCookbook do
   end
 
   describe "#generate_policyfile" do
-    it "generates a policyfile in the temp cookbook" do
-      f = tc.generate_policyfile("foo", "bar")
-      expect(File.read(f)).to eq <<-EOD.gsub(/^ {6}/, "")
-      name "foo_policy"
-      default_source :supermarket
-      run_list "foo::bar"
-      cookbook "foo", path: "."
-      EOD
+    context "when there is no existing policyfile" do
+      it "generates a policyfile in the temp cookbook" do
+        f = tc.generate_policyfile("foo", "bar")
+        expect(File.read(f)).to eq <<-EOD.gsub(/^ {8}/, "")
+        name "foo_policy"
+        default_source :supermarket
+        run_list "foo::bar"
+        cookbook "foo", path: "."
+        EOD
+      end
+    end
+
+    context "when there is an existing policyfile" do
+      before do
+        File.open(File.join(tc.path, "Policyfile.rb"), "a") do |f|
+          f << "this is a policyfile"
+        end
+      end
+      it "only overrides the existing run_list in the policyfile" do
+        f = tc.generate_policyfile("foo", "bar")
+        expect(File.read(f)).to eq <<-EOD.gsub(/^ {8}/, "")
+        this is a policyfile
+        # Overriding run_list with command line specified value
+        run_list "foo::bar"
+        EOD
+      end
     end
   end
 


### PR DESCRIPTION
### Description

When converging a recipe in an existing cookbook we don't want to blow
away a possible existing Policyfile because it could have custom sources
configured.

### Issues Resolved

SHACK-233

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>