### PR TITLE
unsubscribe to dep updates to prevent dual PRs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -80,16 +80,6 @@ subscriptions:
       # publish to third party package managers that have a dependency
       # on this artifact's availability
       - trigger_pipeline:third-party-packages
-
-  - workload: chef/chef-workstation-app:master_completed:pull_request_merged:chef/chef-workstation-app:master:*
-    actions:
-      - bash:.expeditor/update_chef-workstation-app_to_latest.sh
-  - workload: chef/delivery-cli:master_completed:pull_request_merged:chef/delivery-cli:master:*
-    actions:
-      - bash:.expeditor/update_delivery-cli_to_latest.sh
-  - workload: chef/chef-analyze:master_completed:pull_request_merged:chef/chef-analyze:master:*
-    actions:
-      - bash:.expeditor/update_chef-analyze_to_latest.sh
   - workload: artifact_published:stable:chef:15*
     actions:
       # update our pinned version for chef/chef-bin in Gemfile

--- a/omnibus/verification/verify.rb
+++ b/omnibus/verification/verify.rb
@@ -194,10 +194,10 @@ module ChefWorkstation
 
       add_component "chef-apply" do |c|
         c.gem_base_dir = "chef-apply"
-      #   c.unit_test do
-      #     bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
-      #     sh("#{embedded_bin("bundle")} exec rspec")
-      #   end
+        # c.unit_test do
+        #   bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
+        #   sh("#{embedded_bin("bundle")} exec rspec")
+        # end
         c.smoke_test { sh("#{bin("chef-run")} -v", env: { "CHEF_TELEMETRY_OPT_OUT" => "true" }) }
       end
 


### PR DESCRIPTION
## Description
Prevents things like https://github.com/chef/chef-workstation/pull/1174
that try to merge cw-18 to master.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
