### PR TITLE
Update the list of Kitchen Drivers

### DIFF
--- a/www/content/workstation/config_yml_kitchen.md
+++ b/www/content/workstation/config_yml_kitchen.md
@@ -542,8 +542,7 @@ provisioner:
 The following example shows platform settings for the Microsoft Windows
 platform:
 
-### ``` yaml
-
+``` yaml
 platforms:
   - name: eval-win2012r2-standard
     os_type: windows
@@ -687,7 +686,7 @@ back-end server, and two add-ons (Chef Push Jobs and Chef management
 console). The `platforms` block uses an `attributes` section to define
 Chef server-specific attributes that are used by all three test suites:
 
-## ``` yaml
+``` yaml
 driver:
   name: vagrant
 
@@ -758,7 +757,7 @@ Test-Kitchen can handle reboots (when initiated from Chef Infra Client)
 by setting `retry_on_exit_code`, `max_retries` and `wait_for_retry`
 attributes on the provisioner in `kitchen.yml` file as follows :
 
-## ``` yaml
+``` yaml
 provisioner:
    name: chef_zero
    retry_on_exit_code:
@@ -770,11 +769,11 @@ provisioner:
      client_fork: false  # Forked instances don't return the real exit code
 ```
 
-**One note on linux nodes**: The shutdown command blocks (as opposed to
+**One note on Linux nodes**: The shutdown command blocks (as opposed to
 the windows variant which registers the reboot and returns right away),
 so once the timeout period passes, Chef Infra Client and the node are in
 a race to see who can exit/shutdown first - so you may or may not get
-the exit code out of linux instances. In that case, you can add `1` to
+the exit code out of Linux instances. In that case, you can add `1` to
 the `retry_on_exit_code` array and that should catch both cases.
 
 Please refer [YAML

--- a/www/content/workstation/config_yml_kitchen.md
+++ b/www/content/workstation/config_yml_kitchen.md
@@ -770,7 +770,7 @@ provisioner:
 ```
 
 **One note on Linux nodes**: The shutdown command blocks (as opposed to
-the windows variant which registers the reboot and returns right away),
+the Windows variant which registers the reboot and returns right away),
 so once the timeout period passes, Chef Infra Client and the node are in
 a race to see who can exit/shutdown first - so you may or may not get
 the exit code out of Linux instances. In that case, you can add `1` to

--- a/www/content/workstation/config_yml_kitchen.md
+++ b/www/content/workstation/config_yml_kitchen.md
@@ -32,7 +32,7 @@ data across any combination of platforms and test suites:
 
 This topic details functionality that is packaged with Chef Workstation.
 See <https://kitchen.ci/docs/getting-started/> for more information
-about Kitchen.
+about Test Kitchen.
 
 {{< /note >}}
 

--- a/www/layouts/shortcodes/ws_test_kitchen_drivers.md
+++ b/www/layouts/shortcodes/ws_test_kitchen_drivers.md
@@ -11,8 +11,6 @@ hypervisors, such as VMware, Hyper-V, or VirtualBox.
 
 Chef Workstation includes many common Test Kitchen drivers.
 
-
-
 </div>
 
 </div>
@@ -38,44 +36,48 @@ Some popular drivers:
 </thead>
 <tbody>
 <tr class="odd">
+<td><a href="https://github.com/test-kitchen/kitchen-azurerm">kitchen-azurerm</a></td>
+<td>A driver for Microsoft Azure.</td>
+</tr>
+<tr class="even">
 <td><a href="https://github.com/test-kitchen/kitchen-cloudstack">kitchen-cloudstack</a></td>
 <td>A driver for CloudStack.</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="https://github.com/test-kitchen/kitchen-digitalocean">kitchen-digitalocean</a></td>
-<td>A driver for DigitalOcean.</td>
+<td>A driver for DigitalOcean. This driver ships in Chef Workstation.</td>
+</tr>
+<tr class="even">
+<td><a href="https://github.com/test-kitchen/kitchen-dokken">kitchen-dokken</a></td>
+<td>A driver for Docker. This driver ships in Chef Workstation.</td>
 </tr>
 <tr class="odd">
-<td><a href="https://github.com/portertech/kitchen-docker">kitchen-docker</a></td>
-<td>A driver for Docker.</td>
-</tr>
-<tr class="even">
 <td><a href="https://github.com/test-kitchen/kitchen-dsc">kitchen-dsc</a></td>
 <td>A driver for Windows PowerShell Desired State Configuration (DSC).</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="https://github.com/test-kitchen/kitchen-ec2">kitchen-ec2</a></td>
 <td>A driver for Amazon EC2. This driver ships in Chef Workstation.</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="https://github.com/test-kitchen/kitchen-google">kitchen-google</a></td>
 <td>A driver for Google Compute Engine. This driver ships in Chef Workstation</td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><a href="https://github.com/test-kitchen/kitchen-hyperv">kitchen-hyperv</a></td>
-<td>A driver for Hyper-V Server.</td>
+<td>A driver for Microsoft Hyper-V Server. This driver ships in Chef Workstation.</td>
+</tr>
+<tr class="odd">
+<td><a href="https://github.com/test-kitchen/kitchen-openstack">kitchen-openstack</a></td>
+<td>A driver for OpenStack. This driver ships in Chef Workstation.</td>
 </tr>
 <tr class="even">
-<td><a href="https://github.com/test-kitchen/kitchen-openstack">kitchen-openstack</a></td>
-<td>A driver for OpenStack.</td>
-</tr>
-<tr class="odd">
 <td><a href="https://github.com/test-kitchen/kitchen-rackspace">kitchen-rackspace</a></td>
 <td>A driver for Rackspace.</td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><a href="https://github.com/test-kitchen/kitchen-vagrant">kitchen-vagrant</a></td>
-<td>A driver for Vagrant. This driver ships in Chef Workstation.</td>
+<td>A driver for HashiCorp Vagrant. This driver ships in Chef Workstation.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Make sure we don't mention kitchen-docker anymore, add dokken and azure
and make sure we note which ones are in Workstation.

Signed-off-by: Tim Smith <tsmith@chef.io>