### PR TITLE
Provide instructions via error message when no auth method is available.

### DIFF
--- a/components/chef-run/i18n/en.yml
+++ b/components/chef-run/i18n/en.yml
@@ -330,7 +330,7 @@ errors:
     sudo requires tty on this system
 
     In order to continue, sudo must be configured to no longer require tty.
-    You can do this by modifying /etc/sudoers -- see below.
+    You can do this by modifying /etc/sudoers:
 
     For all users:
       Defaults !requiretty
@@ -341,13 +341,13 @@ errors:
   CHEFTRN007: |
     No authentication methods available.
 
-    No password or key files have been provided, and no keys have been found
-    from your SSH agent.
+    Try...
+    - Provide a password with "--password PASSWORD"
+    - Provide a key with "-identity-file PATH/TO/FILE"
+    - Enable ssh-agent and add keys
+    - Add a host entry to your ssh configuration
 
-    To connect, please provide a password (--password) or key (--identity-file),
-    or enable ssh-agent and add your key files to that.
-
-    For more details around resolving this, please visit:
+    Additional instructions can be found in the troubleshooting documentation:
 
     https://www.chef.sh/docs/chef-workstation/troubleshooting/#error-code-cheftrn007
 

--- a/components/chef-run/i18n/en.yml
+++ b/components/chef-run/i18n/en.yml
@@ -338,6 +338,19 @@ errors:
     Per-user:
       Defaults:username !requiretty
 
+  CHEFTRN007: |
+    No authentication methods available.
+
+    No password or key files have been provided, and no keys have been found
+    from your SSH agent.
+
+    To connect, please provide a password (--password) or key (--identity-file),
+    or enable ssh-agent and add your key files to that.
+
+    For more details around resolving this, please visit:
+
+    https://www.chef.sh/docs/chef-workstation/troubleshooting/#error-code-cheftrn007
+
   CHEFTRN999: |
     Connection failed: %1
 

--- a/components/chef-run/lib/chef-run/target_host.rb
+++ b/components/chef-run/lib/chef-run/target_host.rb
@@ -54,6 +54,7 @@ module ChefRun
       [:sudo_password, :sudo, :sudo_command, :password, :user].each do |key|
         connection_opts[key] = opts_in[key] if opts_in.has_key? key
       end
+
       Train.target_config(connection_opts)
     end
 
@@ -214,6 +215,8 @@ module ChefRun
             ["CHEFTRN005", sudo_command] # :sudo_command_not_found
           when /Sudo requires a TTY.*/   # :sudo_no_tty
             "CHEFTRN006"
+          when /has no keys added/
+            "CHEFTRN007"
           else
             ["CHEFTRN999", original_exception.message]
           end

--- a/www/site/content/docs/chef-workstation/troubleshooting.md
+++ b/www/site/content/docs/chef-workstation/troubleshooting.md
@@ -36,6 +36,7 @@ Remove using respective package manager based on the distribution, for example, 
 
 ## Error code CHEFINT001
 
+
 ```
 CHEFINT001
 
@@ -44,9 +45,48 @@ An remote error has occurred:
   Your SSH Agent has no keys added, and you have not specified a password or a key file.
 ```
 
-How to add your `ssh` key:
+
+This error now appears as CHEFTRN007.  If you're running an older version of chef-run
+it will appear as CHEFINT001 with the message above.  Follow the steps detailed under
+CHEFTRN007 below to resolve.
+
+## Error code CHEFTRN007
+
+`No authentication methods available`
+
+This error occurs when there are no available ssh authentication methods to provide to the server.
+chef-run requires a password, a key file, or a `.ssh/config` host entry containing a KeyFile.
+Information about each option is below.
+
+### resolve via chef-run flags
+
+Use `--password` to provide the password required to authenticate to the host:
 
 ```
+chef-run --password $PASSWORD myhost.example.com --password
+```
+
+Alternatively, explicitly provide an identity file using '--identity-file':
+
+```
+chef-run --identity-file /path/to/your/ssh/key
+```
+
+### resolve by adding key(s) to ssh-agent
+```
+# ensure ssh-agent is running.  This may report it is already started:
+$ ssh-agent
+
+# Add your key file(s):
 $ ssh-add
 Identity added: /home/timmy/.ssh/id_rsa (/home/timmy/.ssh/id_rsa)
+```
+
+### resolve by adding a host entry to ~/.ssh/config
+
+Add an entry for this host to your .ssh/config:
+
+```
+host example.com
+  IdentityFile /path/to/valid/key
 ```


### PR DESCRIPTION
### Description
This handles the error 'Your SSH Agent has no keys added...' out of
train, and exposes it as CHEFTRN007 which contains instructions to
remedy.

### Issues Resolved

This prevents the operator from seeing this error as "CHEFINT001" and a message dump of the original train error, instead presenting instructions on how to resolve the error. 
![keys-error](https://user-images.githubusercontent.com/1130204/42240490-7c8aca2c-7ed5-11e8-91a5-4aea2ce784c4.png)


### Check List

- [ ] New functionality includes tests.  No: we need to expand how we're testing train errors to be more specific, but that will get picked up during the error refactor. 
- [x] All tests pass
- [x] All commits have been signed-off for the [Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
- [x] PR title is a worthy inclusion in the CHANGELOG
