### PR TITLE
Push a git tag after a VERSION change

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -44,6 +44,9 @@ merge_actions:
         - "Expeditor: Skip Omnibus"
         - "Expeditor: Skip All"
       only_if: bash:.expeditor/determine_version.sh
+  - bash:.expeditor/push-git-tag.sh:
+      only_if: bash:.expeditor/determine_version.sh
+      post_commit: true
 
 pipelines:
   - verify:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,6 +30,7 @@ github:
 # https://expeditor.chef.io/docs/getting-started/subscriptions/#merge-actions
 # The `merge_actions` key is a shortcut for the
 # `pull_request_merged:<GITHUB_REPO>:<RELEASE_BRANCH>:*` subscription.
+#
 merge_actions:
   - bash:.expeditor/determine_version.sh:
       ignore_labels:
@@ -39,14 +40,15 @@ merge_actions:
       ignore_labels:
         - "Expeditor: Skip Changelog"
         - "Expeditor: Skip All"
+  # The git commit happens here
+  - bash:.expeditor/push-git-tag.sh:
+      only_if: bash:.expeditor/determine_version.sh
+      post_commit: true
   - trigger_pipeline:omnibus/release:
       ignore_labels:
         - "Expeditor: Skip Omnibus"
         - "Expeditor: Skip All"
       only_if: bash:.expeditor/determine_version.sh
-  - bash:.expeditor/push-git-tag.sh:
-      only_if: bash:.expeditor/determine_version.sh
-      post_commit: true
 
 pipelines:
   - verify:

--- a/.expeditor/push-git-tag.sh
+++ b/.expeditor/push-git-tag.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This gets run as a post-commit hook after merge to add the version tag so it
+# is easy to determine what changes are in a particular build.
+#
+# https://expeditor.chef.io/docs/reference/action-filters/#post-commit
+
+
+VERSION=`cat VERSION`
+
+git tag $VERSION
+git push origin $VERSION


### PR DESCRIPTION
Normally expeditor does a 'git tag' for us when we use
'built_in:bump_version' but in this case we are doing the version bump
on our own since sometimes we do a major/minor bump based on the the
date.
