### PR TITLE
Clean up user messaging order in uninstall script

### DIFF
--- a/omnibus/files/uninstall-scripts/uninstall.sh
+++ b/omnibus/files/uninstall-scripts/uninstall.sh
@@ -18,21 +18,20 @@ is_darwin()
 }
 
 if is_darwin; then
-  echo "This uninstaller will remove Chef Workstation"
-  if ! sudo -n true 2>/dev/null; then 
-    echo "Enter your password to continue"
-  fi
-  echo "Closing Chef Workstation App"
-  osascript -e 'quit app "Chef Workstation App"'
+  echo "This uninstaller will remove Chef Workstation."
   sudo -s -- <<EOF
-echo "Uninstalling Chef Workstation"
-echo "Removing files"
+if [ $(osascript -e 'application "Chef Workstation App" is running') = 'true' ]; then
+  echo "Closing Chef Workstation App..."
+  osascript -e 'quit app "Chef Workstation App"' > /dev/null 2>&1;
+fi
+echo "Uninstalling Chef Workstation..."
+echo "  -> Removing files..."
 sudo rm -rf '/opt/chef-workstation'
 sudo rm -rf '/Applications/Chef Workstation App.app'
-echo "Removing binary links in /usr/local/bin"
+echo "  -> Removing binary links in /usr/local/bin..."
 sudo find /usr/local/bin -lname '/opt/chef-workstation/*' -delete
-echo "Forgeting com.getchef.pkg.chef-workstation package"
-sudo pkgutil --forget com.getchef.pkg.chef-workstation
-echo "Chef Workstation Uninstalled"
+echo "  -> Forgeting com.getchef.pkg.chef-workstation package..."
+sudo pkgutil --forget com.getchef.pkg.chef-workstation > /dev/null 2>&1;
+echo "Chef Workstation Uninstalled."
 EOF
 fi


### PR DESCRIPTION
### Description

1. Prompt user for password before closing app message during uninstall.
2. Only show closing app message if app is running.

During uninstall the the user interaction was like:
```
This uninstaller will remove Chef Workstation
Enter your password to continue
Closing Chef Workstation App
Password:
Uninstalling Chef Workstation
Removing files
Removing binary links in /usr/local/bin
Forgeting com.getchef.pkg.chef-workstation package
Forgot package 'com.getchef.pkg.chef-workstation' on '/'.
Chef Workstation Uninstalled
```

This change fixes it to:
```
This uninstaller will remove Chef Workstation.
Password:
Closing Chef Workstation App...
Uninstalling Chef Workstation...
  -> Removing files...
  -> Removing binary links in /usr/local/bin...
  -> Forgeting com.getchef.pkg.chef-workstation package...
Chef Workstation Uninstalled.
```
and the following if the app isn't open and you already have sudo:
```
This uninstaller will remove Chef Workstation.
Uninstalling Chef Workstation...
  -> Removing files...
  -> Removing binary links in /usr/local/bin...
  -> Forgeting com.getchef.pkg.chef-workstation package...
Chef Workstation Uninstalled.
```

### Check List

- [X] PR title is a worthy inclusion in the CHANGELOG
- [X] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md