### PR TITLE
Update to the latest omnibus-software for double bundler detection

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: efb7d011ff5a7ff648346a388d6f83314d42209c
+  revision: 35e8a6187e07e91fa7040d8b050e8bc508c4261f
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.185.0)
+    aws-partitions (1.189.0)
     aws-sdk-core (3.59.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)


### PR DESCRIPTION
Make sure we have the double bundler detection logic in ruby-cleanup.

Signed-off-by: Tim Smith <tsmith@chef.io>