### PR TITLE
Fix reversed condition for CWA lib detection

### DIFF
--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -49,7 +49,7 @@ else # linux - postinst does not run for windows.
   cwa_app_path="$INSTALLER_DIR/components/chef-workstation-app/chef-workstation-app"
   ldd "$cwa_app_path" | grep "not found" >/dev/null 2>&1
   # 0 rc means grep found 'not found' text - and we have missing deps.
-  if [ $? -eq 1 ]; then
+  if [ $? -eq 0 ]; then
     echo ""
     echo "To run the experimental Chef Workstation App, use your"
     echo "platform's package manager to install these dependencies:"


### PR DESCRIPTION
Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Description
This corrects a reversed `postinst` conditional that would cause the package install to tell the user that they could run chef-workstation-app when there were still deps to install. 

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change

