### PR TITLE
Avoid ruby win32 warnings by patching Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,3 @@ group :development do
   gem "chef-cli"
   gem "rspec"
 end
-
-instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
-
-# If you want to load debugging tools into the bundle exec sandbox,
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "master"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "master"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "ruby_windows"
 gem "artifactory"
 
 gem "pedump"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: e707177c0eecc79b281c838d63543ee1f959d454
-  branch: master
+  revision: 908d5def776911d14204f4a572b194cf9d639412
+  branch: ruby_windows
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.6.1)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.256.0)
+    aws-partitions (1.258.0)
     aws-sdk-core (3.86.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.27.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.59.0)
+    aws-sdk-s3 (1.60.1)
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)


### PR DESCRIPTION
Avoid these useless warnings that show up every time you run any command.

Signed-off-by: Tim Smith <tsmith@chef.io>