### PR TITLE
Add EXPEDITOR_ prefix to environment variables

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -3,9 +3,9 @@
 set -eou pipefail
 
 # Download the release-notes for our specific build
-curl -o release-notes.md "https://packages.chef.io/release-notes/${PRODUCT_KEY}/${VERSION}.md"
+curl -o release-notes.md "https://packages.chef.io/release-notes/${EXPEDITOR_PRODUCT_KEY}/${EXPEDITOR_VERSION}.md"
 
-topic_title="Chef Workstation $VERSION Released!"
+topic_title="Chef Workstation $EXPEDITOR_VERSION Released!"
 topic_body=$(cat <<EOH
 We are delighted to announce the availability of version $VERSION of Chef Workstation.
 $(cat release-notes.md)

--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -6,8 +6,8 @@ git clone https://github.com/chef/chef-workstation.wiki.git
 
 pushd ./chef-workstation.wiki
   # Publish release notes to S3
-  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${PRODUCT_KEY}/${VERSION}.md" --acl public-read --content-type "text/plain" --profile chef-cd
-  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/${CHANNEL}/latest/${PRODUCT_KEY}/release-notes.md" --acl public-read --content-type "text/plain" --profile chef-cd
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${EXPEDITOR_PRODUCT_KEY}/${EXPEDITOR_VERSION}.md" --acl public-read --content-type "text/plain" --profile chef-cd
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/${EXPEDITOR_CHANNEL}/latest/${EXPEDITOR_PRODUCT_KEY}/release-notes.md" --acl public-read --content-type "text/plain" --profile chef-cd
 
   # Reset "Stable Release Notes" wiki page
   cat >./Pending-Release-Notes.md <<EOH
@@ -23,7 +23,7 @@ EOH
 
   # Push changes back up to GitHub
   git add .
-  git commit -m "Release Notes for promoted build $VERSION"
+  git commit -m "Release Notes for promoted build $EXPEDITOR_VERSION"
   git push origin master
 popd
 

--- a/.expeditor/purge-cdn.sh
+++ b/.expeditor/purge-cdn.sh
@@ -2,5 +2,5 @@
 
 set -eou pipefail
 
-echo "Purging '${CHANNEL}/${PRODUCT_KEY}/latest' Surrogate Key group from Fastly"
-curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${CHANNEL}/${PRODUCT_KEY}/latest
+echo "Purging '${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest' Surrogate Key group from Fastly"
+curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" "https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest"

--- a/.expeditor/update_chef-workstation-app_to_latest.sh
+++ b/.expeditor/update_chef-workstation-app_to_latest.sh
@@ -12,7 +12,7 @@
 
 set -evx
 
-version=$(get_github_file $REPO master VERSION)
+version=$(get_github_file $EXPEDITOR_REPO master VERSION)
 branch="expeditor/chef_workstation_app_${version}"
 git checkout -b "$branch"
 

--- a/.expeditor/update_chefdk_to_stable.sh
+++ b/.expeditor/update_chefdk_to_stable.sh
@@ -11,16 +11,16 @@
 
 set -evx
 
-branch="expeditor/chef_dk_${VERSION}"
+branch="expeditor/chef_dk_${EXPEDITOR_VERSION}"
 git checkout -b "$branch"
 
-sed -i -r "s/override :\"chef-dk\",\s+version: \"v[^\"]+\"/override :\"chef-dk\", version: \"v${VERSION}\"/" omnibus_overrides.rb
+sed -i -r "s/override :\"chef-dk\",\s+version: \"v[^\"]+\"/override :\"chef-dk\", version: \"v${EXPEDITOR_VERSION}\"/" omnibus_overrides.rb
 
 git add .
 
 # give a friendly message for the commit and make sure it's noted for any future audit of our codebase that no
 # DCO sign-off is needed for this sort of PR since it contains no intellectual property
-git commit --message "Bump ChefDK to $VERSION" --message "This pull request was triggered automatically via Expeditor when ChefDK $VERSION was promoted to stable." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+git commit --message "Bump ChefDK to $EXPEDITOR_VERSION" --message "This pull request was triggered automatically via Expeditor when ChefDK $EXPEDITOR_VERSION was promoted to stable." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
 
 open_pull_request
 

--- a/.expeditor/update_delivery-cli_to_latest.sh
+++ b/.expeditor/update_delivery-cli_to_latest.sh
@@ -12,7 +12,7 @@
 
 set -evx
 
-version=$(get_github_file $REPO master VERSION)
+version=$(get_github_file $EXPEDITOR_REPO master VERSION)
 branch="expeditor/delivery-cli_${version}"
 git checkout -b "$branch"
 


### PR DESCRIPTION
### Description
Expeditor now adds the `EXPEDITOR_` prefix to environment variables it
manages so it is easier to determine where environment variables
come from.

Signed-off-by: Tom Duffield <tom@chef.io>

### Check List

- [ ] PR title is a worthy inclusion in the CHANGELOG
- [ ] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md
