### PR TITLE
Fixing a broken path in the omnibus build

### DIFF
--- a/omnibus/config/software/windows-env-customization.rb
+++ b/omnibus/config/software/windows-env-customization.rb
@@ -22,7 +22,7 @@ name "windows-env-customization"
 skip_transitive_dependency_licensing true
 license :project_license
 
-source path: "#{project.files_path}/#{name}"
+source path: "#{project.files_path}/env-customization"
 
 dependency "ruby"
 


### PR DESCRIPTION
## Description
There is no longer a `windows-env-customization` folder, it got renamed to `env-customization`. We could fix this by 1) specifying the path instead of using the software definition name or 2) rename the software def to `env-customization` so the name matches the existing path.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
