### PR TITLE
Minor changes to omnibus-test.ps1 script

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -10,8 +10,17 @@ If ([string]::IsNullOrEmpty($product)) { $product = "chef-workstation" }
 $version = "$Env:VERSION"
 If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
 
+. C:\buildkite-agent\bin\load-omnibus-toolchain.ps1
+
+If ($env:OMNIBUS_WINDOWS_ARCH -eq "x86") {
+  $architecture = "i386"
+}
+ElseIf ($env:OMNIBUS_WINDOWS_ARCH -eq "x64") {
+  $architecture = "x86_64"
+}
+
 Write-Output "--- Downloading $channel $product $version"
-$download_url = C:\opscode\omnibus-toolchain\embedded\bin\mixlib-install.bat download --url --channel "$channel" "$product" --version "$version"
+$download_url = C:\opscode\omnibus-toolchain\embedded\bin\mixlib-install.bat download --url --channel "$channel" "$product" --version "$version" --architecture "$architecture"
 $package_file = "$Env:Temp\$(Split-Path -Path $download_url -Leaf)"
 Invoke-WebRequest -OutFile "$package_file" -Uri "$download_url"
 


### PR DESCRIPTION
### Description

This is a minor change to the new `omnibus-test.ps1` script so it downloads the package for the correct architecture.

### Check List

- [ ] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
- [ ] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md
