### PR TITLE
[pipeline-fix] Keep the `chef` binary around until the new one is ready.

### DIFF
--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -78,6 +78,8 @@ build do
     appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 
+  copy "#{install_dir}/bin/chef-cli", "#{install_dir}/bin/chef"
+
   # Clear git-checked-out gems (most of this cleanup has been moved into the chef-cleanup omnibus-software definition,
   # but chef-client still needs git-checked-out gems)
   block "Delete bundler git installs" do

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -25,15 +25,13 @@ else
     PREFIX="/usr"
 fi
 
-binaries="chef-run berks chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client chef-analyze"
+# The current list of binaries we symlink into usr/bin. This should be kept in sync with the list in postrm,
+# and binaries that are no longer used should be included in postrm's retired_binaries list.
+binaries="chef-run berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client chef-analyze"
 
 for binary in $binaries; do
   ln -sf "$INSTALLER_DIR/bin/$binary" $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"
 done
-
-# We will be replacing `chef` soon , but let's keep a working `chef` binary in the package
-# until we do.
-ln -sf "$INSTALLER_DIR/bin/chef-cli" $PREFIX/bin/chef || error_exit "Cannot link $binary to $PREFIX/bin"
 
 if is_darwin; then
   restart_required=false

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -10,11 +10,14 @@ is_darwin()
 }
 
 cleanup_symlinks() {
-  # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
-  # leftovers from older versions.
-  chefdk_binaries="berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
-  binaries="chef-run chef-workstation-app $chefdk_binaries chef-analyze"
 
+  # Keep removed binary symlinks in this list, so that removal of upgraded packages still cleans up
+  # leftovers from older versions.
+  retired_binaries="dco"
+
+  # The current list of binaries. This should be kept in sync with the list in `postinst`.
+  current_binaries="chef-run berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
+  binaries="$current_binaries $retired_binaries"
   for binary in $binaries; do
     rm -f "$PREFIX/bin/$binary"
   done

--- a/omnibus/verification/verify.rb
+++ b/omnibus/verification/verify.rb
@@ -188,7 +188,7 @@ module ChefWorkstation
           sh("#{embedded_bin("bundle")} exec #{embedded_bin("rspec")}")
         end
         c.smoke_test do
-          run_in_tmpdir("#{bin("chef")} generate cookbook example")
+          run_in_tmpdir("#{bin("chef-cli")} generate cookbook example")
         end
       end
 
@@ -237,7 +237,7 @@ module ChefWorkstation
         c.gem_base_dir = "chef-cli"
         c.smoke_test do
           tmpdir do |cwd|
-            sh("#{bin("chef")} generate cookbook example", cwd: cwd)
+            sh("#{bin("chef-cli")} generate cookbook example", cwd: cwd)
             cb_cwd = File.join(cwd, "example")
             sh(embedded_bin("rspec"), cwd: cb_cwd)
           end
@@ -263,7 +263,7 @@ module ChefWorkstation
 
           if File.directory?(usr_bin_prefix)
             sh!("#{usr_bin_path("berks")} -v")
-            sh!("#{usr_bin_path("chef")} -v")
+            sh!("#{usr_bin_path("chef-cli")} -v")
             sh!("#{usr_bin_path("chef-client")} -v")
             sh!("#{usr_bin_path("chef-solo")} -v")
             sh!("#{usr_bin_path("delivery")} -V") unless Chef::Platform.windows?
@@ -345,7 +345,7 @@ module ChefWorkstation
               INSPEC_TEST
             end
             # TODO when we appbundle inspec, no longer `chef exec`
-            sh("#{bin("chef")} exec #{embedded_bin("inspec")} exec .", cwd: cwd)
+            sh("#{bin("chef-cli")} exec #{embedded_bin("inspec")} exec .", cwd: cwd)
           end
         end
       end


### PR DESCRIPTION
This fixes the broken build. 

We validate that `chef` top-level command works in the
omnibus-test.* script. These tests explicitly look for the
command in the omnibus bin dir, which does not have a `chef` command anymore -
only chef-cli.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>


## Related Issues

introduced with #551 

## Types of changes
 (label applied) 

