### PR TITLE
Bump Chef Workstation App to 0.0.30

### DIFF
--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -55,7 +55,7 @@ override :"chef-dk", version: "v3.3.23"
 # App is merged then Expeditor takes the latest tag, runs a script to replace it here
 # and pushes a new commit / build through.
 
-override :"chef-workstation-app", version: "v0.0.29"
+override :"chef-workstation-app", version: "v0.0.30"
 
 # DK's overrides; god have mercy on my soul
 # This comes from DK's ./omnibus_overrides.rb


### PR DESCRIPTION
This pull request was triggered automatically via Expeditor when Chef Workstation App 0.0.30 was merged.

This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required.