### PR TITLE
[SHACK-357] Include latest stable release of ChefDK

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -39,18 +39,7 @@ merge_actions:
         - "Expeditor: Skip All"
       only_if: built_in:bump_version
 
-# I copied the `ignore_labels` from the chef-dk expeditor config
-# since the labels apply to that workload (not the chef-workstation
-# workload like the `merge_actions` block)
 subscriptions:
-  - workload: chef/chef-dk:master_completed:pull_request_merged:chef/chef-dk:master:*
+  - workload: artifact_published:stable:chefdk:3*
     actions:
-      - built_in:bump_version:
-          ignore_labels:
-            - "Expeditor: Skip Version Bump"
-            - "Expeditor: Skip All"
-      - built_in:trigger_omnibus_release_build:
-          ignore_labels:
-            - "Expeditor: Skip Build"
-            - "Expeditor: Skip All"
-          only_if: built_in:bump_version
+      - bash:.expeditor/update_chefdk_to_stable.sh

--- a/.expeditor/update_chefdk_to_stable.sh
+++ b/.expeditor/update_chefdk_to_stable.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+############################################################################
+# What is this script?
+#
+# Chef Workstation uses Expeditor to manage the bundled version of the ChefDK.
+# Currently we always want to include the stable version of ChefDK inside
+# Workstation, so this script takes that version and uses sed to insert
+# it into the omnibus project definition. Then it commits that change
+# and opens a pull request for review and merge.
+############################################################################
+
+set -evx
+
+branch="expeditor/chef_dk_${VERSION}"
+git checkout -b "$branch"
+
+sed -i -r "s/override :\"chef-dk\",\s+version: \"v[^\"]+\"/override :\"chef-dk\", version: \"v${VERSION}\"/" omnibus/config/projects/chef-workstation.rb
+
+git add .
+
+# give a friendly message for the commit and make sure it's noted for any future audit of our codebase that no
+# DCO sign-off is needed for this sort of PR since it contains no intellectual property
+git commit --message "Bump ChefDK to $VERSION" --message "This pull request was triggered automatically via Expeditor when ChefDK $VERSION was promoted to stable." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+
+open_pull_request
+
+# Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
+git checkout -
+git branch -D "$branch"

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -45,24 +45,11 @@ build_iteration 1
 # Workstation RFC (https://github.com/chef/chef-rfc/pull/308). But until we do
 # we need to pull `chef-apply` in as a gem dependency of the ChefDK.
 
-# This means the promotion process for getting new Chef Apply changes out is:
-# 1. Merge the Chef Apply PR which causes expeditor to build a new gem
-# 2. Update the dependencies in the ChefDK with a PR
-# 3. Perform a new build of Chef Workstation. Because it pulls in ChefDK from
-# `master` it will get the latest ChefDK and transitively the latest update
-# to Chef Apply.
+# The ChefDK version is pinned by Expeditor. Whenever ChefDK is promoted to stable
+# then Expeditor takes that version, runs a script to replace it here and pushes
+# a new commit / build through.
 
-# I've automated steps 1 and 3. This means that the _new_ process for promoting
-# Chef Apply changes is:
-# 1. Update the dependencies in the ChefDK with a PR
-# 2. After Chef Workstation gets a new build triggered and completed, promote Chef Workstation as normal
-
-# I realize this is not ideal but I think its the best way forward today. We
-# could try and do something sneaky/cute where we pull Chef Apply into
-# Chef Workstation as a separate dependency but that exposes the risk that we
-# break dependency resolution for the ChefDK (and transitively Chef Workstation)
-
-override :"chef-dk",      version: "master"
+override :"chef-dk", version: "v3.3.23"
 
 # DK's overrides; god have mercy on my soul
 # This comes from DK's ./omnibus_overrides.rb


### PR DESCRIPTION
### Description

Expeditor will manage the pinned version for us. Whenever ChefDK is released it will update the omnibus pin.

### Issues Resolved

SHACK-357

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
- [x] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md

Signed-off-by: tyler-ball <tball@chef.io>