### PR TITLE
Surround announcement release notes with newlines

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -8,7 +8,9 @@ curl -o release-notes.md "https://packages.chef.io/release-notes/${EXPEDITOR_PRO
 topic_title="Chef Workstation $EXPEDITOR_VERSION Released!"
 topic_body=$(cat <<EOH
 We are delighted to announce the availability of version $EXPEDITOR_VERSION of Chef Workstation.
+
 $(cat release-notes.md)
+
 ---
 ## Get the Build
 


### PR DESCRIPTION
This will ensure the Markdown that is part of the undelrying release
notes is not mixed in with the Markdown in the rest of the Discourse
announcement message.

Fixes chef/release-engineering#765

I've also fixed the affected Discourse message at:
https://discourse.chef.io/t/chef-workstation-0-8-7-released/15745

Signed-off-by: Seth Chisamore <schisamo@chef.io>
