### PR TITLE
Fix typo in PATH /opt/chefworkstation -> /opt/chef-workstation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG CHANNEL=stable
 ARG EXPEDITOR_VERSION
 ARG VERSION=0.9.42
 ENV DEBIAN_FRONTEND=noninteractive \
-    PATH=/opt/chefworkstation/bin:/opt/chefworkstation/embedded/bin:/root/.chefdk/gem/ruby/2.6.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/opt/chef-workstation/bin:/opt/chef-workstation/embedded/bin:/root/.chefdk/gem/ruby/2.6.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Allow the build arg below to be controlled by either build arguments
 ENV VERSION ${EXPEDITOR_VERSION:-${VERSION}}


### PR DESCRIPTION
Signed-off-by: Brent Smith <brent.smith@lightspeedhq.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Binaries were not executable without specifying their entire path.

```
:➜  ~ docker run --rm -it chef/chefworkstation which bundle
:➜  ~ docker run --rm -it chef/chefworkstation:issue564 which bundle
/opt/chef-workstation/embedded/bin/bundle
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef-workstation/issues/564

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
