### PR TITLE
Manually building and installing docker-api gem

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -72,8 +72,11 @@ group(:omnibus_package) do
   gem "kitchen-digitalocean", ">= 0.10.0"
   gem "kitchen-dokken", ">= 2.8.1"
   # docker-api appears to be unmaintained, and has a noisy deprecation
-  # warning under ruby 2.7. Use a local fork. Dependency of kitchen-dokken.
-  gem "docker-api", git: "https://github.com/chef/docker-api.git"
+  # warning under ruby 2.7. Using a fork via an omnibus software def.
+  # Must use the software def because the ruby cleanup deletes the
+  # bundled gem. Chef Infra Client does not have this issue with Ohai
+  # and I do not understand why.
+  gem "docker-api" # , git: "https://github.com/chef/docker-api.git", branch: "master"
   gem "kitchen-google", ">= 2.0.0"
   gem "kitchen-hyperv", ">= 0.5.1"
   gem "kitchen-inspec", ">= 1.0"

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/chef/docker-api.git
-  revision: afa9cc675cee491ef70315600de923fcb07b3ea3
-  specs:
-    docker-api (1.34.2)
-      excon (>= 0.47.0)
-      multi_json
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -369,6 +361,9 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
+    docker-api (1.34.2)
+      excon (>= 0.47.0)
+      multi_json
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     droplet_kit (3.7.0)
@@ -1049,7 +1044,7 @@ DEPENDENCIES
   cookstyle (~> 5.20)
   dep-selector-libgecode
   dep_selector
-  docker-api!
+  docker-api
   ed25519
   fauxhai-ng (~> 7.5)
   ffi-libarchive

--- a/omnibus/config/software/docker-api.rb
+++ b/omnibus/config/software/docker-api.rb
@@ -1,0 +1,38 @@
+#
+# Copyright 2012-2020 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "docker-api"
+default_version "master"
+
+source git: "https://github.com/chef/docker-api.git"
+
+license "MIT"
+license_file "https://raw.githubusercontent.com/chef/docker-api/master/LICENSE"
+
+dependency "ruby"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # docker-api does not have any unique dependencies not already
+  # included in Chef Workstation. We let the master gem bundle
+  # install those gems. If we ever add custom dependencies into
+  # our fork we need to re-add bundle install here for make the
+  # gemfile pull from the fork and don't build here.
+  # bundle "install", env: env
+  gem "build docker-api.gemspec", env: env
+  gem "install docker-api-*.gem --no-document --ignore-dependencies", env: env
+end

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -52,6 +52,12 @@ dependency "google-protobuf"
 # @todo Contact gem mainter about getting new release.
 dependency "rb-fsevent-gem" if mac_os_x?
 
+# The docker-api gem has not been maintained so we are building and installing
+# a fork of it. If the maintainer releases a fix with our change we can switch
+# back to just installing it. The docker-api gem is required by kitchen-dokken
+# in its gemspec.
+dependency "docker-api"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 


### PR DESCRIPTION
## Description
The ruby cleanup omnibus software dep removes the gem installed by
bundler. I am not sure how Ohai does not have this issue. Reverting
to a pattern I understand to fix our build for now.

In the future it would be nice to only have to manage this gem via
the Gemfile and without the docker-api omnibus software definition.

## Related Issue
https://buildkite.com/chef/chef-chef-workstation-master-omnibus-release/builds/356#eb929cfb-d3cb-4862-9990-75c1a99c09d0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
