### PR TITLE
Make it clear in testing when we run the verify suite

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -35,6 +35,6 @@ Write-Output "--- Ensure the 'chef-analyze' cli works (chef-analyze help)"
 chef-analyze help
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-# Run Workstation verification suite
+Write-Output "--- Run the verification suite"
 C:/opscode/chef-workstation/embedded/bin/ruby.exe omnibus/verification/run.rb
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -50,5 +50,5 @@ if is_darwin; then
   test -d "/Applications/Chef Workstation App.app"
 fi
 
-# Run Workstation verification suite
+echo "--- Run Workstation verification suite"
 /opt/chef-workstation/embedded/bin/ruby omnibus/verification/run.rb


### PR DESCRIPTION
These echos get a carrot for folding. Without this the stuff gets grouped in with the chef-analyze tests.

Signed-off-by: Tim Smith <tsmith@chef.io>