### PR TITLE
Cleanup rake tasks in gems we ship

### DIFF
--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -32,6 +32,7 @@ build do
     # find the embedded ruby gems dir and clean it up for globbing
     target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
     files = %w{
+      .appveyor.yml
       .autotest
       .github
       .kokoro

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -120,6 +120,7 @@ build do
         *.gemspec
         Gemfile
         Rakefile
+        tasks/*.rake
       }
 
       Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -32,6 +32,7 @@ build do
     # find the embedded ruby gems dir and clean it up for globbing
     target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
     files = %w{
+      .autotest
       .github
       .kokoro
       Appraisals


### PR DESCRIPTION
There's no need to ship the rake tasks when we've already removed the Rakefile for these gems. This removes 56 additional files which take up 200k on disk.
```
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/strings-ansi-0.2.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/strings-ansi-0.2.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/strings-ansi-0.2.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-cursor-0.7.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-cursor-0.7.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-cursor-0.7.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-table-0.11.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-table-0.11.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-table-0.11.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uuidtools-2.1.5/tasks/rspec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uuidtools-2.1.5/tasks/git.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uuidtools-2.1.5/tasks/benchmark.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uuidtools-2.1.5/tasks/gem.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uuidtools-2.1.5/tasks/metrics.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/uuidtools-2.1.5/tasks/yard.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equatable-0.6.1/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equatable-0.6.1/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/equatable-0.6.1/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/necromancer-0.5.1/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/necromancer-0.5.1/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/necromancer-0.5.1/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-screen-0.7.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-screen-0.7.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-screen-0.7.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/addressable-2.5.2/tasks/rspec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/addressable-2.5.2/tasks/git.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/addressable-2.5.2/tasks/clobber.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/addressable-2.5.2/tasks/gem.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/addressable-2.5.2/tasks/metrics.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/addressable-2.5.2/tasks/yard.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/thread_safe-0.3.6/tasks/update_doc.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-spinner-0.9.2/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-spinner-0.9.2/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-spinner-0.9.2/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http_parser.rb-0.6.0/tasks/fixtures.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http_parser.rb-0.6.0/tasks/compile.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http_parser.rb-0.6.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/http_parser.rb-0.6.0/tasks/submodules.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-color-0.5.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-color-0.5.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-color-0.5.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-prompt-0.20.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-prompt-0.20.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-prompt-0.20.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-reader-0.7.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-reader-0.7.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-reader-0.7.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-box-0.5.0/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-box-0.5.0/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/tty-box-0.5.0/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/pastel-0.7.3/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/pastel-0.7.3/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/pastel-0.7.3/tasks/spec.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/strings-0.1.8/tasks/coverage.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/strings-0.1.8/tasks/console.rake
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/strings-0.1.8/tasks/spec.rake
```

This also removes .autotest files which removes another 2 files from our install:

```
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/minitest-5.11.3/.autotest
Deleting /opt/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/os-1.0.1/.autotest
```

Signed-off-by: Tim Smith <tsmith@chef.io>