### PR TITLE
I accidently bumped the bundler version after fixing the update dep script

### DIFF
--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -1091,4 +1091,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   1.17.3


### PR DESCRIPTION
## Description
I fixed the `update_deps.sh` script so this should not happen anymore, then merged a 6 day old PR that had been made before that script was fixed 🙄 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
