### PR TITLE
Add empty third party pkg pipeline to expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -46,6 +46,8 @@ pipelines:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
+  - third-party-packages:
+      description: post-release publishing of Workstation packages to third party distribution platforms
 
 subscriptions:
   - workload: artifact_published:unstable:chef-workstation:{{version_constraint}}
@@ -62,6 +64,7 @@ subscriptions:
       - bash:.expeditor/purge-cdn.sh
       - bash:.expeditor/announce-release.sh
       - built_in:tag_docker_image
+
   - workload: chef/chef-workstation-app:master_completed:pull_request_merged:chef/chef-workstation-app:master:*
     actions:
       - bash:.expeditor/update_chef-workstation-app_to_latest.sh

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -1,0 +1,1 @@
+# This pipeline is currently under development.


### PR DESCRIPTION
This creates the pipeline that will be used to publish packages to chocolately. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
