### PR TITLE
chef-sugar helpers are now in chef-utils

### DIFF
--- a/omnibus/verification/spec/unit/verify_spec.rb
+++ b/omnibus/verification/spec/unit/verify_spec.rb
@@ -50,7 +50,6 @@ describe ChefWorkstation::Command::Verify do
       "package installation",
       "openssl",
       "inspec",
-      "chef-sugar",
       "opscode-pushy-client",
       "git",
       "delivery-cli",

--- a/omnibus/verification/verify.rb
+++ b/omnibus/verification/verify.rb
@@ -408,24 +408,6 @@ module ChefWorkstation
         end
       end
 
-      # We try and use some chef-sugar code to make sure it loads correctly
-      add_component "chef-sugar" do |c|
-        c.gem_base_dir = "chef-sugar"
-        c.smoke_test do
-          tmpdir do |cwd|
-            with_file(File.join(cwd, "foo.rb")) do |f|
-              f.write <<~EOF
-                require 'chef/sugar'
-                log 'something' do
-                  not_if  { _64_bit? }
-                end
-              EOF
-            end
-            sh("#{bin("chef-apply")} foo.rb", cwd: cwd)
-          end
-        end
-      end
-
       attr_reader :verification_threads
       attr_reader :verification_results
       attr_reader :verification_status


### PR DESCRIPTION
chef-utils (from chef/chef/chef-utils) is included as part of core chef
now and includes most of the helpers that used to be separately shipped
in the chef-sugar library. We no longer ship the chef-sugar library and
thus no longer need to test it.
