### PR TITLE
Introduce Release Notes process; Announce releases on discourse.chef.io

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -12,23 +12,9 @@ $(cat release-notes.md)
 ---
 ## Get the Build
 
-As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/$product_key/$version) or by using the \`mixlib-install\` :
+If you are running the experimental application you can download this version from the menu after the app next update check. You can also download binaries directly from [downloads.chef.io](https://downloads.chef.io/$product_key/$version).
 
-\`\`\`
-$ mixlib-install download $product_key -v $version
-\`\`\`
-
-Alternatively, you can install Chef Workstation using one of the following command options:
-
-\`\`\`
-# In Shell
-$ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P $product_key -v $version
-
-# In Windows Powershell
-. { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project $product_key -version $version
-\`\`\`
-
-As always, we welcome your feedback and invite you to contact us directly or share your [feedback online](https://www.chef.io/feedback/). Thanks for using Chef Workstation!
+As always, we welcome your feedback and invite you to contact us directly or share your [email](mailto:workstation@chef.io). Thanks for using Chef Workstation!
 EOH
 )
 

--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eou pipefail
+
+# Download the release-notes for our specific build
+curl -o release-notes.md "https://packages.chef.io/release-notes/${product_key}/${version}.md"
+
+topic_title="Chef Workstation $version Released!"
+topic_body=$(cat <<EOH
+We are delighted to announce the availability of version $version of Chef Workstation.
+$(cat release-notes.md)
+---
+## Get the Build
+
+As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/$product_key/$version) or by using the \`mixlib-install\` :
+
+\`\`\`
+$ mixlib-install download $product_key -v $version
+\`\`\`
+
+Alternatively, you can install Chef Workstation using one of the following command options:
+
+\`\`\`
+# In Shell
+$ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P $product_key -v $version
+
+# In Windows Powershell
+. { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project $product_key -version $version
+\`\`\`
+
+As always, we welcome your feedback and invite you to contact us directly or share your [feedback online](https://www.chef.io/feedback/). Thanks for using Chef Workstation!
+EOH
+)
+
+# category 9 is "Chef Release Announcements": https://discourse.chef.io/c/chef-release
+
+curl -X POST https://discourse.chef.io/posts \
+  -H "Content-Type: multipart/form-data" \
+  -F "api_username=chef-ci" \
+  -F "api_key=$DISCOURSE_API_TOKEN" \
+  -F "category=9" \
+  -F "title=$topic_title" \
+  -F "raw=$topic_body"
+
+# Cleanup
+rm release-notes.md

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -51,6 +51,7 @@ subscriptions:
     actions:
       - bash:.expeditor/publish-release-notes.sh
       - bash:.expeditor/purge-cdn.sh
+      - bash:.expeditor/announce-release.sh
   - workload: artifact_published:stable:chefdk:3*
     actions:
       - bash:.expeditor/update_chefdk_to_stable.sh

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -47,6 +47,10 @@ pipelines:
       description: Pull Request validation tests
 
 subscriptions:
+  - workload: artifact_published:stable:chef-workstation:{{version_constraint}}
+    actions:
+      - bash:.expeditor/publish-release-notes.sh
+      - bash:.expeditor/purge-cdn.sh
   - workload: artifact_published:stable:chefdk:3*
     actions:
       - bash:.expeditor/update_chefdk_to_stable.sh

--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eou pipefail
+
+git clone https://github.com/chef/chef-workstation.wiki.git
+
+pushd ./chef-workstation.wiki
+  # Publish release notes to S3
+  aws s3 cp Stable-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${product_key}/${version}.md" --acl public-read --content-type "text/plain" --profile chef-cd
+  aws s3 cp Stable-Release-Notes.md "s3://chef-automate-artifacts/${channel}/latest/${product_key}/release-notes.md" --acl public-read --content-type "text/plain" --profile chef-cd
+
+  # Reset "Stable Release Notes" wiki page
+  cat >./Stable-Release-Notes.md <<EOH
+## New Features
+-
+## Improvements
+-
+## Bug Fixes
+-
+## Backward Incompatibilities
+-
+EOH
+
+  # Push changes back up to GitHub
+  git add .
+  git commit -m "Release Notes for promoted build $version"
+  git push origin master
+popd
+
+rm -rf chef-workstation.wiki

--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -6,11 +6,11 @@ git clone https://github.com/chef/chef-workstation.wiki.git
 
 pushd ./chef-workstation.wiki
   # Publish release notes to S3
-  aws s3 cp Stable-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${product_key}/${version}.md" --acl public-read --content-type "text/plain" --profile chef-cd
-  aws s3 cp Stable-Release-Notes.md "s3://chef-automate-artifacts/${channel}/latest/${product_key}/release-notes.md" --acl public-read --content-type "text/plain" --profile chef-cd
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${product_key}/${version}.md" --acl public-read --content-type "text/plain" --profile chef-cd
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/${channel}/latest/${product_key}/release-notes.md" --acl public-read --content-type "text/plain" --profile chef-cd
 
   # Reset "Stable Release Notes" wiki page
-  cat >./Stable-Release-Notes.md <<EOH
+  cat >./Pending-Release-Notes.md <<EOH
 ## New Features
 -
 ## Improvements

--- a/.expeditor/purge-cdn.sh
+++ b/.expeditor/purge-cdn.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eou pipefail
+
+echo "Purging '${channel}/${product_key}/latest' Surrogate Key group from Fastly"
+curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${channel}/${product_key}/latest


### PR DESCRIPTION
This change introduces the release notes process we have been
solidifying for Automate 2:

- Release Notes are captured in a simple wiki page on the project repository: https://github.com/chef/chef-workstation/wiki/Stable-Release-Notes
- These captured release notes are then automatically published to a known publicly accessible location when the promotion to `stable` is executed

Please remember release notes are not changelogs! The audience is our end-users, not other engineers. If you need a quick primer on what goes into good release notes, take a look at these excellent articles:
https://medium.com/@DigitalGov/the-life-changing-magic-of-writing-release-notes-4c460970565
https://www.prodpad.com/blog/writing-release-notes/

The published release notes are available at the following URLs:
```
https://packages.chef.io/release-notes/stable/chef-workstation/latest.md
https://packages.chef.io/release-notes/chef-workstation/<VERSION>.md
```
Additionally, we'll also begin to automatically announce release on discourse.chef.io. Here is an example announcement for Automate 2 which is produced in the same way:
https://discourse.chef.io/t/automate-2-version-20181020020209-released/13901