### PR TITLE
Our verify scripts should fail the pipeline if any of our commands fail

### DIFF
--- a/ci/verify.bat
+++ b/ci/verify.bat
@@ -5,7 +5,9 @@ REM ; package is working correctly after install.
 
 REM ; chef-run version ensures our bin ends up on path and the basic ruby env is
 REM ; working.
-call chef-run version
+call chef-run --version
+IF %ERRORLEVEL% NEQ 0 goto :error
 
 REM ; Ensure our ChefDK works
-chef env
+call chef env
+IF %ERRORLEVEL% NEQ 0 goto :error

--- a/ci/verify.sh
+++ b/ci/verify.sh
@@ -1,8 +1,9 @@
 # This script is used in the jenkins part of our pipeline to verify our package
 # is working correctly after install.
+set -e
 
 # chef version ensures our bin ends up on path and the basic ruby env is working.
-chef-run version
+chef-run --version
 
 # Ensure our ChefDK works
 chef env


### PR DESCRIPTION
### Description

Our pipeline is passing `chef-run version` when it should not be.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tyleraball@gmail.com>