### PR TITLE
Update knife-ec2 to 1.0.31 and knife-vsphere to 4.1.3

### DIFF
--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -559,7 +559,7 @@ GEM
       chef (>= 15.0)
       excon (>= 0.50)
       mixlib-shellout
-    knife-ec2 (1.0.28)
+    knife-ec2 (1.0.31)
       aws-sdk-ec2 (~> 1.95)
       aws-sdk-s3 (~> 1.43)
       chef (>= 15.1)
@@ -577,7 +577,7 @@ GEM
       rbvmomi (>= 1.11, < 3.0)
       savon (~> 2.11)
       vsphere-automation-sdk (~> 0.4)
-    knife-vsphere (4.1.1)
+    knife-vsphere (4.1.3)
       chef (>= 15.1)
       chef-vault (>= 2.6.0)
       filesize (>= 0.1.1, < 0.3.0)


### PR DESCRIPTION
Both of these reduce the number of files that need to be loaded and speed up knife operations for all plugins.

Signed-off-by: Tim Smith <tsmith@chef.io>