### PR TITLE
Enable auto-publishing stable releases to choco 

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -64,6 +64,9 @@ subscriptions:
       - bash:.expeditor/purge-cdn.sh
       - bash:.expeditor/announce-release.sh
       - built_in:tag_docker_image
+      # publish to third party package managers that have a dependency
+      # on this artifact's availability
+      - trigger_pipeline:third-party-packages
 
   - workload: chef/chef-workstation-app:master_completed:pull_request_merged:chef/chef-workstation-app:master:*
     actions:

--- a/.expeditor/publish_to_chocolatey.ps1
+++ b/.expeditor/publish_to_chocolatey.ps1
@@ -1,0 +1,44 @@
+$ErrorActionPreference="stop"
+
+Write-Host "--- Fetching latest release data from omnitruck API"
+$Uri = "https://omnitruck.chef.io/stable/chef-workstation/metadata?p=windows&pv=2016&m=x86_64&v=latest"
+$releaseRecord = Invoke-RestMethod -Uri $Uri -Headers @{accept="application/json"} -ErrorAction Stop
+
+Write-Host "--- Copying templates locally"
+$tempDir = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName())
+New-Item $tempDir -ItemType Directory -Force | Out-Null
+Copy-Item -Path "components/packaging/chocolatey/*" -Destination $tempDir -Recurse
+
+Write-Host "--- Patching templates"
+$files = Get-ChildItem  -Path $tempDir -Filter *.*  -Recurse | Where-Object {!$_.PSIsContainer} | Select-Object FullName
+ForEach ($file in $files) {
+    (Get-Content $file.FullName).
+        Replace('$url$', $releaseRecord.url).
+        Replace('$version$', $releaseRecord.version).
+        Replace('$checksum$', $releaseRecord.sha256) |
+        Set-Content $file.FullName
+
+    Write-Host "--- DEBUG - Patched " $file.FullName " follows:"
+    Get-Content $file.FullName | Write-Host
+}
+
+Write-Host "--- Publishing package"
+
+$valid_build_creator="Chef Expeditor"
+$pack_cmd = "choco pack $tempDir/chef-workstation.nuspec --version " + $releaseRecord.version
+$publish_cmd = "choco push chef-workstation." + $releaseRecord.version + ".nupkg --timeout 600"
+
+try {
+    if($env:BUILDKITE_BUILD_CREATOR -eq $valid_build_creator) {
+        Invoke-Expression $pack_cmd
+        if ($LASTEXITCODE -ne 0) { throw "unable to choco pack" }
+        Invoke-Expression "$publish_cmd --key $env:CHOCO_API_KEY"
+        if ($LASTEXITCODE -ne 0) { throw "unable to publish Chocolatey package" }
+    } else {
+        Write-Host "--- NOT PUBLISHING: Build triggered by $env:BUILDKITE_BUILD_CREATOR and not $valid_build_creator"
+        Write-Host $pack_cmd
+        Write-Host $publish_cmd " --key <elided ChocoApiKey>"
+    }
+} finally {
+    Remove-Item $tempDir -Recurse -Force
+}

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -1,1 +1,14 @@
-# This pipeline is currently under development.
+steps:
+  - label: ":chocolate_bar: Publish Chocolatey package"
+    command:
+      - powershell .expeditor/publish_to_chocolatey.ps1
+    expeditor:
+      secrets:
+        CHOCO_API_KEY:
+          path: account/static/chocolatey/chef-ci
+          field: api_key
+      executor:
+        docker:
+          host_os: windows
+          environment:
+

--- a/components/packaging/chocolatey/chef-workstation.nuspec
+++ b/components/packaging/chocolatey/chef-workstation.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>chef-workstation</id>
+    <title>Chef Workstation</title>
+    <tags>chefdk chef-dk chef workstation chef-client client development chef-workstation</tags>
+    <summary>Chef Workstation gives you everything you need to get started with Chef. Ad-hoc remote execution, scans and configuration tasks, cookbook creation tools, as well as robust dependency and testing software all in one easy-to-install package.</summary>
+    <description>Chef Workstation gives you everything you need to get started with Chef. Ad-hoc remote execution, scans and configuration tasks, cookbook creation tools, as well as robust dependency and testing software all in one easy-to-install package.</description>
+    <authors>Chef Software, Inc.</authors>
+    <owners>Chef Software, Inc.</owners>
+    <copyright>2018-2020 Chef Software, Inc.</copyright>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <bugTrackerUrl>https://github.com/chef/chef-workstation/issues</bugTrackerUrl>
+    <docsUrl>https://docs.chef.io/workstation/</docsUrl>
+    <iconUrl>https://raw.githubusercontent.com/chef/chocolatey-packages/master/chef.png</iconUrl>
+    <licenseUrl>https://raw.githubusercontent.com/chef/chef-workstation/master/LICENSE</licenseUrl>
+    <mailingListUrl>https://discourse.chef.io/</mailingListUrl>
+    <projectSourceUrl>https://github.com/chef/chef-workstation</projectSourceUrl>
+    <projectUrl>https://github.com/chef/chef-workstation/</projectUrl>
+    <releaseNotes>https://packages.chef.io/release-notes/chef-workstation/$version$.md</releaseNotes>
+    <version>$version$</version>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools"/>
+  </files>
+</package>

--- a/components/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/components/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,13 @@
+$packageArgs = @{
+    packageName    = 'chef-workstation'
+    unzipLocation  = $toolsDir
+    fileType       = 'MSI'
+    # These are replaced in in publish_to_chocolatey.ps1
+    url64bit       = '$url$'
+    checksum64     = '$checksum$'
+    checksumType64 = 'sha256'
+    silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+    validExitCodes = @(0, 3010)
+}
+
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
## Description

This adds Chocolatey to the third-party-packages
buildkite pipeline, so that every stable release will
get published to Chocolatey.
