### PR TITLE
Remove Upgrade Lab feature flag from usage and config docs

### DIFF
--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 
 	"github.com/chef/chef-workstation/components/main-chef-wrapper/dist"
-	"github.com/chef/go-libs/featflag"
 )
 
 func main() {
@@ -39,18 +38,8 @@ func main() {
 
 	switch subCommand {
 	case "report", "capture":
-		if featflag.ChefFeatAnalyze.Enabled() {
+		cmd = exec.Command(dist.AnalyzeExec, allArgs...)
 
-			cmd = exec.Command(dist.AnalyzeExec, allArgs...)
-
-		} else {
-			fmt.Printf("`%s` is experimental and in development.\n\n", featflag.ChefFeatAnalyze.Key())
-			fmt.Printf("Temporarily enable `%s` with the environment variable:\n", featflag.ChefFeatAnalyze.Key())
-			fmt.Printf("\t%s=true\n\n", featflag.ChefFeatAnalyze.Env())
-			fmt.Printf("Or, permanently by modifying $HOME/.chef-workstation/config.toml with:\n")
-			fmt.Printf("\t[features]\n\t%s = true\n", featflag.ChefFeatAnalyze.Key())
-			os.Exit(0)
-		}
 	case "help", "-h", "--help":
 		usage()
 		os.Exit(0)
@@ -111,16 +100,9 @@ Available Commands:
     delete-policy           Delete all revisions of a policy on the Chef Infra Server
     undelete                Undo a delete command
     describe-cookbook       Prints cookbook checksum information used for cookbook identifier
-`
-
-	if featflag.ChefFeatAnalyze.Enabled() {
-		// add the experimental section to the usage message
-		msg = msg + `
-Experimental Commands:
     report                  Report on the state of existing infrastructure from a Chef Infra Server
     capture                 Copy the state of an existing node locally for testing and verification
 `
-	}
 	fmt.Printf(msg)
 }
 

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,9 +4,9 @@
 # Expeditor takes that version, runs a script to replace it here and pushes a new
 # commit / build through.
 
-override "chef-analyze", version: "0.1.89"
+override "chef-analyze", version: "0.1.90"
 override "delivery-cli", version: "0.0.54"
-override "chef-workstation-app", version: "v0.1.78"
+override "chef-workstation-app", version: "v0.1.79"
 # /DO NOT MODIFY
 
 override "libarchive", version: "3.4.2"

--- a/www/content/workstation/config.md
+++ b/www/content/workstation/config.md
@@ -397,7 +397,7 @@ example = true
 ```
 
 Description
-: List of experimental features. Features are not enabled by default. Enable the feature with `name = true` and disable with `name = false`. The above example enables one feature, which is the `example` feature (there are currently no actual features that can be controlled in this manner). You can also enable or disable any feature from the command line using an environment variable. For example, setting `CHEF_FEAT_EXAMPLE=true` from the command line enables the `example` feature for the duration of your terminal session.
+: List of experimental features. Boolean. Default: none. Enable the feature with `feature = true` and disable with `feature = false`.  `example = true` enables one feature, which is the `example` feature. You can also enable or disable any feature from the command line using an environment variable. For example, setting `CHEF_FEAT_EXAMPLE=true` from the command line enables the `example` feature for the duration of your terminal session.
 
 Values
 : `name = true`, `name = false`

--- a/www/content/workstation/config.md
+++ b/www/content/workstation/config.md
@@ -393,11 +393,11 @@ Enable and disable experimental features for Chef Workstation.
 
 ```toml
 [features]
-analyze = true
+example = true
 ```
 
 Description
-: List of experimental features. Features are not enabled by default. Enable the feature with `name = true` and disable with `name = false`. The above example enables one feature, which is the `analyze` feature. You can also enable or disable any feature from the command line using an environment variable. For example, setting `CHEF_FEAT_ANALYZE=true` from the command line enables the `analyze` feature for the duration of your terminal session.
+: List of experimental features. Features are not enabled by default. Enable the feature with `name = true` and disable with `name = false`. The above example enables one feature, which is the `example` feature (there are currently no actual features that can be controlled in this manner). You can also enable or disable any feature from the command line using an environment variable. For example, setting `CHEF_FEAT_EXAMPLE=true` from the command line enables the `example` feature for the duration of your terminal session.
 
 Values
 : `name = true`, `name = false`


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Remove the "Experimental" section from the usage output of the main CLI wrapper, merging its contents with the rest of the usage.

Makes `report` and `capture` commands available without the feature flag.

Also updates the config docs to remove mention of the `analyze` setting, while leaving docs in place for the feature flags mechanism in general.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Partially implements #1135 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
