### PR TITLE
Windows install: Remove experimental wording and make workstation top level in the installer

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -14,7 +14,7 @@ $(cat release-notes.md)
 ---
 ## Get the Build
 
-If you are running the experimental application you can download this version from the menu after the app next update check. You can also download binaries directly from [downloads.chef.io](https://downloads.chef.io/$EXPEDITOR_PRODUCT_KEY/$EXPEDITOR_VERSION).
+If you are running the Chef Workstation toolbar application you can download this version from the menu after the app next update check. You can also download binaries directly from [downloads.chef.io](https://downloads.chef.io/$EXPEDITOR_PRODUCT_KEY/$EXPEDITOR_VERSION).
 
 As always, we welcome your feedback and invite you to contact us directly or share your [email](mailto:workstation@chef.io). Thanks for using Chef Workstation!
 EOH

--- a/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
@@ -37,11 +37,8 @@
   <String Id="FeatureChefWSDesktopPSShortcut">Desktop PowerShell Shortcut</String>
   <String Id="FeatureChefWSDesktopPSShortcutDesc">Install a <%= friendly_name %> PowerShell shortcut to your Desktop.</String>
 
-	<String Id="FeatureExperimental">Install Experimental Features</String>
-	<String Id="FeatureExperimentalDesc">These features may be incomplete or unstable</String>
-
-  <String Id="FeatureExperimentalChefWS"><%= friendly_name %> App</String>
-  <String Id="FeatureExperimentalChefWSDesc">Enable the <%= friendly_name %> App</String>
+  <String Id="FeatureChefWSApp"><%= friendly_name %> App</String>
+  <String Id="FeatureChefWSAppDesc">Enable the <%= friendly_name %> App</String>
 
   <String Id="FeatureChefWSAppAutostart">Start on login</String>
   <String Id="FeatureChefWSAppAutostartDesc">Configure the <%= friendly_name %> App to autostart on login</String>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -201,14 +201,6 @@
             Show="minimized"
             Icon="cwsps.ico"/>
         </Component>
-
-        <Component Id="ChefWSAppDesktopShortcut" Guid="91f753ca-d87b-4ef2-915c-2183bef16177">
-          <Shortcut Id="ChefWSAppDesktopShortcutDef"
-            Name="!(loc.ChefWSAppShortcutName)"
-            Description="!(loc.ChefWSAppShortcutDesc)"
-            Target="[WSAPPDIR]\Chef Workstation App.exe"
-            Icon="cws.ico"/>
-        </Component>
       </Directory>
     </Directory>
 
@@ -217,8 +209,7 @@
          [x] Chef Workstation
            [x] Start Menu Shortcut
            [x] Desktop Shortcut
-         [x] Experimental Features
-           [x] Chef Workstation App (includes shortcuts and autostart)
+         [x] Chef Workstation App (includes shortcuts and autostart)
     -->
     <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)"
       Description="!(loc.FeatureMainDesc)"
@@ -243,15 +234,12 @@
       </Feature>
     </Feature>
 
-    <Feature Id="ExperimentalFeatures" Title="!(loc.FeatureExperimental)" Description="!(loc.FeatureExperimentalDesc)" Level="1000" AllowAdvertise="no" Display="collapse">
-      <Feature Id="ExperimentalChefWSApp" Title="!(loc.FeatureExperimentalChefWS)" Description="!(loc.FeatureExperimentalChefWSDesc)">
-        <!-- 2018-10-08  disabling automstart until we're ready to enable it for all platforms
+    <Feature Id="ChefWSApp" Title="!(loc.FeatureChefWSApp)" Description="!(loc.FeatureChefWSAppDesc)" Level="1000" AllowAdvertise="no">
+      <!-- 2018-10-08  disabling automstart until we're ready to enable it for all platforms
 
-             <ComponentRef Id="ChefWSAppAutostartShortcut" />
-         -->
-        <ComponentRef Id="ChefWSAppStartMenuShortcut" />
-        <ComponentRef Id="ChefWSAppDesktopShortcut" />
-      </Feature>
+            <ComponentRef Id="ChefWSAppAutostartShortcut" />
+        -->
+      <ComponentRef Id="ChefWSAppStartMenuShortcut" />
     </Feature>
 
     <!--


### PR DESCRIPTION
We want to get this in the hands of users. This still doesn't install it by default and I removed the desktop shortcut that doesn't make sense.

Signed-off-by: Tim Smith <tsmith@chef.io>