### PR TITLE
Update omnibus to use ruby-cleanup

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: a2ee7a44bfb67203001e82b893cbab4cd3e33a75
+  revision: 1736d68a4efe36db6287c34b1d9d3c8226dfd4f3
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 9e1741c2e5925f60822c3192d7c8fc74a6947eeb
+  revision: 6cfec3a04de67aea335c23b5a3bd334a3a68fafe
   specs:
-    omnibus (6.0.2)
-      aws-sdk (~> 2)
+    omnibus (6.0.4)
+      aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
       ffi-yajl (~> 2.2)
@@ -29,13 +29,20 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.146)
-      aws-sdk-resources (= 2.11.146)
-    aws-sdk-core (2.11.146)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.105.0)
+    aws-sdk-core (3.31.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.146)
-      aws-sdk-core (= 2.11.146)
+    aws-sdk-kms (1.9.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.21.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     berkshelf (7.0.6)
       chef (>= 13.6.52)
@@ -136,7 +143,7 @@ GEM
       multi_json (~> 1.10)
     method_source (0.9.0)
     minitar (0.6.1)
-    mixlib-archive (0.4.16)
+    mixlib-archive (0.4.18)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
@@ -164,9 +171,9 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     nori (2.6.0)
-    octokit (4.12.0)
+    octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.5.4)
+    ohai (14.6.2)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -256,7 +263,7 @@ GEM
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.7)
     uuidtools (2.1.5)
-    winrm (2.2.3)
+    winrm (2.3.0)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -268,7 +275,7 @@ GEM
     winrm-elevated (1.1.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.3.0)
+    winrm-fs (1.3.1)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -124,7 +124,7 @@ end
 dependency "nodejs-binary"
 dependency "chef-workstation-app"
 dependency "uninstall-scripts"
-dependency "chef-cleanup"
+dependency "ruby-cleanup"
 
 exclude "**/.git"
 exclude "**/bundler/git"


### PR DESCRIPTION
chef-cleanup has been renamed to ruby-cleanup since that's what it
actually is. This updates the omnibus definition to use the new
definition name.

Signed-off-by: Tim Smith <tsmith@chef.io>