### PR TITLE
Update CHANGELOG.md to capture PR #251

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 #### Merged Pull Requests
 - [SHACK-370] Disable windows chef workstation app autostart [#250](https://github.com/chef/chef-workstation/pull/250) ([marcparadise](https://github.com/marcparadise))
+- [SHACK-371] Uninstall ChefDK on OSX [#251](https://github.com/chef/chef-workstation/pull/251) ([jonsmorrow](https://github.com/jonsmorrow))
 <!-- latest_release -->
 
 ## [0.1.218](https://github.com/chef/chef-workstation/tree/0.1.218) (2018-10-03)


### PR DESCRIPTION
### Description

PR #251 wasn't built on merge due to an Expeditor outage and as a result CHANGELOG.md did not get updated.

### Issues Resolved

None

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
- [x] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md