### PR TITLE
remove chefx symlink references

### DIFF
--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -26,7 +26,7 @@ else
 fi
 
 chefdk_binaries="berks chef chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
-binaries="chef-run chefx $chefdk_binaries"
+binaries="chef-run $chefdk_binaries"
 
 for binary in $binaries; do
   ln -sf $INSTALLER_DIR/bin/$binary $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -13,7 +13,7 @@ cleanup_symlinks() {
   # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
   # leftovers from older versions.
   chefdk_binaries="berks chef chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
-  binaries="chef-run chefx chef-workstation-app $chefdk_binaries"
+  binaries="chef-run chef-workstation-app $chefdk_binaries"
 
   for binary in $binaries; do
     rm -f $PREFIX/bin/$binary


### PR DESCRIPTION
### Description

This change removes the `chefx` binary references in `postinst` and `postrm` as it is a relic of old versions and is no longer used.
# Do not modify or remove the line above.
# Everything below it will be ignored.

Requesting a pull to chef:master from chef:jtimberman/nix-chefx

Write a message for this pull request. The first block
of text is the title and the rest is the description.