### PR TITLE
Fixes all notarization issues

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "master"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "master"
+gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "jm/deep_sign"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "jm/deep_sign_chef"
 gem "artifactory"
 
 gem "pedump"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: ebdd701bcf29f76ba7f1bbfc5e338b7c19287133
-  branch: master
+  revision: 92d1d03cbefdd694d48ad6a03489535d3dc04d2a
+  branch: jm/deep_sign_chef
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.6.1)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 70855aab656d333622c51171828b4f41d04f6ef5
-  branch: master
+  revision: 7af181d6ddec25c450b4c5ce13fad6b03593eb8c
+  branch: jm/deep_sign
   specs:
-    omnibus (6.1.21)
+    omnibus (7.0.0)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar (>= 3.3)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.263.0)
+    aws-partitions (1.264.0)
     aws-sdk-core (3.89.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)

--- a/omnibus/config/patches/rb-fsevent-gem.patch
+++ b/omnibus/config/patches/rb-fsevent-gem.patch
@@ -1,0 +1,24 @@
+diff --git a/bin/fsevent_watch b/bin/fsevent_watch
+index 889204f..17b894b 100755
+Binary files a/bin/fsevent_watch and b/bin/fsevent_watch differ
+diff --git a/ext/rakefile.rb b/ext/rakefile.rb
+index d7789bd..fd8ec36 100644
+--- a/ext/rakefile.rb
++++ b/ext/rakefile.rb
+@@ -48,13 +48,13 @@ CLOBBER.include $final_exe.to_s
+ task :sw_vers do
+   $mac_product_version = `sw_vers -productVersion`.strip
+   $mac_build_version = `sw_vers -buildVersion`.strip
+-  $MACOSX_DEPLOYMENT_TARGET = ENV["MACOSX_DEPLOYMENT_TARGET"] || $mac_product_version.sub(/\.\d*$/, '')
+-  $CFLAGS = "#{$CFLAGS} -mmacosx-version-min=#{$MACOSX_DEPLOYMENT_TARGET}"
++  $MACOSX_MIN_TARGET = $mac_product_version.sub(/\.\d*$/, '')
++  $CFLAGS = "#{$CFLAGS} -mmacosx-version-min=#{$MACOSX_MIN_TARGET}"
+ end
+ 
+ task :get_sdk_info => :sw_vers do
+   $SDK_INFO = {}
+-  version_info = `xcodebuild -version -sdk macosx#{$MACOSX_DEPLOYMENT_TARGET}`
++  version_info = `xcodebuild -version -sdk macosx`
+   raise "invalid SDK" unless !!$?.exitstatus
+   version_info.strip.each_line do |line|
+     next if line.strip.empty?

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -116,7 +116,7 @@ end
 
 package :pkg do
   identifier "com.getchef.pkg.chef-workstation"
-  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
+  signing_identity "Chef Software, Inc. (EU3VF8YLX2)"
 end
 
 package :msi do

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -47,6 +47,11 @@ dependency "libzmq"
 # for train
 dependency "google-protobuf"
 
+# This is a transative dep but we need to build from source so binaries are built on current sdk.
+# Only matters on mac.
+# @todo Contact gem mainter about getting new release.
+dependency "rb-fsevent-gem" if mac_os_x?
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -41,6 +41,8 @@ version("2.24.1") { source sha256: "ad5334956301c86841eb1e5b1bb20884a6bad89a10a6
 
 source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 
+bin_dirs ["#{install_dir}/gitbin", "#{install_dir}/embedded/libexec/git-core"]
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/omnibus/config/software/rb-fsevent-gem.rb
+++ b/omnibus/config/software/rb-fsevent-gem.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2012-2020 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rb-fsevent-gem"
+default_version "master"
+
+source git: "https://github.com/thibaudgg/rb-fsevent.git"
+
+license "Apache-2.0"
+license_file "https://raw.githubusercontent.com/thibaudgg/rb-fsevent/master/LICENSE.txt"
+
+dependency "ruby"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  # Look up active sdk version.
+  sdk_ver = `xcrun --sdk macosx --show-sdk-version`.strip
+  env["MACOSX_DEPLOYMENT_TARGET"] = sdk_ver
+
+  bundle "install", env: env
+  bundle "exec rake replace_exe", env: env, cwd: "#{project_dir}/ext"
+  bundle "exec rake install:local", env: env
+end


### PR DESCRIPTION
## Description
This changes makes the neccessary changes to enable the pkg to pass apples notarization requirements.

1. Update omnibus and omnibus-software to versions that support deep signing
2. Drop 'Developer ID Installer:' from signing key. This lets sigining pick up the correct key for what is being signed.
3. Add bin_dirs and lib_dirs to gems and git-custom-bindir software definitions so siging can find their binaries and libraries.
4. Add software definition for rb-fsevent-gem so we build the gem. This resolves an issue where the shipped binary is build on to old an sdk.
5. Patch rb-fsevent-gem build to work in our environment. Set minimum target to current os and discover the sdk version.

* Note it is currently pointed at branches in omnibus and omnibus software. Let's work towards merging this and we can do a follow on change once those branches merge.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

## Related Issue
https://github.com/chef/omnibus/pull/924
https://github.com/chef/omnibus-software/pull/1146

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
