### PR TITLE
[ci] Add artifactory to omnibus/Gemfile and update omnibus gem

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "master"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "master"
+gem "artifactory"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 035cc8392be8906b4c13e7dd2048d9c659fd034e
+  revision: 33bddeefb10afe23a57ea72807625881ab01990f
   branch: master
   specs:
-    omnibus (6.0.30)
+    omnibus (6.1.0)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -30,19 +30,20 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.189.0)
-    aws-sdk-core (3.59.0)
+    aws-partitions (1.195.0)
+    aws-sdk-core (3.61.2)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.23.0)
-      aws-sdk-core (~> 3, >= 3.58.0)
+    aws-sdk-kms (1.24.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.45.0)
-      aws-sdk-core (~> 3, >= 3.58.0)
+    aws-sdk-s3 (1.46.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
@@ -371,6 +372,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  artifactory
   berkshelf (>= 7.0)
   kitchen-vagrant
   omnibus!


### PR DESCRIPTION
### Description

This change only affects CI. A new version of omnibus is required and the artifactory gem is required for the publish part of the build stage.

### Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22