### PR TITLE
Add libGlesV2 to whitelist chef-workstation-app.

### DIFF
--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -36,6 +36,7 @@ default_version "v0.1.5"
 # dependencies to allow it to continue in any case.
 if linux?
   whitelist_file(%r{components/chef-workstation-app/libffmpeg\.so})
+  whitelist_file(%r{components/chef-workstation-app/libGLESv2\.so})
   whitelist_file(%r{components/chef-workstation-app/chef-workstation-app})
 end
 


### PR DESCRIPTION
We recently upgraded to electron v6 [1], which introduced this new dependency.

Because we have not unpacked the electron build dependencies for
inclusion into omnibus, we're adding this to the whitelist.
Similar to the other whitelisted components, this means that
chef-workstation-app will not run when they are missing on the target
Linux system.

We currently have a check in postinstall.sh that warns when this
happens.

[1] https://github.com/chef/chef-workstation-app/commit/33b278d4468a0095fea050d280ca49f1a688a06c
pour

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
