### PR TITLE
Aggressively clean up files in the workstation install

### DIFF
--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -61,6 +61,7 @@ build do
       examples
       ext
       FAQ.txt
+      frozen_old_spec
       Gemfile.devtools
       Gemfile.lock
       Gemfile.travis

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -34,63 +34,69 @@ build do
     files = %w{
       .github
       .kokoro
-      examples
-      example
-      docs
-      doc
-      doc-api
-      sample
-      samples
-      test
-      tests
+      Appraisals
+      ARCHITECTURE.md
+      autotest/*
+      bench
       benchmark
       benchmarks
-      rakelib
-      CHANGELOG.md
-      CONTRIBUTORS.md
-      README.md
-      README.markdown
-      HISTORY.md
-      TODO.md
-      CONTRIBUTING.md
-      ISSUE_TEMPLATE.md
-      UPGRADING.md
-      CODE_OF_CONDUCT.md
-      Code-of-Conduct.md
-      ARCHITECTURE.md
-      CHANGES.md
-      README.YARD.md
-      GUIDE.md
-      MIGRATING.md
-      README.txt
-      HISTORY.txt
-      Manifest.txt
-      Manifest
-      CHANGES.txt
-      CHANGELOG.txt
-      warning.txt
-      FAQ.txt
-      release-script.txt
-      TODO
-      HISTORY
-      CHANGES
       CHANGELOG
+      CHANGELOG.md
+      CHANGELOG.rdoc
+      CHANGELOG.txt
+      CHANGES
+      CHANGES.md
+      CHANGES.txt
+      Code-of-Conduct.md
+      CODE_OF_CONDUCT.md
+      CONTRIBUTING.md
+      CONTRIBUTING.rdoc
+      CONTRIBUTORS.md
+      doc
+      doc-api
+      docs
+      donate.png
+      ed25519.png
+      example
+      examples
+      ext
+      FAQ.txt
+      Gemfile.devtools
+      Gemfile.lock
+      Gemfile.travis
+      GUIDE.md
+      HISTORY
+      HISTORY.md
+      History.rdoc
+      HISTORY.txt
+      INSTALL
+      ISSUE_TEMPLATE.md
+      logo.png
+      man
+      Manifest
+      Manifest.txt
+      MIGRATING.md
+      rakelib
       README
       README-json-jruby.md
-      Gemfile.travis
-      Gemfile.lock
-      Gemfile.devtools
+      README.markdown
+      README.md
       README.rdoc
-      CHANGELOG.rdoc
-      History.rdoc
-      CONTRIBUTING.rdoc
+      README.txt
+      README.YARD.md
       README_INDEX.rdoc
-      logo.png
-      donate.png
-      Appraisals
-      website
-      man
+      release-script.txt
+      sample
+      samples
       site
+      test
+      tests
+      TODO
+      TODO.md
+      travis_build_script.sh
+      UPGRADING.md
+      warning.txt
+      website
     }
 
     Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -108,5 +108,37 @@ build do
         File.delete(f)
       end
     end
+
+    block "Removing Gemspec / Rakefile / Gemfile unless there's a bin dir" do
+      # find the embedded ruby gems dir and clean it up for globbing
+      target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
+      files = %w{
+        *.gemspec
+        Gemfile
+        Rakefile
+      }
+
+      Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|
+        # don't delete these files if there's a bin dir in the same dir
+        unless Dir.exist?(File.join(File.dirname(f), "bin"))
+          puts "Deleting #{f}"
+          File.delete(f)
+        end
+      end
+    end
+
+    block "Removing spec dirs unless we're in components we test in the verify command" do
+      # find the embedded ruby gems dir and clean it up for globbing
+      target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
+
+      Dir.glob(Dir.glob("#{target_dir}/*/spec")).each do |f|
+
+        # don't delete these files if we use them in our verify tests
+        unless File.basename(File.expand_path("..", f)).match?(/^(berkshelf|test-kitchen|chef|chef-cli|chef-apply|chefspec)-\d/)
+          puts "Deleting unused spec dir #{f}"
+          FileUtils.remove_dir(f)
+        end
+      end
+    end
   end
 end

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -78,6 +78,7 @@ build do
       Manifest.txt
       MIGRATING.md
       rakelib
+      readme.erb
       README
       README-json-jruby.md
       README.markdown
@@ -92,12 +93,14 @@ build do
       site
       test
       tests
+      THANKS.txt
       TODO
-      TODO.md
+      TODO*.md
       travis_build_script.sh
       UPGRADING.md
       warning.txt
       website
+      yard-template
     }
 
     Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|


### PR DESCRIPTION
- Remove /ext dirs from gems since we've already compiled the extensions and no longer need the hundreds of files here
- Remove Rakefile/Gemspec/Gemfile when we don't also have a bin dir (appbundler needs these)
- Remove specs that we're not using in our verify command

This might seem overly complex, but the win is pretty substantial so I'd argue it's worth the trouble. Stats for this PR on my mac:

9.28% reduction in size of /opt/chef-workstation (47.9 megs)
11.47% reductions in /opt/chef-workstation file count (4,934 files)

