### PR TITLE
Update Mac installer text to list the current components of Workstation

### DIFF
--- a/.expeditor/update_dockerfile.sh
+++ b/.expeditor/update_dockerfile.sh
@@ -3,8 +3,8 @@
 ############################################################################
 # What is this script?
 #
-# Chef-DK uses a workflow tool called Expeditor to manage version bumps, changelogs
-# and releases. When the current release of Chef-DK is promoted to stable this script
+# Chef Workstation uses a workflow tool called Expeditor to manage version bumps, changelogs
+# and releases. When the current release of Chef Workstation is promoted to stable this script
 # is run by Expeditor to update the version in the Dockerfile to match the stable
 # release.
 ############################################################################

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@
 * **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
 * **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
 
-Chef Workstation installs everything you need to get started using Chef on Windows, Mac and Linux.
-It includes:
-- chef-run, a new tool for executing ad-hoc tasks against your servers
-- ChefDK, all the tools you know and love
+Chef Workstation installs everything you need to get started using Chef on Windows, Mac and Linux. It includes:
+
+* Chef Workstation App
+* Chef Infra Client
+* Chef InSpec
+* Chef Command Line Tool
+* Test Kitchen
+* Cookstyle
+* Various Test Kitchen and Knife plugins for clouds
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
 * **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
 
-Chef Workstation installs everything you need to get started using Chef on Windows, Mac and Linux. It includes:
+Chef Workstation installs everything you need to get started using Chef products on Windows, Mac and Linux. It includes:
 
 * Chef Workstation App
 * Chef Infra Client

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -39,14 +39,6 @@ end
 build_version Omnibus::BuildVersion.semver
 build_iteration 1
 
-# One problem with the ChefDK today is that it includes a shit load of gem
-# dependencies.  We resolve all those dependencies in 1 location today - in the
-# ChefDK repo (with its `Gemfile.lock`).
-
-# We eventually want to fix that problem as part of implementing the Chef
-# Workstation RFC (https://github.com/chef/chef-rfc/pull/308). But until we do
-# we need to pull `chef-apply` in as a gem dependency of the ChefDK.
-
 # In order to prevent unecessary cache expiration,
 # package and package version overrides, build_version
 # and build_iteration are kept in <project-root>/omnibus_overrides.rb

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -68,12 +68,6 @@ build do
   # install the whole bundle first
   bundle "install --jobs 10 --without #{excluded_groups.join(" ")}", env: env
 
-  # TODO - we'll want a better way to manage this - likely some kind of callback
-  # from chef-cli so that we can hook in our own version output.
-  #
-  # Cross platform way to sed. Need to cleanup the backup fail.
-  # command("sed -i.bak 's/\\$CHEF_WS_VERSION\\$/#{project.build_version}/' #{project_dir}/lib/chef-dk/cli.rb", env: env)
-  # command("rm #{project_dir}/lib/chef-dk/cli.rb.bak")
   appbundle "chef", lockdir: project_dir, gem: "chef", without: %w{docgen chefstyle}, env: env
 
   appbundle "foodcritic", lockdir: project_dir, gem: "foodcritic", without: %w{development test}, env: env

--- a/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
+++ b/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
@@ -16,8 +16,8 @@
 #
 
 # This script sets the SSL_CERT_FILE environment variable to the CA cert bundle
-# that ships with omnibus packages of Chef and Chef DK. If this environment
-# variable is already configured, this script is a no-op.
+# that ships with omnibus packages of Chef Infra Client and Chef Workstation. If
+# this environment variable is already configured, this script is a no-op.
 #
 # This is required to make Chef tools use https URLs out of the box.
 

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -36,9 +36,9 @@ platforms:
       box: chef/windows-server-2012r2-standard # private
       synced_folders:
       # We have to mount this repos enclosing folder as the Omnibus build
-      # gets cranky if the mounted ChefDK source folder is a symlink. This
-      # mounts at `C:\vagrant\code` and the ChefDK source folder is available
-      # at `C:\vagrant\code\chef-dk`
+      # gets cranky if the mounted Chef Workstation source folder is a symlink. This
+      # mounts at `C:\vagrant\code` and the Chef Workstation source folder is available
+      # at `C:\vagrant\code\chef-workstation`
       - ['../..', '/vagrant/code']
 
 suites:

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -12,8 +12,8 @@ is_darwin()
 cleanup_symlinks() {
   # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
   # leftovers from older versions.
-  chefdk_binaries="berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
-  binaries="chef-run chef-workstation-app $chefdk_binaries chef-analyze"
+  workstation_binaries="berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
+  binaries="chef-run chef-workstation-app $workstation_binaries chef-analyze"
 
   for binary in $binaries; do
     rm -f "$PREFIX/bin/$binary"

--- a/omnibus/resources/chef-workstation/pkg/welcome.html.erb
+++ b/omnibus/resources/chef-workstation/pkg/welcome.html.erb
@@ -16,6 +16,7 @@ Including:
   <li><strong>Chef Command Line Tool</strong></li>
   <li><strong>Test Kitchen</strong></li>
   <li><strong>Cookstyle</strong></li>
+  <li><strong>Ad-hoc remote execution with chef-run</strong></li>
   <li><strong>Various Test Kitchen and Knife plugins for clouds</strong></li>
 </ul>
 <br>

--- a/omnibus/resources/chef-workstation/pkg/welcome.html.erb
+++ b/omnibus/resources/chef-workstation/pkg/welcome.html.erb
@@ -5,14 +5,18 @@
 </head>
 <body>
 <font face="Helvetica">
-This package will install <b><%= friendly_name %></b>, which has everything you need to get started with Chef.
+This package will install <b><%= friendly_name %></b>, which has everything you need to get started with Chef products.
 <br>
 <br>
 Including:
 <ul>
-  <li><strong>chef-run:</strong> Ad-hoc remote execution of Chef</li>
-  <li><strong>ChefDK:</strong> Tools for local Chef Development</li>
-  <li><strong>Chef Workstation App:</strong> Chef's menu bar application</li>
+  <li><strong>Chef Workstation App</strong></li>
+  <li><strong>Chef Infra Client</strong></li>
+  <li><strong>Chef InSpec</strong></li>
+  <li><strong>Chef Command Line Tool</strong></li>
+  <li><strong>Test Kitchen</strong></li>
+  <li><strong>Cookstyle</strong></li>
+  <li><strong>Various Test Kitchen and Knife plugins for clouds</strong></li>
 </ul>
 <br>
 For more information please visit: <a href="https://chef.sh">https://chef.sh</a>.


### PR DESCRIPTION
This updates the readme and installer list of components that we ship to
match what we display in the chef -v output + a mention of knife/kitchen
plugins. This gives users a better idea of what we're shipping in this
package. I also removed all the remaining mentions to DK I could find in
the codebase.

Closes #473 and #472

Signed-off-by: Tim Smith <tsmith@chef.io>