### PR TITLE
Minor updates to the omnibus cookbook

### DIFF
--- a/omnibus/cookbooks/chef-workstation-builder/metadata.rb
+++ b/omnibus/cookbooks/chef-workstation-builder/metadata.rb
@@ -4,6 +4,5 @@ maintainer_email "shackers@chef.io"
 license          "Apache-2.0"
 description      "Builds a Chef Workstation package"
 version          "1.0.0"
-
-depends "omnibus"
-depends "yum-epel", "~> 0.6"
+depends          "omnibus"
+depends          "yum-epel"

--- a/omnibus/cookbooks/chef-workstation-builder/recipes/default.rb
+++ b/omnibus/cookbooks/chef-workstation-builder/recipes/default.rb
@@ -1,10 +1,6 @@
 # ensure packages are available and up-to-date
-case node["platform_family"]
-when "debian"
-  apt_update
-when "rhel"
-  include_recipe "yum-epel::default"
-end
+apt_update
+include_recipe "yum-epel::default" if platform_family?("rhel")
 
 include_recipe "omnibus::default"
 


### PR DESCRIPTION
Remove the pin on the very old yum-epel
Simplify the platform logic a bit since apt_update will auto skip on non-debian platforms

Signed-off-by: Tim Smith <tsmith@chef.io>