### PR TITLE
Create ~/.chef-workstation before config file

### DIFF
--- a/components/chef-cli/lib/chef-cli/config.rb
+++ b/components/chef-cli/lib/chef-cli/config.rb
@@ -70,6 +70,7 @@ module ChefCLI
       end
 
       def create_default_config_file
+        FileUtils.mkdir_p(WS_BASE_PATH)
         FileUtils.touch(default_location)
       end
 

--- a/components/chef-run/lib/chef-run/startup.rb
+++ b/components/chef-run/lib/chef-run/startup.rb
@@ -93,6 +93,7 @@ module ChefRun
     def create_default_config
       UI::Terminal.output T.creating_config(Config.default_location)
       UI::Terminal.output ""
+      FileUtils.mkdir_p(Config::WS_BASE_PATH)
       FileUtils.touch(Config.default_location)
     end
 


### PR DESCRIPTION
### Description

This change adds the requisite `mkdir` commands to make sure the directory exists before attempting to write under it. Note—I didn't copy the “unless exist” clause as used in the integration tests because `mkdir` is idempotent and I trust it's actually less expensive without our condition.

### Issues Resolved

Attempting to run these programs without `~/.chef-workstation` already created results in a Ruby stack trace as it fails to write a config file to that path.

```
+$ chef-run
Creating config file in /home/trevor/.chef-workstation/config.toml.

Traceback (most recent call last):
        11: from /usr/bin/chef-run:179:in `<main>'
        10: from /usr/bin/chef-run:179:in `load'
         9: from /opt/chef-workstation/embedded/lib/ruby/gems/2.5.0/gems/chef-run-0.1.133/bin/chef-run:23:in `<top (required)>'
         8: from /opt/chef-workstation/embedded/lib/ruby/gems/2.5.0/gems/chef-run-0.1.133/lib/chef-run/startup.rb:36:in `run'
         7: from /opt/chef-workstation/embedded/lib/ruby/gems/2.5.0/gems/chef-run-0.1.133/lib/chef-run/startup.rb:89:in `first_run_tasks'
         6: from /opt/chef-workstation/embedded/lib/ruby/gems/2.5.0/gems/chef-run-0.1.133/lib/chef-run/startup.rb:96:in `create_default_config'                                                                                        
         5: from /opt/chef-workstation/embedded/lib/ruby/2.5.0/fileutils.rb:1051:in `touch'
         4: from /opt/chef-workstation/embedded/lib/ruby/2.5.0/fileutils.rb:1051:in `each'
         3: from /opt/chef-workstation/embedded/lib/ruby/2.5.0/fileutils.rb:1053:in `block in touch'
         2: from /opt/chef-workstation/embedded/lib/ruby/2.5.0/fileutils.rb:1057:in `rescue in block in touch'
         1: from /opt/chef-workstation/embedded/lib/ruby/2.5.0/fileutils.rb:1057:in `open'
/opt/chef-workstation/embedded/lib/ruby/2.5.0/fileutils.rb:1057:in `initialize': No such file or directory @ rb_sysopen - /home/trevor/.chef-workstation/config.toml (Errno::ENOENT)         
```

### Check List

- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>