### PR TITLE
Pin delivery-cli version and add subscription

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -59,3 +59,6 @@ subscriptions:
   - workload: chef/chef-workstation-app:master_completed:pull_request_merged:chef/chef-workstation-app:master:*
     actions:
       - bash:.expeditor/update_chef-workstation-app_to_latest.sh
+  - workload: chef/delivery-cli:master_completed:pull_request_merged:chef/delivery-cli:master:*
+    actions:
+      - bash:.expeditor/update_delivery-cli_to_latest.sh

--- a/.expeditor/update_delivery-cli_to_latest.sh
+++ b/.expeditor/update_delivery-cli_to_latest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+############################################################################
+# What is this script?
+#
+# Chef Workstation uses Expeditor to manage the bundled version of the Delivery CLI.
+# Currently we always want to include the latest version of Delivery CLI inside
+# Workstation, so this script takes that version and uses sed to insert
+# it into the omnibus project definition. Then it commits that change
+# and opens a pull request for review and merge.
+############################################################################
+
+set -evx
+
+branch="expeditor/delivery_cli_${VERSION}"
+git checkout -b "$branch"
+
+sed -i -r "s/override :\"delivery-cli\",\s+version: \"v[^\"]+\"/override :\"delivery-cli\", version: \"v${VERSION}\"/" omnibus/config/projects/chef-workstation.rb
+
+git add .
+
+# give a friendly message for the commit and make sure it's noted for any future audit of our codebase that no
+# DCO sign-off is needed for this sort of PR since it contains no intellectual property
+git commit --message "Bump Delivery CLI to $VERSION" --message "This pull request was triggered automatically via Expeditor when Delivery CLI $VERSION was merged to master." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+
+open_pull_request
+
+# Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
+git checkout -
+git branch -D "$branch"

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -52,6 +52,7 @@ build_iteration 1
 # a new commit / build through.
 
 override :"chef-dk", version: "v3.6.57"
+override "delivery-cli", version: "0.0.45"
 
 # DK's overrides; god have mercy on my soul
 # This comes from DK's ./omnibus_overrides.rb


### PR DESCRIPTION
### Description

Now that A2 includes workflow there may be features added to delivery-cli.
In the past we always just pulled master whenever we built workstation, but
this means we only pick up delivery-cli changes when we build for other reasons.
This change pins the version and adds an expeditor subcription that updates a
new version override in our omnibus project definition so we can stay up
to date.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

### Issues Resolved

None.

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [ ] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md