### PR TITLE
Fixes tray app upgrades on mac

### DIFF
--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -33,6 +33,13 @@ for binary in $binaries; do
 done
 
 if is_darwin; then
+  restart_required=false
+  # Close the app if it is running.
+  if [ $(osascript -e 'application "Chef Workstation App" is running') = 'true' ]; then
+    restart_required=true
+    echo "Closing Chef Workstation App..."
+    osascript -e 'quit app "Chef Workstation App"' > /dev/null 2>&1;
+  fi
   # chef-workstation-app is configured to build Mac as a zip file instead
   # of a directory. Otherwise, the mac pkgbuild command will find the Chef Workstation App
   # within the larger Chef Workstatoin package, and will not include it in the Chef Workstation
@@ -40,11 +47,18 @@ if is_darwin; then
   echo "Moving Chef Workstation App to the Applications folder"
   pushd $INSTALLER_DIR/components/chef-workstation-app
   unzip chef-workstation-app-mac.zip
+  sudo rm -rf "/Applications/Chef Workstation App.app"
   sudo mv "mac/Chef Workstation App.app" /Applications
   rm -r mac
   popd
 
   ln -sf $INSTALLER_DIR/bin/uninstall_chef_workstation $PREFIX/bin || error_exit "Cannot link uninstall_chef_workstation to $PREFIX/bin"
+
+  # Restart the app if it was running.
+  if $restart_required; then
+    echo "Restarting Chef Workstation App..."
+    osascript -e 'open app "Chef Workstation App"' > /dev/null 2>&1;
+  fi
 else # linux - postinst does not run for windows.
   cwa_app_path="$INSTALLER_DIR/components/chef-workstation-app/chef-workstation-app"
   ldd "$cwa_app_path" | grep "not found" >/dev/null 2>&1


### PR DESCRIPTION
### Description

We need to close the tray app and remove it before
the new version can be installed. If the app was running
we restart the app.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

### Check List

- [ ] PR title is a worthy inclusion in the CHANGELOG
- [ ] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md