### PR TITLE
mac_os:(launcher) run at boot

### DIFF
--- a/omnibus/files/uninstall-scripts/uninstall_chef_workstation
+++ b/omnibus/files/uninstall-scripts/uninstall_chef_workstation
@@ -20,11 +20,9 @@ is_darwin()
 if is_darwin; then
   echo "This uninstaller will remove Chef Workstation."
   sudo /bin/sh -s <<'EOF'
-if [ $(osascript -e 'application "Chef Workstation App" is running') = 'true' ]; then
-  echo "Closing Chef Workstation App..."
-  osascript -e 'quit app "Chef Workstation App"' > /dev/null 2>&1;
-fi
 echo "Uninstalling Chef Workstation..."
+echo "  -> Removing Chef Workstation App..."
+/opt/chef-workstation/bin/chef_workstation_app_launcher remove
 echo "  -> Removing files..."
 sudo rm -rf '/opt/chef-workstation'
 sudo rm -rf '/Applications/Chef Workstation App.app'

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -32,10 +32,12 @@ for binary in $binaries; do
 done
 
 if is_darwin; then
-  restart_required=false
+  # the app launcher comes from the chef-workstation-app repo, here we are just using
+  # it to start the app as a service on MacOS systems, it will start at boot
+  app_launcher=chef_workstation_app_launcher
+
   # Close the app if it is running.
   if [ $(osascript -e 'application "Chef Workstation App" is running') = 'true' ]; then
-    restart_required=true
     echo "Closing Chef Workstation App..."
     osascript -e 'quit app "Chef Workstation App"' > /dev/null 2>&1;
   fi
@@ -48,16 +50,15 @@ if is_darwin; then
   unzip chef-workstation-app-mac.zip
   sudo rm -rf "/Applications/Chef Workstation App.app"
   sudo mv "Chef Workstation App.app" /Applications/
+  mv "/Applications/Chef Workstation App.app/Contents/Resources/assets/scripts/$app_launcher" $INSTALLER_DIR/bin || error_exit "Cannot move $app_launcher to $INSTALLER_DIR/bin"
   rm -f chef-workstation-app-mac.zip
   popd
 
   ln -sf $INSTALLER_DIR/bin/uninstall_chef_workstation $PREFIX/bin || error_exit "Cannot link uninstall_chef_workstation to $PREFIX/bin"
 
   # Restart the app if it was running.
-  if $restart_required; then
-    echo "Restarting Chef Workstation App..."
-    osascript -e 'open app "Chef Workstation App"' > /dev/null 2>&1;
-  fi
+  echo "Restarting Chef Workstation App..."
+  $INSTALLER_DIR/bin/$app_launcher load
 else # linux - postinst does not run for windows.
   cwa_app_path="$INSTALLER_DIR/components/chef-workstation-app/chef-workstation-app"
   ldd "$cwa_app_path" | grep "not found" >/dev/null 2>&1


### PR DESCRIPTION
## Description
This change has a dependency on chef/chef-workstation-app#153 and once it is
merged it will enable the Chef Workstation App to be run at boot by leveraging
the new `chef_workstation_app_launcher` script.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef-workstation/issues/819

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
