### PR TITLE
downgrade rubygems to 3.0.3

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -12,7 +12,7 @@ override "chef-workstation-app", version: "v0.1.8"
 # This comes from DK's ./omnibus_overrides.rb
 # If this stays, may need to duplicate that file and the rake
 # tasks for updating dependencies
-override :rubygems, version: "3.0.4"
+override :rubygems, version: "3.0.3" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which results in performance issues / CLI warnings. Make sure these versions match before bumping either.
 override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"


### PR DESCRIPTION
rubygems ships its own bundler which may differ from bundler
already defined and then we get double bundler which results in
performance issues / CLI warnings. Make sure these versions
match before bumping either.

Signed-off-by: Salim Afiune <afiune@chef.io>