### PR TITLE
Add docs to the PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,9 @@ StackOverflow discussion that's relevant]
 
 - [ ] New functionality includes tests
 - [ ] All tests pass
-- [ ] All commits have been signed-off for the [Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
 - [ ] PR title is a worthy inclusion in the CHANGELOG
+- [ ] You have locally validated the change
+- [ ] `www/site/content/docs/` has been updated with any relevant changes:
+  - * new or changed error messages in 'troubleshooting.md'
+  - * new or changed CLI flags in cli-reference.md
+


### PR DESCRIPTION

### Description

- Docs are an important part of providing a first-class UX, so I added
them to the PR template.
- Removed DCO from checklist, because the DCO bot will block the PR from merge
until commits are all signed off
- Added a sanity check for verifying submitter has run the code locally
from end-to-end, and not just run the tests.


### Issues Resolved
n/a

### Check List
n/a
