### PR TITLE
Minimize Github Issue/PR templates now that Chef Apply is separate project

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,9 @@
-<!--- 
+<!---
 !!!!!! NOTE: CHEF WORKSTATION BUGS ONLY !!!!!!
 
-This issue tracker is for the code contained within this repo.
+This issue tracker is for the code contained within this repo. For bugs originating from
+[ChefDK](https://github.com/chef/chef-dk) or [Chef Apply](https://github.com/chef/chef-apply) tools
+please file an issue in those repos.
 
 -->
 
@@ -13,17 +15,3 @@ This issue tracker is for the code contained within this repo.
 
 ## Platform Version
 <!--- Tell us which Operating System distribution and version Chef Workstation is running on. -->
-
-## Replication Case
-<!--- Tell us what steps to take to replicate your problem.  See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
-for information on how to create a good replication case. -->
-
-## Client Output
-<!--- The relevant output or a link to a gist of the entire run, if there is one. -->
-
-```
-
-```
-
-## Stacktrace
-<!--- Please include the stacktrace.out output or link to a gist of it, if there is one. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,8 @@ StackOverflow discussion that's relevant]
 
 ### Check List
 
-- [ ] New functionality includes tests
-- [ ] All tests pass
 - [ ] PR title is a worthy inclusion in the CHANGELOG
 - [ ] You have locally validated the change
 - [ ] `www/site/content/docs/` has been updated with any relevant changes:
   - * new or changed error messages in 'troubleshooting.md'
   - * new or changed CLI flags in cli-reference.md
-


### PR DESCRIPTION
### Description

Now that Chef Workstation is mostly based around packaging I expect we should be getting far fewer bugs here. Minimizing the issue template accordingly

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] PR title is a worthy inclusion in the CHANGELOG
- [ ] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md

Signed-off-by: tyler-ball <tball@chef.io>