### PR TITLE
Display workstation version in `chef -v`

### DIFF
--- a/omnibus/config/patches/chef-dk/cli.patch
+++ b/omnibus/config/patches/chef-dk/cli.patch
@@ -1,0 +1,33 @@
+diff --git a/lib/chef-dk/cli.rb b/lib/chef-dk/cli.rb
+index d789b075..4bf739ee 100644
+--- a/lib/chef-dk/cli.rb
++++ b/lib/chef-dk/cli.rb
+@@ -95,15 +95,22 @@ BANNER
+     end
+ 
+     def show_version
+-      msg("Chef Development Kit Version: #{ChefDK::VERSION}")
+-
+-      ["chef-client", "delivery", "berks", "kitchen", "inspec"].each do |component|
+-        result = Bundler.with_clean_env { shell_out("#{component} --version") }
++      msg("Chef Workstation: $CHEF_WS_VERSION$")
++
++      {
++        "chef-run": "chef-run", 
++        "chef-client": "chef-client",
++        "delivery-cli": "delivery",
++        "berks": "berks",
++        "test-kitchen": "kitchen",
++        "inspec": "inspec"
++      }.each do |component, cmd|
++        result = Bundler.with_clean_env { shell_out("#{cmd} --version") }
+         if result.exitstatus != 0
+-          msg("#{component} version: ERROR")
++          msg("  #{component}: ERROR")
+         else
+           version = result.stdout.lines.first.scan(/(?:master\s)?[\d+\.\(\)]+\S+/).join("\s")
+-          msg("#{component} version: #{version}")
++          msg("  #{component}: #{version}")
+         end
+       end
+     end

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -61,6 +61,13 @@ dependency "google-protobuf"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # Patch cli.rb show_version function and add token we can later use to swap in the build_version.
+  patch source: "cli.patch", target: "./lib/chef-dk/cli.rb"
+
+  # Cross platform way to sed. Need to cleanup the backup fail.
+  command("sed -i.bak 's/\\$CHEF_WS_VERSION\\$/#{project.build_version}/' #{project_dir}/lib/chef-dk/cli.rb", env: env)
+  command("rm #{project_dir}/lib/chef-dk/cli.rb.bak")
+
   excluded_groups = %w{server docgen maintenance pry travis integration ci}
   excluded_groups << "ruby_prof" if aix?
   excluded_groups << "ruby_shadow" if aix?


### PR DESCRIPTION
### Description

This change monkey patches cli.rb from chefdk durning the omnibus build so that it shows chef workstation's version.

Signed-off-by: Jon Morrow <jmorrow@chef.io>
```
➜  omnibus git:(jm/patch_chef_cli) ✗ chef -v
Chef Workstation Version: 0.2.25+20181020052834
chef-dk version: 3.4.18
chef-apply version: 14.5.33
chef-client version: 14.5.33
delivery version: master (6862f27aba89109a9630f0b6c6798efec56b4efe)
berks version: 7.0.6
kitchen version: 1.23.2
inspec version: 2.2.112
```

### Check List

- [ ] PR title is a worthy inclusion in the CHANGELOG
- [ ] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md