### PR TITLE
disable appx packages; update to latest omnibus

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: ca035f744ece299cbdf81f52edb997b4ba1693b2
+  revision: bf006801aa98595383904ea65c098846d8c12ea4
   specs:
-    omnibus (6.0.7)
+    omnibus (6.0.18)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -30,8 +30,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.119.0)
-    aws-sdk-core (3.41.0)
+    aws-partitions (1.136.0)
+    aws-sdk-core (3.46.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -39,7 +39,7 @@ GEM
     aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.27.0)
+    aws-sdk-s3 (1.30.1)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -97,7 +97,7 @@ GEM
       mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
-    chef-sugar (4.1.0)
+    chef-sugar (5.0.0)
     chef-zero (14.0.11)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
@@ -113,7 +113,7 @@ GEM
     erubis (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
+    ffi (1.10.0)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
@@ -131,7 +131,7 @@ GEM
     kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.18)
+    license_scout (1.0.22)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -145,15 +145,15 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
+    mixlib-config (2.2.18)
       tomlrb
     mixlib-install (3.11.5)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (2.0.4)
-    mixlib-shellout (2.4.0)
-    mixlib-versioning (1.2.2)
+    mixlib-log (2.0.9)
+    mixlib-shellout (2.4.4)
+    mixlib-versioning (1.2.7)
     molinillo (0.6.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)
@@ -171,7 +171,7 @@ GEM
     nori (2.6.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.6.2)
+    ohai (14.8.10)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -189,7 +189,7 @@ GEM
       multipart-post (~> 2.0.0)
       progressbar
       zhexdump (>= 0.0.2)
-    plist (3.4.0)
+    plist (3.5.0)
     progressbar (1.10.0)
     proxifier (1.0.3)
     pry (0.12.2)
@@ -259,7 +259,7 @@ GEM
     thor (0.20.3)
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
-    tomlrb (1.2.7)
+    tomlrb (1.2.8)
     uuidtools (2.1.5)
     winrm (2.3.0)
       builder (>= 2.1.2)
@@ -278,7 +278,7 @@ GEM
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
-    wmi-lite (1.0.0)
+    wmi-lite (1.0.2)
     zhexdump (0.0.2)
 
 PLATFORMS
@@ -296,4 +296,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -121,4 +121,9 @@ package :msi do
   signing_identity 'E05FF095D07F233B78EB322132BFF0F035E11B5B', machine_store: true
 end
 
+# We don't support appx builds, and they eat a lot of time.
+package :appx do
+  skip_packager true
+end
+
 compress :dmg


### PR DESCRIPTION
### Description

This disables appx packages and updates omnibus to latest. 
* Update omnibus to the latest to get the new packager
attribute 'skip_packager'. 
* Turn off windows appx packages via `skip_packager` to speed up Jenkins builds. 

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
- [x] (na) `www/site/content/docs/` has been updated with any relevant changes:

