### PR TITLE
Preparing for Chef Workstation 0.4 release - EULA support

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 4187714031ef65026ea91a38ce2b6b2087f8be7f
+  revision: 998efe24bb8ad79fcd09cdef74b67a2787591d14
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 968307c129ee54416f5a4d07ca8f8ca2d2b12825
+  revision: 8bb13d8340822417dacd7f8d1820e78a3d6e56b2
   branch: master
   specs:
-    omnibus (6.0.27)
+    omnibus (6.0.28)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.167.0)
-    aws-sdk-core (3.53.1)
+    aws-partitions (1.172.0)
+    aws-sdk-core (3.54.2)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -41,10 +41,10 @@ GEM
     aws-sdk-kms (1.21.0)
       aws-sdk-core (~> 3, >= 3.53.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.40.0)
+    aws-sdk-s3 (1.42.0)
       aws-sdk-core (~> 3, >= 3.53.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.0)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt_pbkdf (1.0.1)
@@ -219,7 +219,7 @@ GEM
     molinillo (0.6.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    necromancer (0.4.0)
+    necromancer (0.5.0)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-sftp (2.1.2)
@@ -292,7 +292,6 @@ GEM
       winrm-elevated (~> 1.0)
       winrm-fs (~> 1.1)
     thor (0.20.3)
-    timers (4.3.0)
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.8)
@@ -303,23 +302,21 @@ GEM
       net-ssh (>= 2.9, < 6.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    tty-box (0.3.0)
+    tty-box (0.4.0)
       pastel (~> 0.7.2)
-      strings (~> 0.1.4)
-      tty-cursor (~> 0.6.0)
+      strings (~> 0.1.5)
+      tty-cursor (~> 0.7)
     tty-color (0.4.3)
-    tty-cursor (0.6.1)
-    tty-prompt (0.18.1)
-      necromancer (~> 0.4.0)
+    tty-cursor (0.7.0)
+    tty-prompt (0.19.0)
+      necromancer (~> 0.5.0)
       pastel (~> 0.7.0)
-      timers (~> 4.0)
-      tty-cursor (~> 0.6.0)
-      tty-reader (~> 0.5.0)
-    tty-reader (0.5.0)
-      tty-cursor (~> 0.6.0)
-      tty-screen (~> 0.6.4)
+      tty-reader (~> 0.6.0)
+    tty-reader (0.6.0)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.7)
       wisper (~> 2.0.0)
-    tty-screen (0.6.5)
+    tty-screen (0.7.0)
     unicode-display_width (1.6.0)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)

--- a/omnibus/config/patches/chef-dk/base.patch
+++ b/omnibus/config/patches/chef-dk/base.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/chef-dk/command/base.rb b/lib/chef-dk/command/base.rb
+index 5d4d74d5..d91f70a7 100644
+--- a/lib/chef-dk/command/base.rb
++++ b/lib/chef-dk/command/base.rb
+@@ -79,7 +79,7 @@ module ChefDK
+       end
+
+       def check_license_acceptance
+-        LicenseAcceptance::Acceptor.check_and_persist!("chef-dk", ChefDK::VERSION.to_s)
++        LicenseAcceptance::Acceptor.check_and_persist!("chef-workstation", ChefDK::VERSION.to_s)
+       end
+
+     end

--- a/omnibus/config/patches/chef-dk/cli.patch
+++ b/omnibus/config/patches/chef-dk/cli.patch
@@ -1,10 +1,10 @@
 diff --git a/lib/chef-dk/cli.rb b/lib/chef-dk/cli.rb
-index d789b075..4bf739ee 100644
+index 3f991041..1fbf7778 100644
 --- a/lib/chef-dk/cli.rb
 +++ b/lib/chef-dk/cli.rb
-@@ -95,15 +95,22 @@ BANNER
+@@ -95,15 +95,22 @@ module ChefDK
      end
- 
+
      def show_version
 -      msg("Chef Development Kit Version: #{ChefDK::VERSION}")
 -
@@ -13,7 +13,7 @@ index d789b075..4bf739ee 100644
 +      msg("Chef Workstation: $CHEF_WS_VERSION$")
 +
 +      {
-+        "chef-run": "chef-run", 
++        "chef-run": "chef-run",
 +        "chef-client": "chef-client",
 +        "delivery-cli": "delivery",
 +        "berks": "berks",

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -64,6 +64,9 @@ build do
   # Patch cli.rb show_version function and add token we can later use to swap in the build_version.
   patch source: "cli.patch", target: "./lib/chef-dk/cli.rb"
 
+  # Change the license to be accepted for Chef Workstation instead of ChefDK
+  patch source: "base.patch", target: "./lib/chef-dk/command/base.rb"
+
   # Cross platform way to sed. Need to cleanup the backup fail.
   command("sed -i.bak 's/\\$CHEF_WS_VERSION\\$/#{project.build_version}/' #{project_dir}/lib/chef-dk/cli.rb", env: env)
   command("rm #{project_dir}/lib/chef-dk/cli.rb.bak")

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -41,10 +41,16 @@ Write-Output "--- Running verification for $channel $product $version"
 # reload Env:PATH to ensure it gets any changes that the install made (e.g. C:\opscode\chef-workstation\bin\ )
 $Env:PATH = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+$Env:CHEF_LICENSE = "accept-no-persist"
+
 # chef-run version ensures our bin ends up on path and the basic ruby env is working.
 chef-run --version
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 # Ensure our ChefDK works
 chef env
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+# Run ChefDK verification suite to ensure it still works
+chef verify
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -25,8 +25,13 @@ fi
 
 echo "--- Running verification for $channel $product $version"
 
+export CHEF_LICENSE="accept-no-persist"
+
 # chef version ensures our bin ends up on path and the basic ruby env is working.
 chef-run --version
 
 # Ensure our ChefDK works
 chef env
+
+# Run ChefDK verification suite to ensure it still works
+chef verify

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,7 +3,7 @@
 # Whenever ChefDK is promoted to stable or workstation app and delivery cli are merged
 # to master then Expeditor takes that version, runs a script to replace it here and pushes
 # a new commit / build through.
-override :"chef-dk", version: "v3.11.3"
+override :"chef-dk", version: "v4.0.67"
 override "delivery-cli", version: "0.0.52"
 override "chef-workstation-app", version: "v0.1.7"
 # /DO NOT MODIFY
@@ -12,8 +12,8 @@ override "chef-workstation-app", version: "v0.1.7"
 # This comes from DK's ./omnibus_overrides.rb
 # If this stays, may need to duplicate that file and the rake
 # tasks for updating dependencies
-override :rubygems, version: "2.7.9"
-override :bundler, version: "1.17.3"
+override :rubygems, version: "3.0.3"
+override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
 override "liblzma", version: "5.2.4"
@@ -24,13 +24,13 @@ override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "5.9"
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "2.5.5"
+override "ruby", version: "2.6.3"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
 override "libzmq", version: "4.0.7"
-override "openssl", version: "1.0.2r"
+override "openssl", version: "1.0.2s"
 override "rust", version: "1.32.0"
 
 # For workstation app


### PR DESCRIPTION
### Description

This bumps ChefDK to 4.0.67, which is greater than the latest stable
release (4.0.60). We need to do that in order to get a chef-apply that
works with ChefDK 4.0

Differences between .60 and .67 are at
https://github.com/chef/chef-dk/blob/cedb19fd8d05cc1070134a5b920d2560399d7f7d/CHANGELOG.md#changes-since-4060-release

It includes some CVE fixes and docs fixes in addition to the chef-apply
gem bump.

### Issues Resolved

N/A

### Check List

- [x] PR title is a worthy inclusion in the CHANGELOG
- [x] You have locally validated the change
- [x] `www/site/content/docs/` has been updated with any relevant changes:
  - * new or changed error messages in 'troubleshooting.md'
  - * new or changed CLI flags in cli-reference.md
