### PR TITLE
Pin chef-workstation-app version in its software definition

### DIFF
--- a/.expeditor/update_chef-workstation-app_to_latest.sh
+++ b/.expeditor/update_chef-workstation-app_to_latest.sh
@@ -4,7 +4,7 @@
 # What is this script?
 #
 # Chef Workstation uses Expeditor to manage the bundled version of the
-# Chef Workstation App. Currently we always want to include the latest version 
+# Chef Workstation App. Currently we always want to include the latest version
 # of Chef Workstation App inside Workstation, so this script takes that version
 # and uses sed to insert it into the omnibus project definition. Then it commits
 # that change and opens a pull request for review and merge.
@@ -13,11 +13,10 @@
 set -evx
 
 version=$(get_github_file $REPO master VERSION)
-
 branch="expeditor/chef_workstation_app_${version}"
 git checkout -b "$branch"
 
-sed -i -r "s/override :\"chef-workstation-app\",\s+version: \"v[^\"]+\"/override :\"chef-workstation-app\", version: \"v${version}\"/" omnibus/config/projects/chef-workstation.rb
+sed -i -r "s/^default_version .*/default_version \"v${version}\"/" omnibus/config/projects/chef-workstation.rb
 
 git add .
 

--- a/.expeditor/update_chef-workstation-app_to_latest.sh
+++ b/.expeditor/update_chef-workstation-app_to_latest.sh
@@ -16,7 +16,7 @@ version=$(get_github_file $REPO master VERSION)
 branch="expeditor/chef_workstation_app_${version}"
 git checkout -b "$branch"
 
-sed -i -r "s/^default_version .*/default_version \"v${version}\"/" omnibus/config/projects/chef-workstation.rb
+sed -i -r "s/^default_version .*/default_version \"v${version}\"/" omnibus/config/software/chef-workstation.rb
 
 git add .
 

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -53,12 +53,6 @@ build_iteration 1
 
 override :"chef-dk", version: "v3.4.18"
 
-# The Chef Workstation App version is pinned by Expeditor. Whenever Chef Workstation
-# App is merged then Expeditor takes the latest tag, runs a script to replace it here
-# and pushes a new commit / build through.
-
-override :"chef-workstation-app", version: "v0.1.4"
-
 # DK's overrides; god have mercy on my soul
 # This comes from DK's ./omnibus_overrides.rb
 # If this stays, may need to duplicate that file and the rake

--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -20,7 +20,13 @@ skip_transitive_dependency_licensing
 license_file "LICENSE"
 
 source git: "https://github.com/chef/chef-workstation-app"
-default_version "master"
+
+# DO NOT MODIFY
+# The Chef Workstation App version is pinned by Expeditor. Whenever Chef Workstation
+# App is merged then Expeditor takes the latest tag, runs a script to replace it here
+# and pushes a new commit / build through.
+default_version "v0.1.3"
+# /DO NOT MODIFY
 
 # These electron dependencies are pulled in/created
 # by this build. They may have dependendcies that aren't met

--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -25,7 +25,7 @@ source git: "https://github.com/chef/chef-workstation-app"
 # The Chef Workstation App version is pinned by Expeditor. Whenever Chef Workstation
 # App is merged then Expeditor takes the latest tag, runs a script to replace it here
 # and pushes a new commit / build through.
-default_version "v0.1.3"
+default_version "v0.1.4"
 # /DO NOT MODIFY
 
 # These electron dependencies are pulled in/created


### PR DESCRIPTION

### Description
Move the pin and update of chef-workstation-app version
to occur within the chef-workstation-app.rb software definition
instead of a project-level override.

This prevents invalidating the build cache when chef-workstation-app revs.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
