### PR TITLE
Stop building on Ubuntu 14.04

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -14,8 +14,7 @@ builder-to-testers-map:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
-  ubuntu-14.04-x86_64:
-    - ubuntu-14.04-x86_64
+  ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
   windows-2012r2-x86_64:


### PR DESCRIPTION
It's EOL and we shouldn't be building on it anymore

Signed-off-by: Tim Smith <tsmith@chef.io>