### PR TITLE
Simplify our Ruby cleanup in ommnibus

### DIFF
--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -4,4 +4,4 @@ cookbook "chef-workstation-builder",
   path: File.expand_path("cookbooks/chef-workstation-builder", File.dirname(__FILE__))
 
 # Uncomment to use the latest version of the Omnibus cookbook from GitHub
-# cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'
+# cookbook 'omnibus', github: 'chef-cookbooks/omnibus'

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -15,7 +15,7 @@ group :development do
   gem "berkshelf", ">= 7.0"
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem "test-kitchen", ">= 1.23"
+  gem "test-kitchen", ">= 2"
   gem "kitchen-vagrant"
   gem "winrm-elevated"
 end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -388,7 +388,7 @@ DEPENDENCIES
   omnibus!
   omnibus-software!
   pedump
-  test-kitchen (>= 1.23)
+  test-kitchen (>= 2)
   winrm-elevated
 
 BUNDLED WITH

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -35,23 +35,10 @@ build do
       .github
       .kokoro
       Appraisals
-      ARCHITECTURE.md
       autotest/*
       bench
       benchmark
       benchmarks
-      CHANGELOG
-      CHANGELOG.md
-      CHANGELOG.rdoc
-      CHANGELOG.txt
-      CHANGES
-      CHANGES.md
-      CHANGES.txt
-      Code-of-Conduct.md
-      CODE_OF_CONDUCT.md
-      CONTRIBUTING.md
-      CONTRIBUTING.rdoc
-      CONTRIBUTORS.md
       doc
       doc-api
       docs
@@ -60,44 +47,20 @@ build do
       example
       examples
       ext
-      FAQ.txt
       frozen_old_spec
       Gemfile.devtools
       Gemfile.lock
       Gemfile.travis
-      GUIDE.md
-      HISTORY
-      HISTORY.md
-      History.rdoc
-      HISTORY.txt
-      INSTALL
-      ISSUE_TEMPLATE.md
       logo.png
       man
-      Manifest
-      Manifest.txt
-      MIGRATING.md
       rakelib
-      readme.erb
-      README
-      README-json-jruby.md
-      README.markdown
-      README.md
-      README.rdoc
-      README.txt
-      README.YARD.md
-      README_INDEX.rdoc
       release-script.txt
       sample
       samples
       site
       test
       tests
-      THANKS.txt
-      TODO
-      TODO*.md
       travis_build_script.sh
-      UPGRADING.md
       warning.txt
       website
       yard-template

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -1,3 +1,9 @@
+#
+# NOTE: this runs the omnibus cookbook, but does not actually run Omnibus. Use
+# 'kichen converge' to setup the virtual machine and then `kitchen login` to
+# SSH into the machine and run Omnibus.
+#
+
 driver:
   name: vagrant
   forward_agent: yes


### PR DESCRIPTION
Remove the files that we cleanup already via omnibus-software's
ruby-cleanup definition. There's no reason to cleanup the same files in
both.

Signed-off-by: Tim Smith <tsmith@chef.io>