### PR TITLE
Fixing indentation issue on third-party-package pipeline

### DIFF
--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -22,9 +22,6 @@ steps:
         GITHUB_TOKEN:
           account: github/chef
           field: token
-    executor:
-      docker:
-         image: homebrew/brew
-
-
-
+      executor:
+        docker:
+          image: homebrew/brew


### PR DESCRIPTION
## Description
Error from buildkite:
```
2020-05-14 16:38:51 WARN   POST https://agent.buildkite.com/v3/jobs/b94f1321-bd21-465c-adf8-bee6fe85de54/pipelines: 422 `executor` is not a valid property on the `command` step. Please check the documentation to get a full list of supported properties. (Attempt 1/60 Retrying in 5s)
--
  | 2020-05-14 16:38:51 ERROR  Unrecoverable error, skipping retries
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
