### PR TITLE
Switch from using git submodules to ignored folders for www dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "www/site/themes/chef"]
-	path = www/site/themes/chef
-	url = https://github.com/chef/chef-hugo-theme.git
-[submodule "www/chef-www"]
-	path = www/chef-www
-	url = https://github.com/chef/chef-www.git

--- a/www/.gitignore
+++ b/www/.gitignore
@@ -1,0 +1,13 @@
+# Hugo
+public
+
+# markdownlint
+.markdownlint.json
+
+# chef-www-acceptance.cd.chef.co content
+chef-sh
+
+# upstream repos
+chef-www
+site/themes/chef
+site/layouts

--- a/www/Makefile
+++ b/www/Makefile
@@ -1,6 +1,27 @@
-sync:
-	git submodule update --init --remote --rebase
+# we use pushd/popd here, and /bin/sh of our chefes/buildkite image is not bash
+# so we have to override the default shell here
+SHELL=bash
+
+chef-www:
+	git clone https://github.com/chef/chef-www.git chef-www
+
+site/themes/chef:
+	git clone https://github.com/chef/chef-hugo-theme.git site/themes/chef
+
+clean:
+	rm -rf chef-sh
+	rm -rf chef-www
+	rm -rf site/layouts
+	rm -rf site/themes/chef
+
+sync: chef-www site/themes/chef
+	pushd chef-www && git fetch && git reset --hard origin/master && popd
+	pushd site/themes/chef && git fetch && git reset --hard origin/master && popd
+	cp -R chef-www/site/layouts site/
 	aws --profile chef-cd s3 sync s3://chef-www-acceptance.cd.chef.co chef-sh --delete
 
 serve: sync
 	cd site && hugo server --buildDrafts --noHTTPCache
+
+lint: chef-www site/themes/chef
+	pushd site && hugo -D && popd


### PR DESCRIPTION
Git submodules can be fragile, we'll move to the pattern we use for
automate-www/a2 now:
https://github.com/chef/a2/pull/2679

Signed-off-by: Seth Chisamore <schisamo@chef.io>
