### PR TITLE
Pin Rubygems to 3.0.3 to prevent double bundler

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,4 +1,8 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
+---
+# the name we use for this project when interacting with expeditor chatbot
+project:
+  alias: chef-workstation
 
 # The name of the product keys for this product (from mixlib-install)
 product_key:

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,5 +1,5 @@
-# DO NOT MODIFY
-# The ChefDK, delivery-cli, and workstation app versions are pinned by Expeditor.
+# DO NOT MODIFY THIS SECTION
+# The delivery-cli, and workstation app versions are pinned by Expeditor.
 # Whenever ChefDK is promoted to stable or workstation app and delivery cli are merged
 # to master then Expeditor takes that version, runs a script to replace it here and pushes
 # a new commit / build through.

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -8,11 +8,11 @@ override "delivery-cli", version: "0.0.52"
 override "chef-workstation-app", version: "v0.1.8"
 # /DO NOT MODIFY
 
-# DK's overrides; god have mercy on my soul
-# This comes from DK's ./omnibus_overrides.rb
-# If this stays, may need to duplicate that file and the rake
-# tasks for updating dependencies
-override :rubygems, version: "3.0.4"
+# THIS PART IS HAND MANAGED, JUST EDIT THE THING
+#
+# NOTE: You MUST update omnibus-software when adding new versions of
+# software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
+override :rubygems, version: "3.0.3" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which results in performance issues / CLI warnings. Make sure these versions match before bumping either.
 override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"


### PR DESCRIPTION
We already made this same change in DK