### PR TITLE
Fix the chef --version command showing the old DK version

### DIFF
--- a/omnibus/config/patches/chef-dk/cli.patch
+++ b/omnibus/config/patches/chef-dk/cli.patch
@@ -1,0 +1,11 @@
+--- cli.rb	2019-07-08 22:13:46.000000000 -0700
++++ cli2.rb	2019-07-09 10:27:50.000000000 -0700
+@@ -96,7 +96,7 @@
+     end
+
+     def show_version
+-      msg("#{ChefDK::Dist::PRODUCT} version: #{ChefDK::VERSION}")
++      msg("#{ChefDK::Dist::PRODUCT} version: $CHEF_WS_VERSION$")
+       { "#{ChefDK::Dist::INFRA_CLIENT_PRODUCT}": "#{ChefDK::Dist::INFRA_CLIENT_CLI}",
+         "#{ChefDK::Dist::INSPEC_PRODUCT}": "#{ChefDK::Dist::INSPEC_CLI}",
+         "Test Kitchen": "kitchen",

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -77,8 +77,10 @@ dependency "google-protobuf"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  # Patch cli.rb show_version function and add token we can later use to swap in the build_version.
+  # Patch cli.rb show_version function to add token we can later use to swap in the build_version
+  # and also patch dist.rb to change the PRODUCT constant from ChefDK to Chef Workstation
   patch source: "dist.patch", target: "./lib/chef-dk/dist.rb"
+  patch source: "cli.patch", target: "./lib/chef-dk/cli.rb"
 
   # Change the license to be accepted for Chef Workstation instead of ChefDK
   patch source: "base.patch", target: "./lib/chef-dk/command/base.rb"


### PR DESCRIPTION
This all goes away when we switch to the Chef CLI. Then we'll need to find another way to do it all.

Signed-off-by: Tim Smith <tsmith@chef.io>