### PR TITLE
Fix Workstation App Build

### DIFF
--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -67,7 +67,7 @@ build do
     delete dist_dir
 
     npm_bin = File.join(node_bin_path, "npm")
-    command "#{npm_bin} install", env: env
+    command "#{npm_bin} install --unsafe-perm=true --allow-root", env: env
     command "#{npm_bin} run-script build-#{platform_name}", env: env
 
     if mac?


### PR DESCRIPTION
## Description
Adding `--unsafe-perm=true --allow-root` to `npm install`.

This gets around permission errors when building locally
on OSX Catalina.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
