### PR TITLE
Speed up dep bumping jobs by not installing gem documentation

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -22,7 +22,7 @@ git checkout -b "$branch"
 sleep 120
 
 # attempt to install the gem first which seems to help bundler cache
-gem install $EXPEDITOR_GEM_NAME
+gem install $EXPEDITOR_GEM_NAME --no-document
 
 pushd components/gems
 bundle _1.17.3_ install

--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -23,7 +23,7 @@
 # TODO - when deleting this, also delete omnibus/config/templates/git-custom-bindir
 
 name "git-custom-bindir"
-default_version "2.24.1"
+default_version "2.26.2"
 
 license "LGPL-2.1"
 license_file "LGPL-2.1"


### PR DESCRIPTION
## Description
Our dep bumping jobs appear to be getting killed, and I am still troubleshooting that. But there is no reason to install documentation for these gems when our goal is to update the `Gemfile.lock`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
