### PR TITLE
[bug-fix] Enable interactive 'chef' commands

### DIFF
--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -70,6 +70,7 @@ func main() {
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 
 	// TODO @afiune handle the errors in a better way
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Description
Currently, any `chef` command that requires STDIN interaction is broken,
things like `chef generate cookbook` will ask for accepting the license
and we are unable to do so. Another example is `chef exec irb`.

This PR fixes that problem by linking the STDIN from the terminal to the
underlying spawned command.

## Current State
```
➜  chef exec irb
Switch to inspect mode.
➜  
```
## With this Fix!
```
➜  chef exec irb
irb(main):001:0> puts "hello"
hello
=> nil
irb(main):002:0>
``` 

Closes https://github.com/chef/chef-workstation/issues/637

Signed-off-by: Salim Afiune <afiune@chef.io>

## Related Issue
https://github.com/chef/chef-workstation/issues/637
https://github.com/chef/chef-workstation/issues/652

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
