### PR TITLE
Fixing indentation issue on third-party-package pipeline

### DIFF
--- a/.expeditor/create_pr_for_homebrew.sh
+++ b/.expeditor/create_pr_for_homebrew.sh
@@ -5,12 +5,14 @@
 
 set -ex
 echo "--- Getting chef/homebrew-cask repository and updating latest from upstream Homebrew/homebrew-casks"
-git clone git@github.com:/chef/homebrew-cask
+git clone git@github.com:/chef/homebrew-cask-autotesting homebrew-cask
+#git clone git@github.com:/chef/homebrew-cask
 cd homebrew-cask
 git config user.email "expeditor@chef.io"
 git config user.name "Chef Expeditor"
 
-git remote add upstream git@github.com:/Homebrew/homebrew-cask
+#git remote add upstream git@github.com:/Homebrew/homebrew-cask
+git remote add upstream git@github.com:/marcparadise/homebrew-cask-autotesting
 git fetch --all
 # Reset the chef/homebrew-cask fork to the upstream so we are always
 # making a PR off their master
@@ -55,8 +57,11 @@ echo "Updating sha to $SHA"
 
 sed -i -r "s/(sha256\s*'.+')/sha256 '$SHA'/g" Casks/chef-workstation.rb
 
-echo "--- Debug: Delta follows"
+echo "--- Debug: git diff follows"
 git diff
+
+echo "git status follows:"
+git status
 
 echo "-- Verifying Cask"
 echo Running style fixes "brew cask style --fix"
@@ -80,6 +85,8 @@ EOB
 )
 
 echo "-- Committing change and opening PR"
+git status
+
 git add ./Casks/chef-workstation.rb
 git commit --message "$BODY"
 

--- a/.expeditor/create_pr_for_homebrew.sh
+++ b/.expeditor/create_pr_for_homebrew.sh
@@ -93,16 +93,15 @@ git commit --message "$COMMIT_BODY"
 
 echo "--- Opening PR"
 
-git push "https://x-access-token:${CHEF_CI_GITHUB_AUTH_TOKEN}@github.com/${FORK_OWNER}/${REPO_NAME}.git" "$BRANCH" --force;
+git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${FORK_OWNER}/${REPO_NAME}.git" "$BRANCH" --force;
 # | grep 201 so that we'll exit non-zero unless we receive 201: Created response code.
 result=$(curl --silent --header "Authorization: token $CHEF_CI_GITHUB_AUTH_TOKEN" \
-  --data "{\"title\":\"$TITLE\",\"head\":\"$FORK_OWNER:$BRANCH\",\"base\":\"master\",\"maintainer_can_modify\":true,\"body\":\"$BODY\"}" \
+  --data-binary "{\"title\":\"$TITLE\",\"head\":\"chef:$BRANCH\",\"base\":\"master\",\"maintainer_can_modify\":true}" \
   -XPOST "https://api.github.com/repos/${UPSTREAM_OWNER}/${REPO_NAME}/pulls" \
-  --write-out "%{http_code}")
+  --write-out "Response:%{http_code}")
 
-# More debug goodness...
 echo "$result"
 
-# Fail the build if we didn't get a successfull response code
-echo "$result" | grep "201"
+# Fail the run if 201 (created) response not received.
+echo "$result" | grep "Response:201"
 

--- a/.expeditor/create_pr_for_homebrew.sh
+++ b/.expeditor/create_pr_for_homebrew.sh
@@ -94,7 +94,8 @@ git commit --message "$COMMIT_BODY"
 echo "--- Opening PR"
 
 git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${FORK_OWNER}/${REPO_NAME}.git" "$BRANCH" --force;
-# | grep 201 so that we'll exit non-zero unless we receive 201: Created response code.
+# TODO: we need to include the `body` above, but need to figure out proper encoding to preserve newlines
+#       in the string in a way that doesn't cause the server to reject it...
 result=$(curl --silent --header "Authorization: token $CHEF_CI_GITHUB_AUTH_TOKEN" \
   --data-binary "{\"title\":\"$TITLE\",\"head\":\"chef:$BRANCH\",\"base\":\"master\",\"maintainer_can_modify\":true}" \
   -XPOST "https://api.github.com/repos/${UPSTREAM_OWNER}/${REPO_NAME}/pulls" \

--- a/.expeditor/create_pr_for_homebrew.sh
+++ b/.expeditor/create_pr_for_homebrew.sh
@@ -93,9 +93,9 @@ git commit --message "$COMMIT_BODY"
 
 echo "--- Opening PR"
 
-git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${FORK_OWNER}/${REPO_NAME}.git" "$BRANCH" --force;
+git push "https://x-access-token:${CHEF_CI_GITHUB_AUTH_TOKEN}@github.com/${FORK_OWNER}/${REPO_NAME}.git" "$BRANCH" --force;
 # | grep 201 so that we'll exit non-zero unless we receive 201: Created response code.
-result=$(curl --silent --header "Authorization: token $GITHUB_TOKEN" \
+result=$(curl --silent --header "Authorization: token $CHEF_CI_GITHUB_AUTH_TOKEN" \
   --data "{\"title\":\"$TITLE\",\"head\":\"$FORK_OWNER:$BRANCH\",\"base\":\"master\",\"maintainer_can_modify\":true,\"body\":\"$BODY\"}" \
   -XPOST "https://api.github.com/repos/${UPSTREAM_OWNER}/${REPO_NAME}/pulls" \
   --write-out "%{http_code}")

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -22,9 +22,6 @@ steps:
         GITHUB_TOKEN:
           account: github/chef
           field: token
-    executor:
-      docker:
-         image: homebrew/brew
-
-
-
+      executor:
+        docker:
+          image: homebrew/brew

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -6,6 +6,9 @@ steps:
       accounts:
         - github/chef
       secrets:
+        CHEF_CI_GITHUB_AUTH_TOKEN:
+          path: account/static/github/chef-ci
+          field: token
         GITHUB_TOKEN:
           account: github/chef
           field: token

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -23,5 +23,4 @@ steps:
           account: github/chef
           field: token
       executor:
-        docker:
-          image: homebrew/brew
+        macos:

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: ":mac_os_x: :github: Create PR to update Homebrew/homebrew-cask"
+  - label: ":mac: :github: Create PR to update Homebrew/homebrew-cask"
     command:
       - bash .expeditor/create_pr_for_homebrew.sh
     expeditor:

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -1,17 +1,4 @@
 steps:
-  - label: ":chocolate_bar: Publish Chocolatey package"
-    command:
-      - powershell .expeditor/publish_to_chocolatey.ps1
-    expeditor:
-      secrets:
-        CHOCO_API_KEY:
-          path: account/static/chocolatey/chef-ci
-          field: api_key
-      executor:
-        docker:
-          host_os: windows
-          environment:
-
   - label: ":mac_os_x: :github: Create PR to update Homebrew/homebrew-cask"
     command:
       - bash .expeditor/create_pr_for_homebrew.sh


### PR DESCRIPTION
## Description
Error from buildkite:
```
2020-05-14 16:38:51 WARN   POST https://agent.buildkite.com/v3/jobs/b94f1321-bd21-465c-adf8-bee6fe85de54/pipelines: 422 `executor` is not a valid property on the `command` step. Please check the documentation to get a full list of supported properties. (Attempt 1/60 Retrying in 5s)
--
  | 2020-05-14 16:38:51 ERROR  Unrecoverable error, skipping retries
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
