### PR TITLE
Do not 'replace' chefdk in linux packaging for now

### DIFF
--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -23,7 +23,6 @@ license "Apache-2.0"
 license_file "../LICENSE"
 
 conflict  "chefdk"
-replace   "chefdk"
 
 # Defaults to C:/chef-workstation on Windows
 # and /opt/chef-workstation on all other platforms

--- a/www/site/content/docs/chef-workstation/install.md
+++ b/www/site/content/docs/chef-workstation/install.md
@@ -35,9 +35,34 @@ sudo rpm -U /path-to/chef-workstation.rpm
 
 ## Upgrading
 
-### From Chef Workstation or ChefDK
+### From Chef Workstation
 
-For all platforms, follow the same steps as listed under [Installing]({{< ref "#installing" >}}).
+For all platforms, follow the steps provided under [Installing]({{< ref "#installing" >}}).
+
+### From ChefDK
+
+#### Linux
+
+The Chef Workstation package conflicts with an installed ChefDK package to prevent
+unintentional upgrades.
+
+Prior to installing Chef Workstation, first uninstall ChefDK:
+
+Ubuntu, Debian, and related:
+
+```bash
+sudo dpkg -P chefdk
+```
+
+Red Hat, CentOS, and related:
+
+```bash
+sudo rpm -e chefdk
+```
+
+#### Other
+
+For other platforms, follow the same steps as listed under [Installing]({{< ref "#installing" >}}).
 
 ## Uninstalling
 


### PR DESCRIPTION
### Description

An unintended side effect of declaring that chef-workstation
replaces chefdk is that our yum/apt repositories will identify
chef-workstation as replacing chefdk - so anyone with chefdk installed
who runs yum/apt upgrade will receive chef-workstation instead of the
updated chefdk.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>


### Issues Resolved

#297 

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] (na) You have locally validated the change
- [x] `www/site/content/docs/` has been updated with any relevant changes