### PR TITLE
Update git on windows to 2.23.0

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: b851a32e09a384cad768a6d44df267ffe920cfc2
+  revision: e1779458769356ae6fed51fb7c3685829b6e2a5b
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -33,8 +33,8 @@ GEM
     artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.208.0)
-    aws-sdk-core (3.66.0)
+    aws-partitions (1.212.0)
+    aws-sdk-core (3.67.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -263,7 +263,7 @@ GEM
     retryable (3.0.4)
     ruby-progressbar (1.10.1)
     rubyntlm (0.6.2)
-    rubyzip (1.2.3)
+    rubyzip (1.2.4)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)


### PR DESCRIPTION
This resolves a CVE in git and gives our user base the latest git functionality.

Signed-off-by: Tim Smith <tsmith@chef.io>
