### PR TITLE
Create the .chef dir automatically on mac/linux/windows

### DIFF
--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -83,7 +83,7 @@ for binary in $binaries; do
 done
 
 # everyone needs a .chef dir so let's create it for them
-if [ ! -d "~/.chef/" ]; then
+if [ ! -d ~/.chef/ ]; then
   mkdir ~/.chef
   chmod 700 ~/.chef
 fi

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -83,7 +83,7 @@ for binary in $binaries; do
 done
 
 # everyone needs a .chef dir so let's create it for them
-if [ ! -d ~/.chef/ ]; then
+if [ ! -d "~/.chef/" ]; then
   mkdir ~/.chef
   chmod 700 ~/.chef
 fi

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -82,6 +82,12 @@ for binary in $binaries; do
   ln -sf "$INSTALLER_DIR/bin/$binary" $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"
 done
 
+# everyone needs a .chef dir so let's create it for them
+if [ ! -d ~/.chef/ ]; then
+  mkdir ~/.chef
+  chmod 700 ~/.chef
+fi
+
 if is_darwin; then
   # the app launcher comes from the chef-workstation-app repo, here we are just using
   # it to start the app as a service on MacOS systems, it will start at boot

--- a/omnibus/resources/chef-workstation/msi/assets/create-chef-dir.ps1
+++ b/omnibus/resources/chef-workstation/msi/assets/create-chef-dir.ps1
@@ -1,0 +1,6 @@
+$chef_path = "$HOME\.chef"
+
+If(!(test-path $chef_path))
+{
+  New-Item -ItemType Directory -Force -Path $chef_path
+}

--- a/omnibus/resources/chef-workstation/msi/assets/create-chef-dir.ps1
+++ b/omnibus/resources/chef-workstation/msi/assets/create-chef-dir.ps1
@@ -2,5 +2,5 @@ $chef_path = "$HOME\.chef"
 
 If(!(test-path $chef_path))
 {
-  New-Item -ItemType Directory -Force -Path $chef_path
+  New-Item -ItemType Directory -Path $chef_path
 }

--- a/omnibus/resources/chef-workstation/msi/assets/create-chef-dir.ps1
+++ b/omnibus/resources/chef-workstation/msi/assets/create-chef-dir.ps1
@@ -1,4 +1,4 @@
-$chef_path = "$HOME\.chef"
+$chef_path = "$env:USERPROFILE" + "\.chef"
 
 If(!(test-path $chef_path))
 {

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -94,32 +94,32 @@
        For now, using COMMON_ALTSTARTUP which is the global auto-start folder. Note that this
        may cause some trouble - we haven't yet looked into how the App should behave when multiple
        instances are running across different users.
-  -->
-  <PropertyRef Id="WIX_DIR_COMMON_ALTSTARTUP" />
+    -->
+    <PropertyRef Id="WIX_DIR_COMMON_ALTSTARTUP" />
 
-  <CustomActionRef Id="WixBroadcastSettingChange" />
-  <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+    <CustomActionRef Id="WixBroadcastSettingChange" />
+    <CustomActionRef Id="WixBroadcastEnvironmentChange" />
 
-  <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]"/>
-  <Directory Id="TARGETDIR" Name="SourceDir">
-    <Directory Id="WINDOWSVOLUME">
-      <Directory Id="INSTALLLOCATION" Name="opscode">
-        <Directory Id="PROJECTLOCATION" Name="chef-workstation">
-          <Directory Id="PROJECTLOCATIONBIN" Name="bin">
-            <Component Id="ChefWSPath" Guid="{BC744260-FD5B-4A0F-8EE5-76283072CC09}" >
-              <Environment Id="Environment"
-                Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATIONBIN]" />
-            </Component>
-            <Component Id="ChefWSRegistryEntries" Guid="{67E30C25-5311-4584-9A17-5D47AC28F9CD}">
-              <RegistryKey Root="HKLM" Key="Software\Chef\Chef Workstation">
-                <RegistryValue Type="string" Name="InstallDir" Value="[PROJECTLOCATION]" />
-                <RegistryValue Type="string" Name="BinDir" Value="[PROJECTLOCATIONBIN]" />
-              </RegistryKey>
-            </Component>
-            <Component Id="StartChefWSPowershellScript" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
-              <!-- Note that this refers to a Source relative to the package build directory,
-                     and not in the zip file which contains all of the chef-workstation build -->
-                <File Id="StartChefWSScript" Source="Resources\assets\start-chefws.ps1" KeyPath="yes" />
+    <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]"/>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="WINDOWSVOLUME">
+        <Directory Id="INSTALLLOCATION" Name="opscode">
+          <Directory Id="PROJECTLOCATION" Name="chef-workstation">
+            <Directory Id="PROJECTLOCATIONBIN" Name="bin">
+              <Component Id="ChefWSPath" Guid="{BC744260-FD5B-4A0F-8EE5-76283072CC09}" >
+                <Environment Id="Environment"
+                  Name="PATH" Action="set" Part="last" System="yes" Value="[PROJECTLOCATIONBIN]" />
+              </Component>
+              <Component Id="ChefWSRegistryEntries" Guid="{67E30C25-5311-4584-9A17-5D47AC28F9CD}">
+                <RegistryKey Root="HKLM" Key="Software\Chef\Chef Workstation">
+                  <RegistryValue Type="string" Name="InstallDir" Value="[PROJECTLOCATION]" />
+                  <RegistryValue Type="string" Name="BinDir" Value="[PROJECTLOCATIONBIN]" />
+                </RegistryKey>
+              </Component>
+              <Component Id="StartChefWSPowershellScript" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
+                <!-- Note that this refers to a Source relative to the package build directory,
+                      and not in the zip file which contains all of the chef-workstation build -->
+                  <File Id="StartChefWSScript" Source="Resources\assets\start-chefws.ps1" KeyPath="yes" />
               </Component>
             </Directory>
             <Directory Id="PSMODULES" Name="modules" >

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -116,6 +116,11 @@
                   <RegistryValue Type="string" Name="BinDir" Value="[PROJECTLOCATIONBIN]" />
                 </RegistryKey>
               </Component>
+              <Component Id="CreateDotChefDirPowershellScript" Guid="{DB58E387-1D7C-4D3D-8413-372208B82A8C}" >
+                <!-- Note that this refers to a Source relative to the package build directory,
+                      and not in the zip file which contains all of the chef-workstation build -->
+                  <File Id="CreateDotChefDirScript" Source="Resources\assets\create-chef-dir.ps1" KeyPath="yes" />
+              </Component>
               <Component Id="StartChefWSPowershellScript" Guid="{69EF5736-ED67-45B3-887A-FBFC0AB6DA13}" >
                 <!-- Note that this refers to a Source relative to the package build directory,
                       and not in the zip file which contains all of the chef-workstation build -->

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -236,6 +236,7 @@
       Description="!(loc.FeatureMainDesc)"
       Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="INSTALLLOCATION">
       <ComponentGroupRef Id="ProjectDir" />
+      <ComponentRef Id="CreateDotChefDirPowershellScript" />
       <ComponentRef Id="ChefWSPath" />
       <ComponentRef Id="ChefPSModulePath" />
       <ComponentRef Id="ChefPowerShellRegistryEntries" />

--- a/omnibus/verification/verify.rb
+++ b/omnibus/verification/verify.rb
@@ -262,6 +262,10 @@ module ChefWorkstation
         c.gem_base_dir = "chef-cli"
 
         c.smoke_test do
+          test_path = File.join(Dir.home, ".chef")
+          unless Dir.exist?(test_path)
+            raise "Expected directory #{test_path} to exist after installation complete, but did not find it."
+          end
 
           if File.directory?(usr_bin_prefix)
             sh!("#{usr_bin_path("berks")} -v")


### PR DESCRIPTION
This is one of the manual things you have to do post Workstation install that seems entirely silly. We should just create this directory for them automatically so we can remove this step from the docs.

Signed-off-by: Tim Smith <tsmith@chef.io>