### PR TITLE
Mac uninstall program

### DIFF
--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -120,6 +120,7 @@ end
 
 dependency "nodejs-binary"
 dependency "chef-workstation-app"
+dependency "uninstall-scripts"
 dependency "chef-cleanup"
 
 exclude "**/.git"

--- a/omnibus/config/software/uninstall-scripts.rb
+++ b/omnibus/config/software/uninstall-scripts.rb
@@ -1,0 +1,12 @@
+name "uninstall-scripts"
+
+source path: "#{project.files_path}/uninstall-scripts"
+
+skip_transitive_dependency_licensing true
+license :project_license
+
+build do
+  if mac_os_x?
+    copy "#{project_dir}/uninstall.sh", "#{install_dir}/bin/uninstall_chef_workstation", { :preserve => true }
+  end
+end

--- a/omnibus/files/uninstall-scripts/uninstall.sh
+++ b/omnibus/files/uninstall-scripts/uninstall.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Perform necessary steps to uninstall
+# Chef Workstation.
+#
+
+PROGNAME=`basename $0`
+
+error_exit()
+{
+  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+is_darwin()
+{
+  uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
+if is_darwin; then
+  echo "This uninstaller will remove Chef Workstation"
+  if ! sudo -n true 2>/dev/null; then 
+    echo "Enter your password to continue"
+  fi
+  echo "Closing Chef Workstation App"
+  osascript -e 'quit app "Chef Workstation App"'
+  sudo -s -- <<EOF
+echo "Uninstalling Chef Workstation"
+echo "Removing files"
+sudo rm -rf '/opt/chef-workstation'
+sudo rm -rf '/Applications/Chef Workstation App.app'
+echo "Removing binary links in /usr/local/bin"
+sudo find /usr/local/bin -lname '/opt/chef-workstation/*' -delete
+echo "Forgeting com.getchef.pkg.chef-workstation package"
+sudo pkgutil --forget com.getchef.pkg.chef-workstation
+echo "Chef Workstation Uninstalled"
+EOF
+fi

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -43,6 +43,8 @@ if is_darwin; then
   sudo mv "mac/Chef Workstation App.app" /Applications
   rm -r mac
   popd
+
+  ln -sf $INSTALLER_DIR/bin/uninstall_chef_workstation $PREFIX/bin || error_exit "Cannot link uninstall_chef_workstation to $PREFIX/bin"
 else # linux - postinst does not run for windows.
   cwa_app_path="$INSTALLER_DIR/components/chef-workstation-app/chef-workstation-app"
   ldd "$cwa_app_path" | grep "not found" >/dev/null 2>&1


### PR DESCRIPTION
### Description

This change adds an uninstall program for macs to /usr/local/bin.

### Check List

- [X] PR title is a worthy inclusion in the CHANGELOG
- [ ] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md