### PR TITLE
More improvements to the Windows installer

### DIFF
--- a/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
@@ -38,10 +38,10 @@
   <String Id="FeatureChefWSDesktopPSShortcutDesc">Install a <%= friendly_name %> PowerShell shortcut to your Desktop.</String>
 
   <String Id="FeatureChefWSApp"><%= friendly_name %> App</String>
-  <String Id="FeatureChefWSAppDesc">Enable the <%= friendly_name %> App</String>
+  <String Id="FeatureChefWSAppDesc">Install the <%= friendly_name %> Taskbar App</String>
 
   <String Id="FeatureChefWSAppAutostart">Start on login</String>
-  <String Id="FeatureChefWSAppAutostartDesc">Configure the <%= friendly_name %> App to autostart on login</String>
+  <String Id="FeatureChefWSAppAutostartDesc">Configure the <%= friendly_name %> Taskbar App to autostart on login</String>
 
   <String Id="MinimumOSVersionMessage">This package requires minimum OS version: Windows 7/Windows Server 2008 R2 or greater.</String>
   <String Id="DowngradeErrorMessage">A newer version of [ProductName] is already installed.</String>

--- a/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chef-workstation/msi/localization-en-us.wxl.erb
@@ -38,10 +38,10 @@
   <String Id="FeatureChefWSDesktopPSShortcutDesc">Install a <%= friendly_name %> PowerShell shortcut to your Desktop.</String>
 
   <String Id="FeatureChefWSApp"><%= friendly_name %> App</String>
-  <String Id="FeatureChefWSAppDesc">Install the <%= friendly_name %> Taskbar App</String>
+  <String Id="FeatureChefWSAppDesc">Install the <%= friendly_name %> App</String>
 
   <String Id="FeatureChefWSAppAutostart">Start on login</String>
-  <String Id="FeatureChefWSAppAutostartDesc">Configure the <%= friendly_name %> Taskbar App to autostart on login</String>
+  <String Id="FeatureChefWSAppAutostartDesc">Configure the <%= friendly_name %> App to autostart on login</String>
 
   <String Id="MinimumOSVersionMessage">This package requires minimum OS version: Windows 7/Windows Server 2008 R2 or greater.</String>
   <String Id="DowngradeErrorMessage">A newer version of [ProductName] is already installed.</String>
@@ -52,4 +52,3 @@
   <String Id="DlgDKInstalled_BannerBitmap">WixUI_Bmp_Banner</String>
   <String Id="DlgDKInstalled_Message">You're using ChefDK. It will be upgraded to Chef Workstation.</String>
 </WixLocalization>
-

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -213,8 +213,7 @@
     -->
     <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)"
       Description="!(loc.FeatureMainDesc)"
-      Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION"
-      Display="expand">
+      Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ChefWSPath" />
       <ComponentRef Id="ChefPSModulePath" />
@@ -236,7 +235,7 @@
     </Feature>
 
     <Feature Id="ChefWSApp" Title="!(loc.FeatureChefWSApp)" Description="!(loc.FeatureChefWSAppDesc)"
-      Level="1" AllowAdvertise="no" Display="expand">
+      Level="1" AllowAdvertise="no">
       <ComponentRef Id="ChefWSAppStartMenuShortcut" />
       <Feature Id="ChefWSAppAutostartFeature" Title="!(loc.FeatureChefWSAppAutostart)"
                Description="!(loc.FeatureChefWSAppAutostartDesc)" Level="1000" AllowAdvertise="no" >

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -234,8 +234,8 @@
       </Feature>
     </Feature>
 
-    <Feature Id="ChefWSApp" Title="!(loc.FeatureChefWSApp)" Description="!(loc.FeatureChefWSAppDesc)" Level="1000" AllowAdvertise="no">
-      <!-- 2018-10-08  disabling automstart until we're ready to enable it for all platforms
+    <Feature Id="ChefWSApp" Title="!(loc.FeatureChefWSApp)" Description="!(loc.FeatureChefWSAppDesc)" Level="1" AllowAdvertise="no">
+      <!-- 2018-10-08  disabling autostart until we're ready to enable it for all platforms
 
             <ComponentRef Id="ChefWSAppAutostartShortcut" />
         -->

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -209,7 +209,7 @@
          [x] Chef Workstation
            [x] Start Menu Shortcut
            [x] Desktop Shortcut
-         [x] Chef Workstation App (includes shortcuts and autostart)
+         [x] Chef Workstation App
     -->
     <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)"
       Description="!(loc.FeatureMainDesc)"
@@ -235,12 +235,13 @@
       </Feature>
     </Feature>
 
-    <Feature Id="ChefWSApp" Title="!(loc.FeatureChefWSApp)" Description="!(loc.FeatureChefWSAppDesc)" Level="1" AllowAdvertise="no">
-      <!-- 2018-10-08  disabling autostart until we're ready to enable it for all platforms
-
-            <ComponentRef Id="ChefWSAppAutostartShortcut" />
-        -->
+    <Feature Id="ChefWSApp" Title="!(loc.FeatureChefWSApp)" Description="!(loc.FeatureChefWSAppDesc)"
+      Level="1" AllowAdvertise="no" Display="expand">
       <ComponentRef Id="ChefWSAppStartMenuShortcut" />
+      <Feature Id="ChefWSAppAutostartFeature" Title="!(loc.FeatureChefWSAppAutostart)"
+               Description="!(loc.FeatureChefWSAppAutostartDesc)" Level="1000" AllowAdvertise="no" >
+        <ComponentRef Id="ChefWSAppAutostartShortcut" />
+      </Feature>
     </Feature>
 
     <!--

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -102,7 +102,7 @@
                 <RegistryValue Type="string" Name="BinDir" Value="[PROJECTLOCATIONBIN]" />
               </RegistryKey>
             </Component>
-            <Component Id="StartChefWSPowershellShortcut" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
+            <Component Id="StartChefWSPowershellScript" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
               <!-- Note that this refers to a Source relative to the package build directory,
                      and not in the zip file which contains all of the chef-workstation build -->
                 <File Id="StartChefWSScript" Source="Resources\assets\start-chefws.ps1" KeyPath="yes" />
@@ -222,12 +222,12 @@
       <ComponentRef Id="ChefWSRegistryEntries" />
       <Feature Id="ChefWSStartMenuPSShortcutFeature" Title="!(loc.FeatureChefWSStartMenuPSShortcut)"
         Description="!(loc.FeatureChefWSStartMenuPSShortcutDesc)" Level="1" AllowAdvertise="no" >
-        <ComponentRef Id="StartChefWSPowershellShortcut" />
+        <ComponentRef Id="StartChefWSPowershellScript" />
         <ComponentRef Id="PowershellStartMenuShortcut" />
       </Feature>
       <Feature Id="ChefWSDesktopPSShortcutFeature" Title="!(loc.FeatureChefWSDesktopPSShortcut)"
         Description="!(loc.FeatureChefWSDesktopPSShortcutDesc)" Level="1" AllowAdvertise="no" >
-        <ComponentRef Id="StartChefWSPowershellShortcut" />
+        <ComponentRef Id="StartChefWSPowershellScript" />
         <ComponentRef Id="PowershellDesktopShortcut" />
       </Feature>
       <Feature Id="ChefWSEnvHacks" Title="!(loc.FeatureChefWSEnvHacks)" Description="!(loc.FeatureChefWSEnvHacksDesc)" Level="1000" AllowAdvertise="no">

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -209,7 +209,9 @@
          [x] Chef Workstation
            [x] Start Menu Shortcut
            [x] Desktop Shortcut
+           [ ] Environment Customizations
          [x] Chef Workstation App
+           [ ] Start at login
     -->
     <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)"
       Description="!(loc.FeatureMainDesc)"

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -213,7 +213,8 @@
     -->
     <Feature Id="ChefWSFeature" Title="!(loc.FeatureMainName)"
       Description="!(loc.FeatureMainDesc)"
-      Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
+      Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION"
+      Display="expand">
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ChefWSPath" />
       <ComponentRef Id="ChefPSModulePath" />


### PR DESCRIPTION
1) We were never enabling Chef Workstation App. We were installing it. This updated wording is consistent with the actual Chef Workstation wording
2) Rename some components so it's more clear to folks in the future what they do
3) Call it the Chef Workstation Taskbar App in the description so it's more clear what you're selecting
4) Enable the WS App subfeature to enable it at boot. Have this be disabled by default, but this lets us at least test this functionality for when (soon) we make it default