### PR TITLE
Ensure help, -h, and --help behave the same

### DIFF
--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -51,6 +51,9 @@ func main() {
 			fmt.Printf("\t[features]\n\t%s = true\n", featflag.ChefFeatAnalyze.Key())
 			os.Exit(0)
 		}
+	case "help", "-h", "--help":
+		usage()
+		os.Exit(0)
 
 	// We want to pass every sub-command to the old 'chef' CLI binary that was renamed to
 	// 'chef-cli`, which is our default case.


### PR DESCRIPTION
These should all go the same path as the no-argument
route, displaying local help through usage() and exiting 0.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
