### PR TITLE
Set version of packages on separate line

### DIFF
--- a/.expeditor/update_chef-analyze_to_latest.sh
+++ b/.expeditor/update_chef-analyze_to_latest.sh
@@ -16,7 +16,7 @@ version=$(get_github_file "$EXPEDITOR_REPO" master VERSION)
 branch="expeditor/chef-analyze${version}"
 git checkout -b "$branch"
 
-sed -i -r "s/override \"chef-analyze\",\s+version: \"[^\"]+\"/override \"chef-analyze\", version: \"${version}\"/" omnibus_overrides.rb
+sed -i -r "/^override \"chef-analyze\",/{\$!{N;s/version: \".*\"/\"= ${version}\"/}}" omnibus_overrides.rb
 
 git add .
 

--- a/.expeditor/update_chef-workstation-app_to_latest.sh
+++ b/.expeditor/update_chef-workstation-app_to_latest.sh
@@ -16,7 +16,7 @@ version=$(get_github_file $EXPEDITOR_REPO master VERSION)
 branch="expeditor/chef_workstation_app_${version}"
 git checkout -b "$branch"
 
-sed -i -r "s/override \"chef-workstation-app\",\s+version: \"v[^\"]+\"/override \"chef-workstation-app\", version: \"v${version}\"/" omnibus_overrides.rb
+sed -i -r "/^override \"chef-workstation-app\",/{\$!{N;s/version: \".*\"/\"= ${version}\"/}}" omnibus_overrides.rb
 
 git add .
 

--- a/.expeditor/update_chef.sh
+++ b/.expeditor/update_chef.sh
@@ -14,5 +14,5 @@ set -evx
 sleep 600
 
 # make sure we have rake for the tasks later
-sed -i -r "s/^\s*gem \"chef\".*/  gem \"chef\", \"= ${EXPEDITOR_VERSION}\"/" components/gems/Gemfile
-sed -i -r "s/^\s*gem \"chef-bin\".*/  gem \"chef-bin\", \"= ${EXPEDITOR_VERSION}\"/" components/gems/Gemfile
+sed -i -r "/^\s*gem \"chef\",/{\$!{N;s/\"= .*\"/\"= ${EXPEDITOR_VERSION}\"/}}" components/gems/Gemfile
+sed -i -r "/^\s*gem \"chef-bin\",/{\$!{N;s/\"= .*\"/\"= ${EXPEDITOR_VERSION}\"/}}" components/gems/Gemfile

--- a/.expeditor/update_delivery-cli_to_latest.sh
+++ b/.expeditor/update_delivery-cli_to_latest.sh
@@ -16,7 +16,7 @@ version=$(get_github_file $EXPEDITOR_REPO master VERSION)
 branch="expeditor/delivery-cli_${version}"
 git checkout -b "$branch"
 
-sed -i -r "s/override \"delivery-cli\",\s+version: \"[^\"]+\"/override \"delivery-cli\", version: \"${version}\"/" omnibus_overrides.rb
+sed -i -r "/^override \"delivery-cli\",/{\$!{N;s/version: \".*\"/\"= ${version}\"/}}" omnibus_overrides.rb
 
 git add .
 

--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -52,8 +52,10 @@ group(:omnibus_package) do
   # gems to Rubygems now, so letting this float on latest should always give us the latest
   # stable release. May have to re-pin around major version bumping time, or during patch
   # fixes.
-  gem "chef", "= 15.8.23"
-  gem "chef-bin", "= 15.8.23"
+  gem "chef",
+    "= 15.8.23"
+  gem "chef-bin",
+    "= 15.8.23"
   gem "ohai", ">= 15"
   gem "cheffish", ">= 14.0.1"
 
@@ -62,8 +64,10 @@ group(:omnibus_package) do
   gem "fauxhai-ng", "~> 7.5"
 
   # inspec #TODO revert this pin when we solve build failures
-  gem "inspec-bin", "~> 4.18" # the actual inspec CLI binary
-  gem "inspec", "~> 4.18"
+  gem "inspec-bin",
+    "~> 4.18" # the actual inspec CLI binary
+  gem "inspec",
+    "~> 4.18"
 
   # test-kitchen and plugins
   gem "test-kitchen", ">= 2.0"
@@ -91,8 +95,10 @@ group(:omnibus_package) do
   # ed25519 ssh key support done here as it's a native gem we can't put in train
   gem "ed25519"
   gem "bcrypt_pbkdf"
-  gem "chef-cli", ">= 1.0.9"
-  gem "chef-apply", ">= 0.4.13"
+  gem "chef-cli",
+    ">= 1.0.9"
+  gem "chef-apply",
+    ">= 0.4.13"
 
   # For Delivery build node
   gem "chef-sugar"
@@ -105,6 +111,8 @@ group(:omnibus_package) do
   gem "mixlib-archive", ">= 1.0"
   gem "net-ssh", ">= 4.2.0"
   gem "listen"
+  # 3rd party distros sometimes replace mixlib-install.
+  # Please add parameters on separate line if required
   gem "mixlib-install"
   gem "nokogiri"
   gem "pry-byebug"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,11 @@
 source "https://rubygems.org"
 
-gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "master"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "master"
+gem "omnibus",
+  git: "https://github.com/chef/omnibus.git",
+  branch: "master"
+gem "omnibus-software",
+  git: "https://github.com/chef/omnibus-software.git",
+  branch: "master"
 gem "artifactory"
 
 gem "pedump"

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,9 +4,12 @@
 # Expeditor takes that version, runs a script to replace it here and pushes a new
 # commit / build through.
 
-override "chef-analyze", version: "0.1.71"
-override "delivery-cli", version: "0.0.54"
-override "chef-workstation-app", version: "v0.1.71"
+override "chef-analyze",
+  version: "0.1.71"
+override "delivery-cli",
+  version: "0.0.54"
+override "chef-workstation-app",
+  version: "v0.1.71"
 # /DO NOT MODIFY
 
 override :rubygems, version: "3.0.3" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which results in performance issues / CLI warnings. Make sure these versions match before bumping either.


### PR DESCRIPTION
All packages that are typically replaced by 3rd party distros now have parameters like version on separate lines to simplify patching
Expeditor scripts that handle version bumps have been updated accordingly

This will allow 3rd party distros to patch in their own gems without having to generate new patches with each version bump.

Signed-off-by: Marc Chamberland <chamberland.marc@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
See above

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
none, went straight to PR!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [NA] I have run the pre-merge tests locally and they pass.
- [NA] I have updated the documentation accordingly. # I could add in-line comment if need be
- [NA] I have added tests to cover my changes. # no code change
- [NA] All new and existing tests passed. # no code change
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Aha! Link: https://chef.aha.io/features/SH-1491