### PR TITLE
[SHACK-322]  

### DIFF
--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -37,20 +37,30 @@ end
 build_version Omnibus::BuildVersion.semver
 build_iteration 1
 
-# One problem with the ChefDK today is that it includes a shit load of gem dependencies. We resolve all those dependencies in 1 location today - in the ChefDK repo (with its `Gemfile.lock`).
+# One problem with the ChefDK today is that it includes a shit load of gem
+# dependencies.  We resolve all those dependencies in 1 location today - in the
+# ChefDK repo (with its `Gemfile.lock`).
 
-# We eventually want to fix that problem as part of implementing the Chef Workstation RFC (https://github.com/chef/chef-rfc/pull/308). But until we do we need to pull `chef-apply` in as a gem dependency of the ChefDK.
+# We eventually want to fix that problem as part of implementing the Chef
+# Workstation RFC (https://github.com/chef/chef-rfc/pull/308). But until we do
+# we need to pull `chef-apply` in as a gem dependency of the ChefDK.
 
 # This means the promotion process for getting new Chef Apply changes out is:
 # 1. Merge the Chef Apply PR which causes expeditor to build a new gem
 # 2. Update the dependencies in the ChefDK with a PR
-# 3. Perform a new build of Chef Workstation. Because it pulls in ChefDK from `master` it will get the latest ChefDK and transitively the latest update to Chef Apply.
+# 3. Perform a new build of Chef Workstation. Because it pulls in ChefDK from
+# `master` it will get the latest ChefDK and transitively the latest update
+# to Chef Apply.
 
-# I've automated steps 1 and 3. This means that the _new_ process for promoting Chef Apply changes is:
+# I've automated steps 1 and 3. This means that the _new_ process for promoting
+# Chef Apply changes is:
 # 1. Update the dependencies in the ChefDK with a PR
 # 2. After Chef Workstation gets a new build triggered and completed, promote Chef Workstation as normal
 
-# I realize this is not ideal but I think its the best way forward today. We could try and do something sneaky/cute where we pull Chef Apply into Chef Workstation as a separate dependency but that exposes the risk that we break dependency resolution for the ChefDK (and transitively Chef Workstation)
+# I realize this is not ideal but I think its the best way forward today. We
+# could try and do something sneaky/cute where we pull Chef Apply into
+# Chef Workstation as a separate dependency but that exposes the risk that we
+# break dependency resolution for the ChefDK (and transitively Chef Workstation)
 
 override :"chef-dk",      version: "master"
 
@@ -77,7 +87,7 @@ override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
 override "libzmq", version: "4.0.7"
 override "openssl", version: "1.0.2p"
-
+override "nodejs", version: "10.9.0"
 dependency "preparation"
 
 if windows?
@@ -114,6 +124,9 @@ if windows?
   dependency "ruby-windows-devkit-bash"
   dependency "ruby-windows-system-libraries"
 end
+
+dependency "nodejs-binary"
+dependency "chef-workstation-app"
 
 exclude "**/.git"
 exclude "**/bundler/git"

--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -1,0 +1,50 @@
+name "chef-workstation-app"
+license "Apache-2.0"
+skip_transitive_dependency_licensing
+license_file "LICENSE"
+
+source git: "https://github.com/chef/chef-workstation-tray"
+default_version "SHACK-322/omnibusify-chef-workstation-app"
+
+build do
+  block "do_build" do
+    env = with_standard_compiler_flags(with_embedded_path)
+    app_version = JSON.parse(File.read(File.join(project_dir, "package.json")))["version"]
+    node_tools_dir = ENV['omnibus_nodejs_dir']
+    node_bin_path = windows? ? node_tools_dir : File.join(node_tools_dir, "bin")
+    env['PATH'] = "#{env['PATH']}#{separator}#{node_bin_path}"
+
+    platform_name, artifact_name = if mac_os_x?
+                                     ["mac", "Chef Workstation App-#{app_version}-mac.zip"]
+                                   elsif linux?
+                                     ["linux", "linux-unpacked"]
+                                   elsif windows?
+                                     ["win", "Chef Workstation App-#{app_version}-win.zip"]
+                                   end
+
+
+    dist_dir = File.join(project_dir, "dist")
+    installer_dir = "#{install_dir}/installers"
+
+    artifact_path = File.join(dist_dir, artifact_name)
+    mkdir installer_dir
+    # Ensure no leftover artifacts from a previous build -
+    # electron-builder will recreate it:
+    delete dist_dir
+
+    command "npm install", env: env
+    command "npm install run-script build-#{platform_name}", env: env
+
+    if linux?
+      # For linux we're using directories - electron-builder's packageer
+      # fails on RHEL6 because of a missing GLIBC version for electron-builder's
+      # included compression utilities (7z, tar, etc) during build.
+      # Instead, we'll manually create this archive as part of the build for linux.
+      target = File.join(installer_dir, "chef-workstation-app-#{platform_name}.tar.gz")
+      command "tar -f #{target} -C #{artifact_path} -cz .", env: env
+    else
+      target = File.join(installer_dir, "chef-workstation-app-#{platform_name}.zip")
+      copy artifact_path, target
+    end
+  end
+end

--- a/omnibus/config/software/nodejs-binary.rb
+++ b/omnibus/config/software/nodejs-binary.rb
@@ -1,0 +1,79 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# nodejs-binary provides nodejs using the binary packages provided by
+# the upstream.  Because this is for build-time use only, it does not does
+# not install it into `install_dir` and so does not need to be cleaned up.
+# Instead, it's  instead it's retained in the build cache location.
+#
+# The specific path is shared via the environment variable `omnibus_nodejs_dir`
+# which gets set when this software definition is loaded.
+#
+# To use the nodejs binaries (npm, node) first ensure this is a dependency for
+# your component; then:
+#   *nix, mac,  add ENV['omnibus_nodejs_dir']/bin to the PATH within the `build` block.
+#   * For Windows, add ENV['omnibus_nodejs_dir']  and do not append '\bin'
+#
+#
+# To ensure no ordering issues around load v build time resolution,
+# it may be necessary to include a `block in your `build` block.
+# Here's an example:
+# ```
+# build do
+#  block "stuff-to-run-only-after-all-definitions-are-loaded" do
+#   env = with_standard_compiler_flags(with_embedded_path)
+#   node_tools_dir = ENV['omnibus_nodejs_dir']
+#   node_bin_path = windows? ? node_tools_dir : File.join(node_tools_dir, "bin")
+#   separator = File::PATH_SEPARATOR || ":"
+#   env['PATH'] = "#{env['PATH']}#{separator}#{node_bin_path}"
+#   command "npm build", env: env
+#  end
+# end
+# ```
+
+name "nodejs-binary"
+default_version "10.9.0"
+
+license "MIT"
+license_file "LICENSE"
+skip_transitive_dependency_licensing true
+
+version "10.9.0" do
+  source_hash = if mac_os_x?
+                  "3c4fe75dacfcc495a432a7ba2dec9045cff359af2a5d7d0429c84a424ef686fc"
+                elsif linux?
+                  "d061760884e4705adfc858eb669c44eb66cd57e8cdf6d5d57a190e76723af416"
+                elsif windows?
+                  "6a75cdbb69d62ed242d6cbf0238a470bcbf628567ee339d4d098a5efcda2401e"
+                else
+                  raise "nodejs-binary does not have configuration for this build platform"
+                end
+  source sha256: source_hash
+end
+
+platform_name, platform_ext = if mac_os_x?
+                                %w{darwin tar.gz}
+                              elsif linux?
+                                %w{linux tar.gz}
+                              elsif windows?
+                                %w{win zip}
+                              end
+
+source url: "https://nodejs.org/dist/v#{version}/node-v#{version}-#{platform_name}-x64.#{platform_ext}"
+relative_path "node-v#{version}-#{platform_name}-x64"
+
+ENV['omnibus_nodejs_dir'] = project_dir


### PR DESCRIPTION
### Description

This change adds a build of chef-workstation-app to the omnibus package for Chef Workstation.

The app is not usable without further processing (extract/copying/symlink at install time), but this PR gets it included so that work can begin. 

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
- [ ] ~`www/site/content/docs/` has been updated with any relevant changes:~
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md
