### PR TITLE
Update Test Kitchen to 2.4.0

### DIFF
--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -791,7 +791,7 @@ GEM
     systemu (2.6.5)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    test-kitchen (2.3.4)
+    test-kitchen (2.4.0)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
       license-acceptance (~> 1.0, >= 1.0.11)


### PR DESCRIPTION
This adds functionality necessary for kitchen-pester, makes accepting the license simpler in CI environments, and passes all system env vars into the guest so they can be examined.

Signed-off-by: Tim Smith <tsmith@chef.io>