### PR TITLE
Fix link to api tokens in user guide

### DIFF
--- a/www/site/content/docs/chef-workstation/chef-run-users-guide.md
+++ b/www/site/content/docs/chef-workstation/chef-run-users-guide.md
@@ -187,7 +187,7 @@ documentation](https://docs.chef.io/config_rb_policyfile.html) for examples.
 ## Connecting to Automate 2
 
 You can configure remote nodes managed with `chef-run` to send run
-information to Automate. First, [generate an auth token](https://automate.chef.io/docs/admin/#creating-a-standard-api-token).
+information to Automate. First, [generate an auth token](https://automate.chef.io/docs/api-tokens/#creating-a-standard-api-token).
 
 Next, add the token to [config.toml]({{< ref "../reference/config.md#data-collector" >}}),
 specifying the appropriate [url] (https://automate.chef.io/docs/data-collection/) and


### PR DESCRIPTION
Signed-off-by: Nick Rycar <nickrycar@Nicks-MacBook-Pro.local>

## Description
One of the token links in the Automate 2 section of the docs returns a 404. Updating to match the working link later in the doc. 

## Related Issue
Minor typo fix. No issue logged.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
Docs only change. Didn't touch tests.

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
