### PR TITLE
Bump bundler/rubygems/openssl

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: c824e911af6dab44e9866a5e05d2e0217518a76f
+  revision: 096b70201d073a4aaca8f3b9faf76d4c648d05d5
   specs:
-    omnibus (6.0.21)
+    omnibus (6.0.22)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -39,7 +39,7 @@ GEM
     aws-sdk-kms (1.16.0)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.35.0)
+    aws-sdk-s3 (1.36.0)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,5 +1,5 @@
 # DO NOT MODIFY
-# The ChefDK, delivery-cli, and workstation app versions are pinned by Expeditor. 
+# The ChefDK, delivery-cli, and workstation app versions are pinned by Expeditor.
 # Whenever ChefDK is promoted to stable or workstation app and delivery cli are merged
 # to master then Expeditor takes that version, runs a script to replace it here and pushes
 # a new commit / build through.
@@ -12,25 +12,25 @@ override "chef-workstation-app", version: "v0.1.7"
 # This comes from DK's ./omnibus_overrides.rb
 # If this stays, may need to duplicate that file and the rake
 # tasks for updating dependencies
-override :rubygems, version: "2.7.6"
-override :bundler, version: "1.16.1"
+override :rubygems, version: "2.7.8"
+override :bundler, version: "1.17.3"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
-override "liblzma", version: "5.2.3"
+override "liblzma", version: "5.2.4"
 override "libtool", version: "2.4.2"
-override "libxml2", version: "2.9.8"
+override "libxml2", version: "2.9.9"
 override "libxslt", version: "1.1.30"
 override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "5.9"
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "2.5.3"
+override "ruby", version: "2.5.5"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
 override "libzmq", version: "4.0.7"
-override "openssl", version: "1.0.2p"
+override "openssl", version: "1.0.2r"
 override "rust", version: "1.32.0"
 
 # For workstation app


### PR DESCRIPTION
We're not shipping the same stuff that we ship in DK and we're actually
shipping insecure versions of many of these libraries. This gets us up
to the same level that DK 3 is at.

Signed-off-by: Tim Smith <tsmith@chef.io>