### PR TITLE
Exclude omnibus_packages in chef bundle testing

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -112,7 +112,7 @@ do_install() {
     wrap_ruby_bin "chef-resource-inspector"
     wrap_ruby_bin "chef-shell"
 
-    appbundle "chef" "docgen,chefstyle"
+    appbundle "chef" "docgen,chefstyle,omnibus_packages"
     wrap_ruby_bin "knife"
 
     appbundle "inspec-bin" "changelog,debug,docs,development"

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -73,7 +73,7 @@ build do
   # install the whole bundle first
   bundle "install --jobs 10 --without #{excluded_groups.join(" ")}", env: env
 
-  appbundle "chef", lockdir: project_dir, gem: "chef", without: %w{docgen chefstyle}, env: env
+  appbundle "chef", lockdir: project_dir, gem: "chef", without: %w{docgen chefstyle omnibus_packages}, env: env
 
   appbundle "foodcritic", lockdir: project_dir, gem: "foodcritic", without: %w{development test}, env: env
   appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs development}, env: env


### PR DESCRIPTION
Due to pins in inspec vs. inspec-core in 4.18.51 we're getting failures.
This will be resolved with a new inspec release, but that doesn't
unblock us today.

Signed-off-by: Tim Smith <tsmith@chef.io>