### PR TITLE
[SHACK-353] Enable CWA on Windows

### DIFF
--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -37,20 +37,20 @@ build do
                                    elsif linux?
                                      ["linux", "linux-unpacked"]
                                    elsif windows?
-                                     ["win", "Chef Workstation App-#{app_version}-win.zip"]
+                                     ["win", "win-unpacked"]
                                    end
 
 
     dist_dir = File.join(project_dir, "dist")
-    installer_dir = "#{install_dir}/installers"
-
     artifact_path = File.join(dist_dir, artifact_name)
-    mkdir installer_dir
+    app_install_path = "#{install_dir}/components/chef-workstation-app"
+    mkdir app_install_path
+
     # Ensure no leftover artifacts from a previous build -
     # electron-builder will recreate it:
     delete dist_dir
-    npm_bin = File.join(node_bin_path, "npm")
 
+    npm_bin = File.join(node_bin_path, "npm")
     command "#{npm_bin} install", env: env
     command "#{npm_bin} run-script build-#{platform_name}", env: env
 
@@ -59,10 +59,13 @@ build do
       # fails on RHEL6 because of a missing GLIBC version for electron-builder's
       # included compression utilities (7z, tar, etc) during build.
       # Instead, we'll manually create this archive as part of the build for linux.
-      target = File.join(installer_dir, "chef-workstation-app-#{platform_name}.tar.gz")
+      target = File.join(app_install_path, "chef-workstation-app-#{platform_name}.tar.gz")
       command "tar -f #{target} -C #{artifact_path} -cz .", env: env
+    elsif windows?
+      sync artifact_path, app_install_path
     else
-      target = File.join(installer_dir, "chef-workstation-app-#{platform_name}.zip")
+
+      target = File.join(app_install_path, "chef-workstation-app-#{platform_name}.zip")
       copy artifact_path, target
     end
   end

--- a/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
@@ -23,13 +23,13 @@
   <String Id="FeaturePSModuleName"><%= friendly_name %> PowerShell wrappers</String>
 
   <String Id="FeatureChefWSEnvHacks">Environment Customizations</String>
-  <String Id="FeatureChefWSEnvHacksDesc">Allows Chef Workstation to try to find a suitable HOME drive when running Ruby programs.</String>
+  <String Id="FeatureChefWSEnvHacksDesc">Allows <%= friendly_name %> to try to find a suitable HOME drive when running Ruby programs.</String>
 
   <String Id="ChefWSPowershellShortcutDefName"><%= friendly_name %> PowerShell Prompt</String>
   <String Id="ChefWSPowershellShortcutDefDesc">A PowerShell prompt pre-configured to allow you to work with <%= friendly_name %>'s included suite of tools.</String>
 
   <String Id="ChefWSAppShortcutName"><%= friendly_name %> App [Experimental]</String>
-  <String Id="ChefWSAppShortcutDesc">Manage Chef Workstation preferences, feedback, and updates.</String>
+  <String Id="ChefWSAppShortcutDesc">Manage <%= friendly_name %> preferences, feedback, and updates.</String>
 
   <String Id="FeatureChefWSStartMenuPSShortcut">Start Menu PowerShell Shortcut</String>
   <String Id="FeatureChefWSStartMenuPSShortcutDesc">Install a <%= friendly_name %> shortcut to the Start menu.</String>
@@ -40,7 +40,7 @@
 	<String Id="FeatureExperimental">Install Experimental Features</String>
 	<String Id="FeatureExperimentalDesc">These features may be incomplete or unstable</String>
 
-	<String Id="FeatureExperimentalChefWS">Chef Workstation App</String>
+  <String Id="FeatureExperimentalChefWS"><%= friendly_name %> App</String>
   <String Id="FeatureExperimentalChefWSDesc">Enable the <%= friendly_name %> App</String>
 
   <String Id="FeatureChefWSAppAutostart">Start on login</String>

--- a/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
@@ -19,20 +19,35 @@
   <String Id="VerifyReadyDlgInstallTitle">{\WixUI_Font_Title_White}Ready to install [ProductName]</String>
 
   <String Id="FeatureMainName"><%= friendly_name %></String>
+  <String Id="FeatureMainDesc">Install <%= friendly_name %> to this system.</String>
   <String Id="FeaturePSModuleName"><%= friendly_name %> PowerShell wrappers</String>
-  <String Id="FeatureChefWSEnvHacks">ChefWorkstation Environment Customizations</String>
-  <String Id="FeatureChefWSEnvHacksDesc">Allows ChefWorkstation to try to find a suitable HOME drive when running Ruby programs.</String>
 
-  <String Id="ChefWSShortcutDefName"><%= friendly_name %></String>
-  <String Id="ChefWSShortcutDefDescription"><%= friendly_name %> Command Prompt</String>
+  <String Id="FeatureChefWSEnvHacks">Environment Customizations</String>
+  <String Id="FeatureChefWSEnvHacksDesc">Allows Chef Workstation to try to find a suitable HOME drive when running Ruby programs.</String>
 
-  <String Id="FeatureChefWSStartMenuShortcut">Start Menu Shortcut</String>
-  <String Id="FeatureChefWSStartMenuShortcutDescription">Install a ChefWorkstation shortcut on the user's Start Menu.</String>
-  <String Id="FeatureChefWSDesktopShortcut">Desktop Shortcut</String>
-  <String Id="FeatureChefWSDesktopShortcutDescription">Install a ChefWorkstation shortcut on the user's Desktop.</String>
+  <String Id="ChefWSPowershellShortcutDefName"><%= friendly_name %> PowerShell Prompt</String>
+  <String Id="ChefWSPowershellShortcutDefDesc">A PowerShell prompt pre-configured to allow you to work with <%= friendly_name %>'s included suite of tools.</String>
 
+  <String Id="ChefWSAppShortcutName"><%= friendly_name %> App [Experimental]</String>
+  <String Id="ChefWSAppShortcutDesc">Manage Chef Workstation preferences, feedback, and updates.</String>
+
+  <String Id="FeatureChefWSStartMenuPSShortcut">Start Menu PowerShell Shortcut</String>
+  <String Id="FeatureChefWSStartMenuPSShortcutDesc">Install a <%= friendly_name %> shortcut to the Start menu.</String>
+
+  <String Id="FeatureChefWSDesktopPSShortcut">Desktop PowerShell Shortcut</String>
+  <String Id="FeatureChefWSDesktopPSShortcutDesc">Install a <%= friendly_name %> PowerShell shortcut to your Desktop.</String>
+
+	<String Id="FeatureExperimental">Install Experimental Features</String>
+	<String Id="FeatureExperimentalDesc">These features may be incomplete or unstable</String>
+
+	<String Id="FeatureExperimentalChefWS">Chef Workstation App</String>
+  <String Id="FeatureExperimentalChefWSDesc">Enable the <%= friendly_name %> App</String>
+
+  <String Id="FeatureChefWSAppAutostart">Start on login</String>
+  <String Id="FeatureChefWSAppAutostartDesc">Configure the <%= friendly_name %> App to autostart on login</String>
 
   <String Id="MinimumOSVersionMessage">This package requires minimum OS version: Windows 7/Windows Server 2008 R2 or greater.</String>
   <String Id="DowngradeErrorMessage">A newer version of [ProductName] is already installed.</String>
   <String Id="FileExtractionProgress">Extracting files, please wait...</String>
 </WixLocalization>
+

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -9,9 +9,9 @@
     Name is made of localized product name and version number.
   -->
   <Product Id="*" Name="!(loc.ProductName) v$(var.DisplayVersionNumber)" Language="!(loc.LANG)"
-          Version="$(var.VersionNumber)" Manufacturer="!(loc.ManufacturerName)" UpgradeCode="$(var.UpgradeCode)">
+    Version="$(var.VersionNumber)" Manufacturer="!(loc.ManufacturerName)" UpgradeCode="$(var.UpgradeCode)">
     <Package InstallerVersion="200" InstallPrivileges="elevated"
-             Compressed="yes" InstallScope="perMachine" />
+      Compressed="yes" InstallScope="perMachine" />
 
     <Media Id="1" Cabinet="ChefWorkstation.cab" EmbedCab="yes" CompressionLevel="high" />
     <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" />
@@ -22,26 +22,26 @@
     -->
     <% if fastmsi %>
     <SetProperty Id="FastUnzip"
-                 Value="FASTZIPDIR=[INSTALLLOCATION];FASTZIPAPPNAME=chef-workstation"
-                 Sequence="execute"
-                 Before="FastUnzip" />
+      Value="FASTZIPDIR=[INSTALLLOCATION];FASTZIPAPPNAME=chef-workstation"
+      Sequence="execute"
+      Before="FastUnzip" />
 
     <CustomAction Id="FastUnzip"
-                  BinaryKey="CustomActionFastMsiDLL"
-                  DllEntry="FastUnzip"
-                  Execute="deferred"
-                  Impersonate="no"
-                  Return="check" />
+      BinaryKey="CustomActionFastMsiDLL"
+      DllEntry="FastUnzip"
+      Execute="deferred"
+      Impersonate="no"
+      Return="check" />
 
     <Binary Id="CustomActionFastMsiDLL"
-            SourceFile="CustomActionFastMsi.CA.dll" />
+      SourceFile="CustomActionFastMsi.CA.dll" />
 
     <CustomAction Id="Cleanup"
-                  Directory="INSTALLLOCATION"
-                  ExeCommand="cmd /C &quot;rd /S /Q chef-workstation&quot;"
-                  Execute="deferred"
-                  Impersonate="no"
-                  Return="ignore" />
+      Directory="INSTALLLOCATION"
+      ExeCommand="cmd /C &quot;rd /S /Q chef-workstation&quot;"
+      Execute="deferred"
+      Impersonate="no"
+      Return="ignore" />
 
     <InstallExecuteSequence>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
@@ -51,85 +51,85 @@
     <UI>
       <ProgressText Action="FastUnzip">!(loc.FileExtractionProgress)</ProgressText>
     </UI>
-  <% end %>
+    <% end %>
 
-  <!-- TODO
+    <!-- TODO
        For now, using COMMON_ALTSTARTUP which is the global auto-start folder. Note that this
        may cause some trouble - we haven't yet looked into how the App should behave when multiple
        instances are running. We can instead use WIXDIR_ALTSTARTUP which is per-user - but that means
        if it's installed on a shared server, only one user will get the tray app be default.
-	-->
-	<PropertyRef Id="WIX_DIR_COMMON_ALTSTARTUP" />
+  -->
+  <PropertyRef Id="WIX_DIR_COMMON_ALTSTARTUP" />
 
-	<CustomActionRef Id="WixBroadcastSettingChange" />
-	<CustomActionRef Id="WixBroadcastEnvironmentChange" />
+  <CustomActionRef Id="WixBroadcastSettingChange" />
+  <CustomActionRef Id="WixBroadcastEnvironmentChange" />
 
-	<SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]"/>
-	<Directory Id="TARGETDIR" Name="SourceDir">
-		<Directory Id="WINDOWSVOLUME">
-			<Directory Id="INSTALLLOCATION" Name="opscode">
-				<Directory Id="PROJECTLOCATION" Name="chef-workstation">
-					<Directory Id="PROJECTLOCATIONBIN" Name="bin">
-						<Component Id="ChefWSPath" Guid="{BC744260-FD5B-4A0F-8EE5-76283072CC09}" >
-							<Environment Id="Environment"
-								Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATIONBIN]" />
-						</Component>
-						<Component Id="StartChefWSPowershellShortcut" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
-							<!-- Note that this refers to a Source relative to the package build directory,
-										 and not in the zip file which contains all of the chef-workstation build -->
-								<File Id="StartChefWSScript" Source="Resources\assets\start-chefws.ps1" KeyPath="yes" />
-							</Component>
-						</Directory>
-						<Directory Id="PSMODULES" Name="modules" >
-							<Component Id="ChefPSModulePath" Guid="{FA4B6948-087F-4460-A741-47E5A5E3B235}" >
-								<Environment Id="ChefPSModulePathEnvironment"
-									Name="PSModulePath" Action="set" Part="last" System="yes" Value="[PSMODULES]" />
-							</Component>
-							<Component Id="ChefPowerShellRegistryEntries" Guid="{CA712E00-B031-424D-A439-838454AF94C5}">
-								<RegistryKey Root="HKCR" Key="Chef.PowerShell">
-									<RegistryValue Type="string" Value="Chef.PowerShell" />
-								</RegistryKey>
-								<RegistryKey Root="HKCR" Key="Chef.PowerShell\CLSID">
-									<RegistryValue Type="string" Value="{9008CA83-83E4-41FF-9C07-696E2CC47B52}" />
-								</RegistryKey>
-								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}">
-									<RegistryValue Type="string" Value="Chef.PowerShell" />
-								</RegistryKey>
-								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32">
-									<RegistryValue Type="string" Value="[System64Folder]mscoree.dll" />
-									<RegistryValue Type="string" Name="ThreadingModel" Value="Both" />
-									<RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
-									<RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
-									<RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
-									<RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
-								</RegistryKey>
-								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32\1.0.0.0">
-									<RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
-									<RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
-									<RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
-									<RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
-								</RegistryKey>
-								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\ProgId">
-									<RegistryValue Type="string" Value="Chef.PowerShell" />
-								</RegistryKey>
-								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}" />
-							</Component>
-						</Directory>
-						<Directory Id="COMPONENTS" Name="components">
-							<Directory Id="WSAPPDIR" Name="chef-workstation-app">
-							</Directory>
-						</Directory>
-						<Directory Id="EMBEDDED" Name="embedded" >
-							<Directory Id="EMBEDDEDBIN" Name="bin" >
-								<Component Id="ChefWSEnvHacks" Guid="{3498A65D-33D8-4CF2-BAB8-6FA072A7070D}" >
-									<Environment Id="EnvHacksEnvironment"
-										Name="CHEFDK_ENV_FIX" Action="set" System="yes" Value="1" />
-								</Component>
-							</Directory>
-						</Directory>
-					</Directory>
-				</Directory>
-			</Directory>
+  <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]"/>
+  <Directory Id="TARGETDIR" Name="SourceDir">
+    <Directory Id="WINDOWSVOLUME">
+      <Directory Id="INSTALLLOCATION" Name="opscode">
+        <Directory Id="PROJECTLOCATION" Name="chef-workstation">
+          <Directory Id="PROJECTLOCATIONBIN" Name="bin">
+            <Component Id="ChefWSPath" Guid="{BC744260-FD5B-4A0F-8EE5-76283072CC09}" >
+              <Environment Id="Environment"
+                Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATIONBIN]" />
+            </Component>
+            <Component Id="StartChefWSPowershellShortcut" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
+              <!-- Note that this refers to a Source relative to the package build directory,
+                     and not in the zip file which contains all of the chef-workstation build -->
+                <File Id="StartChefWSScript" Source="Resources\assets\start-chefws.ps1" KeyPath="yes" />
+              </Component>
+            </Directory>
+            <Directory Id="PSMODULES" Name="modules" >
+              <Component Id="ChefPSModulePath" Guid="{FA4B6948-087F-4460-A741-47E5A5E3B235}" >
+                <Environment Id="ChefPSModulePathEnvironment"
+                  Name="PSModulePath" Action="set" Part="last" System="yes" Value="[PSMODULES]" />
+              </Component>
+              <Component Id="ChefPowerShellRegistryEntries" Guid="{CA712E00-B031-424D-A439-838454AF94C5}">
+                <RegistryKey Root="HKCR" Key="Chef.PowerShell">
+                  <RegistryValue Type="string" Value="Chef.PowerShell" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="Chef.PowerShell\CLSID">
+                  <RegistryValue Type="string" Value="{9008CA83-83E4-41FF-9C07-696E2CC47B52}" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}">
+                  <RegistryValue Type="string" Value="Chef.PowerShell" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32">
+                  <RegistryValue Type="string" Value="[System64Folder]mscoree.dll" />
+                  <RegistryValue Type="string" Name="ThreadingModel" Value="Both" />
+                  <RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
+                  <RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
+                  <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
+                  <RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32\1.0.0.0">
+                  <RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
+                  <RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
+                  <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
+                  <RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\ProgId">
+                  <RegistryValue Type="string" Value="Chef.PowerShell" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}" />
+              </Component>
+            </Directory>
+            <Directory Id="COMPONENTS" Name="components">
+              <Directory Id="WSAPPDIR" Name="chef-workstation-app">
+              </Directory>
+            </Directory>
+            <Directory Id="EMBEDDED" Name="embedded" >
+              <Directory Id="EMBEDDEDBIN" Name="bin" >
+                <Component Id="ChefWSEnvHacks" Guid="{3498A65D-33D8-4CF2-BAB8-6FA072A7070D}" >
+                  <Environment Id="EnvHacksEnvironment"
+                    Name="CHEFDK_ENV_FIX" Action="set" System="yes" Value="1" />
+                </Component>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
       <Directory Id="ProgramMenuFolder">
         <!-- Place shortcuts grouped in a "Chef Workstation" folder in the Start menu -->
         <Directory Id="ChefWorkstationFolder" Name="Chef Workstation">
@@ -150,41 +150,41 @@
               Icon="cws.ico"/>
           </Component>
         </Directory>
-			</Directory>
+      </Directory>
 
-			<!-- This component puts the WS App in the common autostart folder [if the Feature is selected] -->
-			<Directory Id="WIX_DIR_COMMON_ALTSTARTUP" >
-				<Component Id="ChefWSAppAutostartShortcut" Guid="{DF9613D2-4BCA-4D81-8BFA-989070EF1633}">
-					<Shortcut Id="ChefAppWSAutostartShortcutDef"
-						Name="!(loc.ChefWSAppShortcutName)"
-						Description="!(loc.ChefWSAppShortcutDesc)"
-						Target="[WSAPPDIR]\Chef Workstation App.exe"
-						Icon="cws.ico"/>
-				</Component>
-			</Directory>
+      <!-- This component puts the WS App in the common autostart folder [if the Feature is selected] -->
+      <Directory Id="WIX_DIR_COMMON_ALTSTARTUP" >
+        <Component Id="ChefWSAppAutostartShortcut" Guid="{DF9613D2-4BCA-4D81-8BFA-989070EF1633}">
+          <Shortcut Id="ChefAppWSAutostartShortcutDef"
+            Name="!(loc.ChefWSAppShortcutName)"
+            Description="!(loc.ChefWSAppShortcutDesc)"
+            Target="[WSAPPDIR]\Chef Workstation App.exe"
+            Icon="cws.ico"/>
+        </Component>
+      </Directory>
 
-			<Directory Id="DesktopFolder" Name="Desktop">
-				<Component Id="PowershellDesktopShortcut" Guid="{396E22A6-A7B6-4AA1-B63C-83A3DD7007A8}">
-					<Shortcut Id="PowershellDesktopShortcutDef"
-						Name="!(loc.ChefWSPowershellShortcutDefName)"
-						Description="!(loc.ChefWSPowershellShortcutDefDesc)"
-						Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
-						Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefWSScript]"
-						Show="minimized"
-						Icon="cws.ico"/>
+      <Directory Id="DesktopFolder" Name="Desktop">
+        <Component Id="PowershellDesktopShortcut" Guid="{396E22A6-A7B6-4AA1-B63C-83A3DD7007A8}">
+          <Shortcut Id="PowershellDesktopShortcutDef"
+            Name="!(loc.ChefWSPowershellShortcutDefName)"
+            Description="!(loc.ChefWSPowershellShortcutDefDesc)"
+            Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
+            Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefWSScript]"
+            Show="minimized"
+            Icon="cws.ico"/>
         </Component>
 
-				<Component Id="ChefWSAppDesktopShortcut" Guid="91f753ca-d87b-4ef2-915c-2183bef16177">
-					<Shortcut Id="ChefWSAppDesktopShortcutDef"
-						Name="!(loc.ChefWSAppShortcutName)"
-						Description="!(loc.ChefWSAppShortcutDesc)"
-						Target="[WSAPPDIR]\Chef Workstation App.exe"
-						Icon="cws.ico"/>
-				</Component>
-			</Directory>
-		</Directory>
+        <Component Id="ChefWSAppDesktopShortcut" Guid="91f753ca-d87b-4ef2-915c-2183bef16177">
+          <Shortcut Id="ChefWSAppDesktopShortcutDef"
+            Name="!(loc.ChefWSAppShortcutName)"
+            Description="!(loc.ChefWSAppShortcutDesc)"
+            Target="[WSAPPDIR]\Chef Workstation App.exe"
+            Icon="cws.ico"/>
+        </Component>
+      </Directory>
+    </Directory>
 
-		<!-- Set the components defined in our fragment files that will be used for our feature  -->
+    <!-- Set the components defined in our fragment files that will be used for our feature  -->
     <!-- Renders the following install options
          [x] Chef Workstation
            [x] Start Menu Shortcut
@@ -195,60 +195,60 @@
     <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)"
       Description="!(loc.FeatureMainDesc)"
       Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
-			<ComponentGroupRef Id="ProjectDir" />
-			<ComponentRef Id="ChefWSPath" />
-			<ComponentRef Id="ChefPSModulePath" />
-			<ComponentRef Id="ChefPowerShellRegistryEntries" />
-			<Feature Id="ChefWSStartMenuPSShortcutFeature" Title="!(loc.FeatureChefWSStartMenuPSShortcut)"
-	             Description="!(loc.FeatureChefWSStartMenuPSShortcutDesc)" Level="1" AllowAdvertise="no" >
-				<ComponentRef Id="StartChefWSPowershellShortcut" />
-				<ComponentRef Id="PowershellStartMenuShortcut" />
-			</Feature>
-			<Feature Id="ChefWSDesktopPSShortcutFeature" Title="!(loc.FeatureChefWSDesktopPSShortcut)"
-               Description="!(loc.FeatureChefWSDesktopPSShortcutDesc)" Level="1" AllowAdvertise="no" >
-				<ComponentRef Id="StartChefWSPowershellShortcut" />
-				<ComponentRef Id="PowershellDesktopShortcut" />
-			</Feature>
-			<Feature Id="ChefWSEnvHacks" Title="!(loc.FeatureChefWSEnvHacks)" Description="!(loc.FeatureChefWSEnvHacksDesc)" Level="1000" AllowAdvertise="no">
-				<ComponentRef Id="ChefWSEnvHacks" />
-			</Feature>
-		</Feature>
+      <ComponentGroupRef Id="ProjectDir" />
+      <ComponentRef Id="ChefWSPath" />
+      <ComponentRef Id="ChefPSModulePath" />
+      <ComponentRef Id="ChefPowerShellRegistryEntries" />
+      <Feature Id="ChefWSStartMenuPSShortcutFeature" Title="!(loc.FeatureChefWSStartMenuPSShortcut)"
+        Description="!(loc.FeatureChefWSStartMenuPSShortcutDesc)" Level="1" AllowAdvertise="no" >
+        <ComponentRef Id="StartChefWSPowershellShortcut" />
+        <ComponentRef Id="PowershellStartMenuShortcut" />
+      </Feature>
+      <Feature Id="ChefWSDesktopPSShortcutFeature" Title="!(loc.FeatureChefWSDesktopPSShortcut)"
+        Description="!(loc.FeatureChefWSDesktopPSShortcutDesc)" Level="1" AllowAdvertise="no" >
+        <ComponentRef Id="StartChefWSPowershellShortcut" />
+        <ComponentRef Id="PowershellDesktopShortcut" />
+      </Feature>
+      <Feature Id="ChefWSEnvHacks" Title="!(loc.FeatureChefWSEnvHacks)" Description="!(loc.FeatureChefWSEnvHacksDesc)" Level="1000" AllowAdvertise="no">
+        <ComponentRef Id="ChefWSEnvHacks" />
+      </Feature>
+    </Feature>
 
-		<Feature Id="ExperimentalFeatures" Title="!(loc.FeatureExperimental)" Description="!(loc.FeatureExperimentalDesc)" Level="1000" AllowAdvertise="no" Display="collapse">
-			<Feature Id="ExperimentalChefWSApp" Title="!(loc.FeatureExperimentalChefWS)" Description="!(loc.FeatureExperimentalChefWSDesc">
-				<ComponentRef Id="ChefWSAppAutostartShortcut" />
-				<ComponentRef Id="ChefWSAppStartMenuShortcut" />
-				<ComponentRef Id="ChefWSAppDesktopShortcut" />
-			</Feature>
-		</Feature>
+    <Feature Id="ExperimentalFeatures" Title="!(loc.FeatureExperimental)" Description="!(loc.FeatureExperimentalDesc)" Level="1000" AllowAdvertise="no" Display="collapse">
+      <Feature Id="ExperimentalChefWSApp" Title="!(loc.FeatureExperimentalChefWS)" Description="!(loc.FeatureExperimentalChefWSDesc)">
+        <ComponentRef Id="ChefWSAppAutostartShortcut" />
+        <ComponentRef Id="ChefWSAppStartMenuShortcut" />
+        <ComponentRef Id="ChefWSAppDesktopShortcut" />
+      </Feature>
+    </Feature>
 
-		<!--
-		UI Stuff
-		-->
-		<Icon Id="cws16.ico" SourceFile="Resources\assets\cws_16x16.ico"/>
-		<Icon Id="cws32.ico" SourceFile="Resources\assets\cws_32x32.ico"/>
-		<Icon Id="cws.ico" SourceFile="Resources\assets\cws.ico"/>
-		<Property Id="ARPPRODUCTICON" Value="cws16.ico" />
-		<Property Id="ARPHELPLINK" Value="https://chef.sh/" />
-		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLLOCATION" />
-		<UIRef Id="ChefWSUI_InstallDir"/>
-		<UI Id="ChefWSUI_InstallDir">
-			<UIRef Id="WixUI_FeatureTree"/>
-			<TextStyle Id="WixUI_Font_Normal_White" FaceName="Tahoma" Size="8" Red="255" Green="255" Blue="255" />
-			<TextStyle Id="WixUI_Font_Bigger_White" FaceName="Tahoma" Size="12" Red="255" Green="255" Blue="255" />
-			<TextStyle Id="WixUI_Font_Title_White" FaceName="Tahoma" Size="9" Bold="yes" Red="255" Green="255" Blue="255" />
-		</UI>
+    <!--
+    UI Stuff
+    -->
+    <Icon Id="cws16.ico" SourceFile="Resources\assets\cws_16x16.ico"/>
+    <Icon Id="cws32.ico" SourceFile="Resources\assets\cws_32x32.ico"/>
+    <Icon Id="cws.ico" SourceFile="Resources\assets\cws.ico"/>
+    <Property Id="ARPPRODUCTICON" Value="cws16.ico" />
+    <Property Id="ARPHELPLINK" Value="https://chef.sh/" />
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLLOCATION" />
+    <UIRef Id="ChefWSUI_InstallDir"/>
+    <UI Id="ChefWSUI_InstallDir">
+      <UIRef Id="WixUI_FeatureTree"/>
+      <TextStyle Id="WixUI_Font_Normal_White" FaceName="Tahoma" Size="8" Red="255" Green="255" Blue="255" />
+      <TextStyle Id="WixUI_Font_Bigger_White" FaceName="Tahoma" Size="12" Red="255" Green="255" Blue="255" />
+      <TextStyle Id="WixUI_Font_Title_White" FaceName="Tahoma" Size="9" Bold="yes" Red="255" Green="255" Blue="255" />
+    </UI>
 
-		<WixVariable Id="WixUILicenseRtf" Value="Resources\assets\LICENSE.rtf" />
-		<WixVariable Id="WixUIDialogBmp" Value="Resources\assets\dialog_background.bmp" />
-		<WixVariable Id="WixUIBannerBmp" Value="Resources\assets\banner_background.bmp" />
+    <WixVariable Id="WixUILicenseRtf" Value="Resources\assets\LICENSE.rtf" />
+    <WixVariable Id="WixUIDialogBmp" Value="Resources\assets\dialog_background.bmp" />
+    <WixVariable Id="WixUIBannerBmp" Value="Resources\assets\banner_background.bmp" />
 
 <!-- TODO these icons serve different purposes in the installer UX, and should probably not all
-		 be set to the same icon. -->
-		<WixVariable Id="WixUIExclamationIco" Value="Resources\assets\cws_32x32.ico" />
-		<WixVariable Id="WixUIInfoIco" Value="Resources\assets\cws_32x32.ico" />
-		<WixVariable Id="WixUINewIco" Value="Resources\assets\cws_16x16.ico" />
-		<WixVariable Id="WixUIUpIco" Value="Resources\assets\cws_16x16.ico" />
+     be set to the same icon. -->
+    <WixVariable Id="WixUIExclamationIco" Value="Resources\assets\cws_32x32.ico" />
+    <WixVariable Id="WixUIInfoIco" Value="Resources\assets\cws_32x32.ico" />
+    <WixVariable Id="WixUINewIco" Value="Resources\assets\cws_16x16.ico" />
+    <WixVariable Id="WixUIUpIco" Value="Resources\assets\cws_16x16.ico" />
 
-	</Product>
+  </Product>
 </Wix>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -51,144 +51,204 @@
     <UI>
       <ProgressText Action="FastUnzip">!(loc.FileExtractionProgress)</ProgressText>
     </UI>
-    <% end %>
+  <% end %>
 
-    <CustomActionRef Id="WixBroadcastSettingChange" />
-    <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+  <!-- TODO
+       For now, using COMMON_ALTSTARTUP which is the global auto-start folder. Note that this
+       may cause some trouble - we haven't yet looked into how the App should behave when multiple
+       instances are running. We can instead use WIXDIR_ALTSTARTUP which is per-user - but that means
+       if it's installed on a shared server, only one user will get the tray app be default.
+	-->
+	<PropertyRef Id="WIX_DIR_COMMON_ALTSTARTUP" />
 
-    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]"/>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="WINDOWSVOLUME">
-        <Directory Id="INSTALLLOCATION" Name="opscode">
-          <Directory Id="PROJECTLOCATION" Name="chef-workstation">
-            <Directory Id="PROJECTLOCATIONBIN" Name="bin">
-              <Component Id="ChefWSPath" Guid="{BC744260-FD5B-4A0F-8EE5-76283072CC09}" >
-                <Environment Id="Environment"
-                  Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATIONBIN]" />
-              </Component>
-              <Component Id="StartChefWS" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
-                <File Id="StartChefWSScript" Source="Resources\assets\start-chefws.ps1" KeyPath="yes" />
-              </Component>
-            </Directory>
-            <Directory Id="PSMODULES" Name="modules" >
-              <Component Id="ChefPSModulePath" Guid="{FA4B6948-087F-4460-A741-47E5A5E3B235}" >
-                <Environment Id="ChefPSModulePathEnvironment"
-                             Name="PSModulePath" Action="set" Part="last" System="yes" Value="[PSMODULES]" />
-              </Component>
-              <Component Id="ChefPowerShellRegistryEntries" Guid="{CA712E00-B031-424D-A439-838454AF94C5}">
-                <RegistryKey Root="HKCR" Key="Chef.PowerShell">
-                  <RegistryValue Type="string" Value="Chef.PowerShell" />
-                </RegistryKey>
-                <RegistryKey Root="HKCR" Key="Chef.PowerShell\CLSID">
-                  <RegistryValue Type="string" Value="{9008CA83-83E4-41FF-9C07-696E2CC47B52}" />
-                </RegistryKey>
-                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}">
-                  <RegistryValue Type="string" Value="Chef.PowerShell" />
-                </RegistryKey>
-                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32">
-                  <RegistryValue Type="string" Value="[System64Folder]mscoree.dll" />
-                  <RegistryValue Type="string" Name="ThreadingModel" Value="Both" />
-                  <RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
-                  <RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
-                  <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
-                  <RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
-                </RegistryKey>
-                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32\1.0.0.0">
-                  <RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
-                  <RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
-                  <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
-                  <RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
-                </RegistryKey>
-                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\ProgId">
-                  <RegistryValue Type="string" Value="Chef.PowerShell" />
-                </RegistryKey>
-                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}" />
-              </Component>
-            </Directory>
-            <Directory Id="EMBEDDED" Name="embedded" >
-              <Directory Id="EMBEDDEDBIN" Name="bin" >
-                <Component Id="ChefWSEnvHacks" Guid="{3498A65D-33D8-4CF2-BAB8-6FA072A7070D}" >
-                  <Environment Id="EnvHacksEnvironment"
-                               Name="CHEFDK_ENV_FIX" Action="set" System="yes" Value="1" />
-                </Component>
-              </Directory>
-            </Directory>
-          </Directory>
-        </Directory>
-      </Directory>
+	<CustomActionRef Id="WixBroadcastSettingChange" />
+	<CustomActionRef Id="WixBroadcastEnvironmentChange" />
+
+	<SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]"/>
+	<Directory Id="TARGETDIR" Name="SourceDir">
+		<Directory Id="WINDOWSVOLUME">
+			<Directory Id="INSTALLLOCATION" Name="opscode">
+				<Directory Id="PROJECTLOCATION" Name="chef-workstation">
+					<Directory Id="PROJECTLOCATIONBIN" Name="bin">
+						<Component Id="ChefWSPath" Guid="{BC744260-FD5B-4A0F-8EE5-76283072CC09}" >
+							<Environment Id="Environment"
+								Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATIONBIN]" />
+						</Component>
+						<Component Id="StartChefWSPowershellShortcut" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
+							<!-- Note that this refers to a Source relative to the package build directory,
+										 and not in the zip file which contains all of the chef-workstation build -->
+								<File Id="StartChefWSScript" Source="Resources\assets\start-chefws.ps1" KeyPath="yes" />
+							</Component>
+						</Directory>
+						<Directory Id="PSMODULES" Name="modules" >
+							<Component Id="ChefPSModulePath" Guid="{FA4B6948-087F-4460-A741-47E5A5E3B235}" >
+								<Environment Id="ChefPSModulePathEnvironment"
+									Name="PSModulePath" Action="set" Part="last" System="yes" Value="[PSMODULES]" />
+							</Component>
+							<Component Id="ChefPowerShellRegistryEntries" Guid="{CA712E00-B031-424D-A439-838454AF94C5}">
+								<RegistryKey Root="HKCR" Key="Chef.PowerShell">
+									<RegistryValue Type="string" Value="Chef.PowerShell" />
+								</RegistryKey>
+								<RegistryKey Root="HKCR" Key="Chef.PowerShell\CLSID">
+									<RegistryValue Type="string" Value="{9008CA83-83E4-41FF-9C07-696E2CC47B52}" />
+								</RegistryKey>
+								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}">
+									<RegistryValue Type="string" Value="Chef.PowerShell" />
+								</RegistryKey>
+								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32">
+									<RegistryValue Type="string" Value="[System64Folder]mscoree.dll" />
+									<RegistryValue Type="string" Name="ThreadingModel" Value="Both" />
+									<RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
+									<RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
+									<RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
+									<RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
+								</RegistryKey>
+								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32\1.0.0.0">
+									<RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
+									<RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
+									<RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
+									<RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
+								</RegistryKey>
+								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\ProgId">
+									<RegistryValue Type="string" Value="Chef.PowerShell" />
+								</RegistryKey>
+								<RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}" />
+							</Component>
+						</Directory>
+						<Directory Id="COMPONENTS" Name="components">
+							<Directory Id="WSAPPDIR" Name="chef-workstation-app">
+							</Directory>
+						</Directory>
+						<Directory Id="EMBEDDED" Name="embedded" >
+							<Directory Id="EMBEDDEDBIN" Name="bin" >
+								<Component Id="ChefWSEnvHacks" Guid="{3498A65D-33D8-4CF2-BAB8-6FA072A7070D}" >
+									<Environment Id="EnvHacksEnvironment"
+										Name="CHEFDK_ENV_FIX" Action="set" System="yes" Value="1" />
+								</Component>
+							</Directory>
+						</Directory>
+					</Directory>
+				</Directory>
+			</Directory>
       <Directory Id="ProgramMenuFolder">
-        <Component Id="StartMenuShortcut" Guid="{6DD3FFF3-E009-40E7-B1C2-EF606B941CCD}">
-          <Shortcut Id="StartMenuShortcutDef"
-                    Name="!(loc.ChefWSShortcutDefName)"
-                    Description="!(loc.ChefWSShortcutDefDescription)"
-                    Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
-                    Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefWSScript]"
-                    Show="minimized"
-                    Icon="cws.ico"/>
+        <!-- Place shortcuts grouped in a "Chef Workstation" folder in the Start menu -->
+        <Directory Id="ChefWorkstationFolder" Name="Chef Workstation">
+          <Component Id="PowershellStartMenuShortcut" Guid="{6DD3FFF3-E009-40E7-B1C2-EF606B941CCD}">
+            <Shortcut Id="PowershellStartMenuShortcutDef"
+              Name="!(loc.ChefWSPowershellShortcutDefName)"
+              Description="!(loc.ChefWSPowershellShortcutDefDesc)"
+              Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
+              Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefWSScript]"
+              Show="minimized"
+              Icon="cws.ico"/>
+          </Component>
+          <Component Id="ChefWSAppStartMenuShortcut" Guid="{6CFD92E5-B45F-48F2-AC17-54B647D65E66}">
+            <Shortcut Id="ChefWSAppStartMenuShortcutDef"
+              Name="!(loc.ChefWSAppShortcutName)"
+              Description="!(loc.ChefWSAppShortcutDesc)"
+              Target="[WSAPPDIR]\Chef Workstation App.exe"
+              Icon="cws.ico"/>
+          </Component>
+        </Directory>
+			</Directory>
+
+			<!-- This component puts the WS App in the common autostart folder [if the Feature is selected] -->
+			<Directory Id="WIX_DIR_COMMON_ALTSTARTUP" >
+				<Component Id="ChefWSAppAutostartShortcut" Guid="{DF9613D2-4BCA-4D81-8BFA-989070EF1633}">
+					<Shortcut Id="ChefAppWSAutostartShortcutDef"
+						Name="!(loc.ChefWSAppShortcutName)"
+						Description="!(loc.ChefWSAppShortcutDesc)"
+						Target="[WSAPPDIR]\Chef Workstation App.exe"
+						Icon="cws.ico"/>
+				</Component>
+			</Directory>
+
+			<Directory Id="DesktopFolder" Name="Desktop">
+				<Component Id="PowershellDesktopShortcut" Guid="{396E22A6-A7B6-4AA1-B63C-83A3DD7007A8}">
+					<Shortcut Id="PowershellDesktopShortcutDef"
+						Name="!(loc.ChefWSPowershellShortcutDefName)"
+						Description="!(loc.ChefWSPowershellShortcutDefDesc)"
+						Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
+						Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefWSScript]"
+						Show="minimized"
+						Icon="cws.ico"/>
         </Component>
-      </Directory>
 
-      <Directory Id="DesktopFolder" Name="Desktop">
-        <Component Id="DesktopShortcut" Guid="{396E22A6-A7B6-4AA1-B63C-83A3DD7007A8}">
-          <Shortcut Id="DesktopShortcutDef"
-                    Name="!(loc.ChefWSShortcutDefName)"
-                    Description="!(loc.ChefWSShortcutDefDescription)"
-                    Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
-                    Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefWSScript]"
-                    Show="minimized"
-                    Icon="cws.ico"/>
-        </Component>
-      </Directory>
-    </Directory>
+				<Component Id="ChefWSAppDesktopShortcut" Guid="91f753ca-d87b-4ef2-915c-2183bef16177">
+					<Shortcut Id="ChefWSAppDesktopShortcutDef"
+						Name="!(loc.ChefWSAppShortcutName)"
+						Description="!(loc.ChefWSAppShortcutDesc)"
+						Target="[WSAPPDIR]\Chef Workstation App.exe"
+						Icon="cws.ico"/>
+				</Component>
+			</Directory>
+		</Directory>
 
-    <!-- Set the components defined in our fragment files that will be used for our feature  -->
-    <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)" Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
-      <ComponentGroupRef Id="ProjectDir" />
-      <ComponentRef Id="ChefWSPath" />
-      <ComponentRef Id="ChefPSModulePath" />
-      <ComponentRef Id="ChefPowerShellRegistryEntries" />
-    </Feature>
-
-    <Feature Id="ChefWSStartMenuShortcutFeature" Title="!(loc.FeatureChefWSStartMenuShortcut)" Description="!(loc.FeatureChefWSStartMenuShortcutDescription)" Level="1" AllowAdvertise="no" >
-      <ComponentRef Id="StartChefWS" />
-      <ComponentRef Id="StartMenuShortcut" />
-    </Feature>
-
-    <Feature Id="ChefWSDesktopShortcutFeature" Title="!(loc.FeatureChefWSDesktopShortcut)" Description="!(loc.FeatureChefWSDesktopShortcutDescription)" Level="1" AllowAdvertise="no" >
-      <ComponentRef Id="StartChefWS" />
-      <ComponentRef Id="DesktopShortcut" />
-    </Feature>
-
-    <Feature Id="ChefWSEnvHacks" Title="!(loc.FeatureChefWSEnvHacks)" Description="!(loc.FeatureChefWSEnvHacksDesc)" Level="1000" AllowAdvertise="no">
-      <ComponentRef Id="ChefWSEnvHacks" />
-    </Feature>
-
-    <!--
-    UI Stuff
+		<!-- Set the components defined in our fragment files that will be used for our feature  -->
+    <!-- Renders the following install options
+         [x] Chef Workstation
+           [x] Start Menu Shortcut
+           [x] Desktop Shortcut
+         [x] Experimental Features
+           [x] Chef Workstation App (includes shortcuts and autostart)
     -->
-    <Icon Id="cws16.ico" SourceFile="Resources\assets\cws_16x16.ico"/>
-    <Icon Id="cws32.ico" SourceFile="Resources\assets\cws_32x32.ico"/>
-    <Icon Id="cws.ico" SourceFile="Resources\assets\cws.ico"/>
-    <Property Id="ARPPRODUCTICON" Value="cws16.ico" />
-    <Property Id="ARPHELPLINK" Value="https://chef.sh/" />
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLLOCATION" />
+    <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)"
+      Description="!(loc.FeatureMainDesc)"
+      Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
+			<ComponentGroupRef Id="ProjectDir" />
+			<ComponentRef Id="ChefWSPath" />
+			<ComponentRef Id="ChefPSModulePath" />
+			<ComponentRef Id="ChefPowerShellRegistryEntries" />
+			<Feature Id="ChefWSStartMenuPSShortcutFeature" Title="!(loc.FeatureChefWSStartMenuPSShortcut)"
+	             Description="!(loc.FeatureChefWSStartMenuPSShortcutDesc)" Level="1" AllowAdvertise="no" >
+				<ComponentRef Id="StartChefWSPowershellShortcut" />
+				<ComponentRef Id="PowershellStartMenuShortcut" />
+			</Feature>
+			<Feature Id="ChefWSDesktopPSShortcutFeature" Title="!(loc.FeatureChefWSDesktopPSShortcut)"
+               Description="!(loc.FeatureChefWSDesktopPSShortcutDesc)" Level="1" AllowAdvertise="no" >
+				<ComponentRef Id="StartChefWSPowershellShortcut" />
+				<ComponentRef Id="PowershellDesktopShortcut" />
+			</Feature>
+			<Feature Id="ChefWSEnvHacks" Title="!(loc.FeatureChefWSEnvHacks)" Description="!(loc.FeatureChefWSEnvHacksDesc)" Level="1000" AllowAdvertise="no">
+				<ComponentRef Id="ChefWSEnvHacks" />
+			</Feature>
+		</Feature>
 
-    <UIRef Id="ChefWSUI_InstallDir"/>
-    <UI Id="ChefWSUI_InstallDir">
-      <UIRef Id="WixUI_FeatureTree"/>
-      <TextStyle Id="WixUI_Font_Normal_White" FaceName="Tahoma" Size="8" Red="255" Green="255" Blue="255" />
-      <TextStyle Id="WixUI_Font_Bigger_White" FaceName="Tahoma" Size="12" Red="255" Green="255" Blue="255" />
-      <TextStyle Id="WixUI_Font_Title_White" FaceName="Tahoma" Size="9" Bold="yes" Red="255" Green="255" Blue="255" />
-    </UI>
+		<Feature Id="ExperimentalFeatures" Title="!(loc.FeatureExperimental)" Description="!(loc.FeatureExperimentalDesc)" Level="1000" AllowAdvertise="no" Display="collapse">
+			<Feature Id="ExperimentalChefWSApp" Title="!(loc.FeatureExperimentalChefWS)" Description="!(loc.FeatureExperimentalChefWSDesc">
+				<ComponentRef Id="ChefWSAppAutostartShortcut" />
+				<ComponentRef Id="ChefWSAppStartMenuShortcut" />
+				<ComponentRef Id="ChefWSAppDesktopShortcut" />
+			</Feature>
+		</Feature>
 
-    <WixVariable Id="WixUILicenseRtf" Value="Resources\assets\LICENSE.rtf" />
-    <WixVariable Id="WixUIDialogBmp" Value="Resources\assets\dialog_background.bmp" />
-    <WixVariable Id="WixUIBannerBmp" Value="Resources\assets\banner_background.bmp" />
+		<!--
+		UI Stuff
+		-->
+		<Icon Id="cws16.ico" SourceFile="Resources\assets\cws_16x16.ico"/>
+		<Icon Id="cws32.ico" SourceFile="Resources\assets\cws_32x32.ico"/>
+		<Icon Id="cws.ico" SourceFile="Resources\assets\cws.ico"/>
+		<Property Id="ARPPRODUCTICON" Value="cws16.ico" />
+		<Property Id="ARPHELPLINK" Value="https://chef.sh/" />
+		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLLOCATION" />
+		<UIRef Id="ChefWSUI_InstallDir"/>
+		<UI Id="ChefWSUI_InstallDir">
+			<UIRef Id="WixUI_FeatureTree"/>
+			<TextStyle Id="WixUI_Font_Normal_White" FaceName="Tahoma" Size="8" Red="255" Green="255" Blue="255" />
+			<TextStyle Id="WixUI_Font_Bigger_White" FaceName="Tahoma" Size="12" Red="255" Green="255" Blue="255" />
+			<TextStyle Id="WixUI_Font_Title_White" FaceName="Tahoma" Size="9" Bold="yes" Red="255" Green="255" Blue="255" />
+		</UI>
 
-    <WixVariable Id="WixUIExclamationIco" Value="Resources\assets\cws_32x32.ico" />
-    <WixVariable Id="WixUIInfoIco" Value="Resources\assets\cws_32x32.ico" />
-    <WixVariable Id="WixUINewIco" Value="Resources\assets\cws_16x16.ico" />
-    <WixVariable Id="WixUIUpIco" Value="Resources\assets\cws_16x16.ico" />
+		<WixVariable Id="WixUILicenseRtf" Value="Resources\assets\LICENSE.rtf" />
+		<WixVariable Id="WixUIDialogBmp" Value="Resources\assets\dialog_background.bmp" />
+		<WixVariable Id="WixUIBannerBmp" Value="Resources\assets\banner_background.bmp" />
 
-  </Product>
+<!-- TODO these icons serve different purposes in the installer UX, and should probably not all
+		 be set to the same icon. -->
+		<WixVariable Id="WixUIExclamationIco" Value="Resources\assets\cws_32x32.ico" />
+		<WixVariable Id="WixUIInfoIco" Value="Resources\assets\cws_32x32.ico" />
+		<WixVariable Id="WixUINewIco" Value="Resources\assets\cws_16x16.ico" />
+		<WixVariable Id="WixUIUpIco" Value="Resources\assets\cws_16x16.ico" />
+
+	</Product>
 </Wix>


### PR DESCRIPTION
### Description

This adds a "Chef Workstation App" feature to the Windows
Installer.  It provides a 'run on login' component that will
add CWA to common startup

If Start menu items are selected, it will include this
shortcut there as well.

This branch also renames the shell shortcut "Chef Workstation" to "Chef
Workstation Command Prompt". This is more in line with recent
discussions around naming, and avoids confusion between a shortcut
called "Chef Workstation" and one named "Chef Workstation App".

This also changes the CWA tray app package location to $install_path/components/chef-workstation-app instead of $install_path/installers - it's more accurate. 


### Check List
- [x]  chef/chef-workstation#7  merged
- [x] finalize wording for installer description, shortcut description
- [x] default to not autostart CWA
- [x] fix source branch of chef-workstation-app to master once chef/chef-workstation-tray#26 merges.
- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
- [x]  N/A ~www/site/content/docs/ has been updated with any relevant changes~
