### PR TITLE
[SHACK-280] Multi-host spinner correctly displays hostnames again

### DIFF
--- a/components/chef-run/lib/chef-run/ui/terminal.rb
+++ b/components/chef-run/lib/chef-run/ui/terminal.rb
@@ -62,11 +62,11 @@ module ChefRun
           @location.puts msg
         end
 
-        def render_parallel_jobs(header, actions, prefix: "")
-          multispinner = TTY::Spinner::Multi.new("[:spinner] #{header}")
-          actions.each do |a|
-            multispinner.register(spinner_prefix(prefix)) do |spinner|
-              reporter = StatusReporter.new(spinner, prefix: prefix, key: :status)
+        def render_parallel_jobs(header, jobs)
+          multispinner = TTY::Spinner::Multi.new("[:spinner] #{header}", output: @location)
+          jobs.each do |a|
+            multispinner.register(spinner_prefix(a.prefix)) do |spinner|
+              reporter = StatusReporter.new(spinner, prefix: a.prefix, key: :status)
               a.run(reporter)
             end
           end

--- a/components/chef-run/spec/unit/ui/terminal_spec.rb
+++ b/components/chef-run/spec/unit/ui/terminal_spec.rb
@@ -20,6 +20,9 @@ require "chef-run/ui/terminal"
 
 RSpec.describe ChefRun::UI::Terminal do
   Terminal = ChefRun::UI::Terminal
+  # Lets send our Terminal output somewhere so it does not clutter the
+  # test output
+  Terminal.location = StringIO.new
 
   it "correctly outputs a message" do
     expect { Terminal.output("test") }


### PR DESCRIPTION
### Description

Before:
![shack-280-before](https://user-images.githubusercontent.com/2481463/42066844-46349c06-7b00-11e8-9740-64e02324e5ec.gif)

After:
![shack-280-after](https://user-images.githubusercontent.com/2481463/42066846-4a9dce8e-7b00-11e8-920e-57c46cbb3b63.gif)

### Issues Resolved

Jira SHACK-280

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the [Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
- [x] PR title is a worthy inclusion in the CHANGELOG

Signed-off-by: tyler-ball <tball@chef.io>
