### PR TITLE
Pinning bundler to 1.17 because 2.x breaks our builds

### DIFF
--- a/components/gems/Rakefile
+++ b/components/gems/Rakefile
@@ -24,8 +24,8 @@ task :update do
   require "bundler"
   Bundler.with_clean_env do
     rm_f "Gemfile.lock"
-    sh "bundle lock --update --add-platform ruby"
-    sh "bundle lock --update --add-platform x64-mingw32"
-    sh "bundle lock --update --add-platform x86-mingw32"
+    sh "bundle _1.17.3_ lock --update --add-platform ruby"
+    sh "bundle _1.17.3_ lock --update --add-platform x64-mingw32"
+    sh "bundle _1.17.3_ lock --update --add-platform x86-mingw32"
   end
 end


### PR DESCRIPTION
## Description
A continuation of
https://github.com/chef/chef-workstation/commit/e7f09766a64a4e065d885acc509112a7a65f8fe8
to try to fix our builds.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
