### PR TITLE
'analyze' is now 'report'

### DIFF
--- a/components/main-chef-wrapper/dist/global.go
+++ b/components/main-chef-wrapper/dist/global.go
@@ -11,6 +11,7 @@ const (
 	AnalyzeExec        = "chef-analyze"
 	ApplyExec          = "chef-apply"
 	AutomateProduct    = "Chef Automate"
+	CLIWrapperExec     = "chef"
 	ClientExec         = "chef-client"
 	ClientProduct      = "Chef Infra Client"
 	CompanyName        = "Chef Software"

--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -40,16 +40,8 @@ func main() {
 	switch subCommand {
 	case "report", "capture":
 		if featflag.ChefFeatAnalyze.Enabled() {
-			// A little special-casing with this - the 'upload' command is a hidden top-level command
-			// in the chef-analyze binary. However, we're exposing it as a subcommand of  'report'.
-			// We'll need to explicitly invoke it as a top-level command of the chef-analyze binary.
 
-			if len(os.Args) > 2 && subCommand == "report" && os.Args[2] == "upload" {
-				cmd = exec.Command(dist.AnalyzeExec, os.Args[2:]...)
-			} else {
-
-				cmd = exec.Command(dist.AnalyzeExec, allArgs...)
-			}
+			cmd = exec.Command(dist.AnalyzeExec, allArgs...)
 
 		} else {
 			fmt.Printf("`%s` is experimental and in development.\n\n", featflag.ChefFeatAnalyze.Key())

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,7 @@
 # Expeditor takes that version, runs a script to replace it here and pushes a new
 # commit / build through.
 
-override "chef-analyze", version: "0.1.85"
+override "chef-analyze", version: "0.1.86"
 override "delivery-cli", version: "0.0.54"
 override "chef-workstation-app", version: "v0.1.78"
 # /DO NOT MODIFY


### PR DESCRIPTION
This makes the top-level command used for analyze features
of 'report' and 'capture' route under the command 'report':

These are now valid:

chef report nodes (chef-analyze report nodes)
chef report cookbooks (chef-analyze report cookbooks)
chef report upload  (chef-analyze upload)
chef report session (chef-analyze session)
chef capture (chef-analyze capture)

Note that there are corresponding branches of the
same name in chef-analyze and go-libs. These will need to merge
before this branch.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
