### PR TITLE
Updates documentation in chef-workstation

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -15,7 +15,7 @@ clean_all:
 	rm -rf results/
 
 serve: assets
-	hugo server --buildDrafts --noHTTPCache --config=config.toml,config_workstation_menu.toml
+	hugo server --buildDrafts --noHTTPCache
 
 lint: assets
 	hugo -D

--- a/www/README.md
+++ b/www/README.md
@@ -189,16 +189,16 @@ Hugo doesn't handle shortcodes that are indented in a list item properly. It int
 the text of the shortcode as a code block. More complicated shortcodes with
 code blocks, notes, additional list items, or other formatting look pretty
 bad. We've created a simple shortcode for handling shortcodes in lists or definition
-lists called `shortcode_indent`.
+lists called `readFile_shortcode`.
 
 To include a shortcode in a list or definition list, just add its file name
-to the `shortcode` parameter of `shortcode_indent` without the .md suffix.
+to the `file` parameter of `readFile_shortcode`.
 
 For example, if you wanted to add `shortcode_file_name.md` to a list:
 ``` md
-1.  Here is some text introducing the shortcode, but it's not necessary.
+1.  Here is some text introducing the shortcode.
 
-    {{< shortcode_indent shortcode="shortcode_file_name" >}}
+    {{< readFile_shortcode file="shortcode_file_name.md" >}}
 ```
 
 ### Highlighting blocks of text
@@ -265,8 +265,6 @@ users from the deleted page to a new or existing page.
 ├── site
 │   ├── content
 │   │   ├── workstation                 # where to keep markdown file documentation
-│   ├── data
-│   │   ├── chef-workstation            # where to keep structured data files used for data templates
 │   ├── layouts
 |   │   ├── shortcodes
 |   │   │   ├── ws_<shortcode_name>.md  # how to name your workstation-specific shortcodes
@@ -275,6 +273,12 @@ users from the deleted page to a new or existing page.
 |   |   |   ├── chef-workstation        # where to keep any images you need to reference in your documentation
 |   |   ├── css
 ```
+
+**Data**
+Content in the `data` subdirectory isn't currently included in the Workstation
+documentation on docs.chef.io. If you need to add files to the `data` subdirectory
+that would be included on docs.chef.io, contact the Docs Team and we can include
+that directory.
 
 ### What is happening behind the scenes
 

--- a/www/content/workstation/_index.md
+++ b/www/content/workstation/_index.md
@@ -12,7 +12,7 @@ aliases = ["/about_workstation.html", "/about_chefdk.html", "/chef_dk.html", "/a
     weight = 10
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/about_workstation.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/_index.md)
 
 {{% ws_chef_workstation %}}
 

--- a/www/content/workstation/chef-workstation-app.md
+++ b/www/content/workstation/chef-workstation-app.md
@@ -2,8 +2,6 @@
 title = "Chef Workstation App"
 draft = false
 
-aliases = ["/chef_workstation_app.html", "/chef_workstation_app/"]
-
 [menu]
   [menu.workstation]
     title = "Chef Workstation App"
@@ -12,19 +10,8 @@ aliases = ["/chef_workstation_app.html", "/chef_workstation_app/"]
     weight = 61
 +++
 
-+++
-title = "About Berkshelf"
-draft = false
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/chef-workstation-app.md)
 
-aliases = ["/berkshelf.html", "/berkshelf/"]
-
-[menu]
-  [menu.workstation]
-    title = "Berkshelf"
-    identifier = "chef_workstation/chef_workstation_tools/berkshelf.md Berkshelf"
-    parent = "chef_workstation/chef_workstation_tools"
-    weight = 10
-+++
 
 # About Chef Workstation App
 

--- a/www/content/workstation/config.md
+++ b/www/content/workstation/config.md
@@ -2,8 +2,6 @@
 title = "Configure Chef Workstation"
 draft = false
 
-aliases = ["/workstation_config.html", "/workstation_config/"]
-
 [menu]
   [menu.workstation]
     title = "Configure Chef Workstation"
@@ -11,6 +9,9 @@ aliases = ["/workstation_config.html", "/workstation_config/"]
     parent = "chef_workstation"
     weight = 50
 +++
+
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/config.md)
+
 
 # Configuration
 

--- a/www/content/workstation/ctl_kitchen.md
+++ b/www/content/workstation/ctl_kitchen.md
@@ -149,7 +149,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -309,7 +309,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -445,7 +445,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -499,7 +499,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -667,7 +667,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -725,7 +725,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -792,7 +792,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -884,7 +884,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -942,7 +942,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -1009,7 +1009,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------
@@ -1144,7 +1144,7 @@ This subcommand has the following options:
     platforms. Use a Ruby regular expression to glob two or more
     platforms into a single run.
 
-    {{< shortcode_indent shortcode="ws_ctl_kitchen_common_option_platforms" >}}
+    {{< readFile_shortcode file="ws_ctl_kitchen_common_option_platforms.md" >}}
 
 Examples
 --------

--- a/www/content/workstation/privacy.md
+++ b/www/content/workstation/privacy.md
@@ -2,8 +2,6 @@
 title = "Privacy and Telemetry"
 draft = false
 
-aliases = ["/privacy.html", "/privacy/"]
-
 [menu]
   [menu.workstation]
     title = "Privacy and Telemetry"
@@ -11,6 +9,8 @@ aliases = ["/privacy.html", "/privacy/"]
     parent = "chef_workstation"
     weight = 20
 +++
+
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/privacy.md)
 
 In order to continually improve Chef Workstation, we collect information to help us identify bugs and understand how people interact with Chef Workstation.
 

--- a/www/content/workstation/troubleshooting.md
+++ b/www/content/workstation/troubleshooting.md
@@ -2,8 +2,6 @@
 title = "Troubleshooting"
 draft = false
 
-aliases = ["troubleshooting.html", "/troubleshooting/"]
-
 [menu]
   [menu.workstation]
     title = "Troubleshooting"
@@ -11,6 +9,9 @@ aliases = ["troubleshooting.html", "/troubleshooting/"]
     parent = "chef_workstation"
     weight = 60
 +++
+
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/troubleshooting.md)
+
 
 Chef Workstation Logs
 =====================

--- a/www/layouts/shortcodes/ws_knife_ssl_check_bad_ssl_certificate.md
+++ b/www/layouts/shortcodes/ws_knife_ssl_check_bad_ssl_certificate.md
@@ -29,7 +29,7 @@ If the server you are connecting to uses a self-signed certificate,
 you must configure chef to trust that certificate.
 
 By default, the certificate is stored in the following location on the
-host where your chef-server runs:
+host where your Chef Infra Server runs:
 
   /var/opt/opscode/nginx/ca/SERVER_HOSTNAME.crt
 

--- a/www/themes/docs-new/layouts/shortcodes/readFile_shortcode.html
+++ b/www/themes/docs-new/layouts/shortcodes/readFile_shortcode.html
@@ -1,6 +1,10 @@
 
 {{ readFile (delimit (slice "layouts/shortcodes/" (.Get "file")) "") | markdownify }}
 
-{{/* This shortcode is used only for processing other shortcodes that have a code block
-  that contains the less than character "<". For some reason Hugo converts that
-  to its html equivalent &lt; in the html output.*/}}
+{{/* This shortcode is used for two purposes.
+  1. Some shortcodes contain a code block with less than character "<". For some
+  reason Hugo converts that to its html equivalent &lt; in the html output.
+
+  2. Shortcodes that are indented because they're in a list don't display properly
+  in the normal method that we use to add shortcodes, {{% shortcode_name %}}. Use
+  this readFile shortcode to include those shortcodes instead.*/}}

--- a/www/themes/docs-new/layouts/shortcodes/shortcode_indent.html
+++ b/www/themes/docs-new/layouts/shortcodes/shortcode_indent.html
@@ -1,1 +1,0 @@
-{{- markdownify (readFile (delimit (slice `layouts/shortcodes/` (.Get "shortcode") `.md` ) "")) -}}


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

This corrects a few minor-ish issues with docs in the `www` directory.

## Description

- corrects the hugo server command in the Makefile
- consolidates two nearly identical shortcodes into one
- removes a duplicate toml config from a page
- adds `edit on GitHub` links to several pages
- update the readme file

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
