### PR TITLE
[SHACK-278] Pinning ChefDK until we can successfully update Nokogiri

### DIFF
--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -40,7 +40,8 @@ build_iteration 1
 override :bundler,        version: "1.16.1"
 override :rubygems,       version: "2.7.6"
 override :ruby,           version: "2.5.1"
-override :"chef-dk",      version: "master"
+# Pinning to the 3_1 branch until that is release successfully, then we can re-float on master
+override :"chef-dk",      version: "3_1"
 
 # DK's overrides; god have mercy on my soul
 # This comes from DK's ./omnibus_overrides.rb


### PR DESCRIPTION
### Description

This pins the ChefDK to the 3.1 release branch (https://github.com/chef/chef-dk/pull/1611). The builds are currently failing with Nokogiri 1.8.3, but rolling back to 1.8.2 temporarily will allow us to clear up the pipeline and get Workstation builds flowing again.

### Issues Resolved

Jira SHACK-278

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the [Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
- [x] PR title is a worthy inclusion in the CHANGELOG
