### PR TITLE
Build on 10.13 but test on 12, 13, and 14

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -12,7 +12,7 @@ builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
-  mac_os_x-10.12-x86_64:
+  mac_os_x-10.13-x86_64: # 10.13 is required to notorize the build, but we support 10.12
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "master"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "master"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "afiune/add-rust-dep-libiconv"
 gem "artifactory"
 
 gem "pedump"
@@ -15,7 +15,7 @@ group :development do
   gem "berkshelf", ">= 7.0"
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem "test-kitchen", ">= 1.23"
+  gem "test-kitchen", ">= 2.0"
   gem "kitchen-vagrant"
   gem "winrm-elevated"
 end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 35e8a6187e07e91fa7040d8b050e8bc508c4261f
-  branch: master
+  revision: 880d9ea9135617c88ab2e7267d8486549b43af79
+  branch: afiune/add-rust-dep-libiconv
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 33bddeefb10afe23a57ea72807625881ab01990f
+  revision: c4c0c518caf5c559ddf3d0ae773013d5dbc6bd3c
   branch: master
   specs:
-    omnibus (6.1.0)
+    omnibus (6.1.2)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -33,8 +33,8 @@ GEM
     artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.195.0)
-    aws-sdk-core (3.61.2)
+    aws-partitions (1.206.0)
+    aws-sdk-core (3.64.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -65,11 +65,11 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (15.1.36)
+    chef (15.2.20)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.1.36)
+      chef-config (= 15.2.20)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -95,11 +95,11 @@ GEM
       train-core (~> 2.0, >= 2.0.12)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (15.1.36-universal-mingw32)
+    chef (15.2.20-universal-mingw32)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.1.36)
+      chef-config (= 15.2.20)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -137,7 +137,7 @@ GEM
       win32-service (>= 2.1.2, < 3.0)
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
-    chef-config (15.1.36)
+    chef-config (15.2.20)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
@@ -182,7 +182,7 @@ GEM
     iso8601 (0.12.1)
     jmespath (1.4.0)
     json (2.2.0)
-    kitchen-vagrant (1.5.2)
+    kitchen-vagrant (1.6.0)
       test-kitchen (>= 1.4, < 3)
     libyajl2 (1.2.0)
     license-acceptance (1.0.13)
@@ -234,7 +234,7 @@ GEM
     nori (2.6.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (15.1.5)
+    ohai (15.2.5)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -279,7 +279,7 @@ GEM
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (2.2.5)
+    test-kitchen (2.3.1)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
       license-acceptance (~> 1.0, >= 1.0.11)
@@ -296,7 +296,7 @@ GEM
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.8)
-    train-core (2.1.13)
+    train-core (2.1.19)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
@@ -378,7 +378,7 @@ DEPENDENCIES
   omnibus!
   omnibus-software!
   pedump
-  test-kitchen (>= 1.23)
+  test-kitchen (>= 2.0)
   winrm-elevated
 
 BUNDLED WITH


### PR DESCRIPTION
We support macOS 10.12 still, but electron-builder no longer notorizes
on 10.12. We need to build on 10.13 and test on all versions.

Signed-off-by: Tim Smith <tsmith@chef.io>