### PR TITLE
Include `mdl` markdown linter.

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -115,6 +115,7 @@ group(:omnibus_package) do
   gem "stove", ">= 7.1.5"
   gem "berkshelf", ">= 7.0.8"
   gem "chef-vault", ">= 3.4.1"
+  gem "mdl"
 end
 
 # Everything except AIX

--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -115,7 +115,7 @@ group(:omnibus_package) do
   gem "stove", ">= 7.1.5"
   gem "berkshelf", ">= 7.0.8"
   gem "chef-vault", ">= 3.4.1"
-  gem "mdl"
+  gem "mdl", ">= 0.7.0"
 end
 
 # Everything except AIX

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -1046,7 +1046,7 @@ DEPENDENCIES
   knife-vsphere (>= 4.0)
   knife-windows (>= 3.0)
   listen
-  mdl
+  mdl (>= 0.7.0)
   minitest (<= 5.10.3)
   mixlib-archive (>= 0.4.16)
   mixlib-install

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -570,6 +570,9 @@ GEM
       chef (>= 15.0)
       winrm (~> 2.1)
       winrm-elevated (~> 1.0)
+    kramdown (2.1.0)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     libyajl2 (1.2.0)
     license-acceptance (1.0.13)
       pastel (~> 0.7)
@@ -586,6 +589,11 @@ GEM
       multi_json (~> 1.10)
     logify (0.2.0)
     lumberjack (1.0.13)
+    mdl (0.7.0)
+      kramdown (~> 2.0)
+      kramdown-parser-gfm (~> 1.0)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
     memoist (0.16.0)
     method_source (0.9.2)
     mime-types (3.3)
@@ -1038,6 +1046,7 @@ DEPENDENCIES
   knife-vsphere (>= 4.0)
   knife-windows (>= 3.0)
   listen
+  mdl
   minitest (<= 5.10.3)
   mixlib-archive (>= 0.4.16)
   mixlib-install


### PR DESCRIPTION
Somehow I still messed up the rebase on https://github.com/chef/chef-workstation/pull/440 so just opening a new PR to get the commits from that merged. Please refer to that PR for all conversation history on this issue.

## Description

This closes https://github.com/chef/chef-workstation/issues/541

Currently we can lint ruby (with `rubocop`) but not the `README.md`s.
This includes `mdl` in the omnibus build. It's a lightweight extensible
markdown linter.

Signed-off-by: Phil Dibowitz <phil@ipom.com>


## Related Issue

https://github.com/chef/chef-dk/issues/1601


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
