### PR TITLE
Update cookstyle to 6.7

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -27,7 +27,7 @@ group(:omnibus_package, :development, :test) do
   gem "pry"
   gem "yard"
   gem "guard"
-  gem "cookstyle", "~> 6.0"
+  gem "cookstyle", "~> 6.7"
   gem "foodcritic", ">= 16.2"
   gem "ffi-libarchive"
 end

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -339,8 +339,8 @@ GEM
       chef-cli
       fauxhai-ng (>= 7.5)
       rspec (~> 3.0)
-    chefstyle (1.0.5)
-      rubocop (= 0.83.0)
+    chefstyle (1.1.0)
+      rubocop (= 0.85.0)
     citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.3)
@@ -349,8 +349,8 @@ GEM
     concurrent-ruby (1.1.6)
     cookbook-omnifetch (0.9.1)
       mixlib-archive (>= 0.4, < 2.0)
-    cookstyle (6.6.9)
-      rubocop (= 0.83.0)
+    cookstyle (6.7.3)
+      rubocop (= 0.85.0)
     cucumber-core (3.2.1)
       backports (>= 3.8.0)
       cucumber-tag_expressions (~> 1.1.0)
@@ -771,13 +771,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.83.0)
+    rubocop (0.85.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
       rexml
+      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
     ruby-prof (1.4.1)
     ruby-prof (1.4.1-x64-mingw32)
     ruby-progressbar (1.10.1)
@@ -1040,7 +1044,7 @@ DEPENDENCIES
   cheffish (>= 15.0.0)
   chefspec (>= 9.0.0, < 10.0)
   chefstyle
-  cookstyle (~> 6.0)
+  cookstyle (~> 6.7)
   dep-selector-libgecode
   dep_selector
   docker-api

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,7 @@
 # Expeditor takes that version, runs a script to replace it here and pushes a new
 # commit / build through.
 
-override "chef-analyze", version: "0.1.95"
+override "chef-analyze", version: "0.1.97"
 override "delivery-cli", version: "0.0.54"
 override "chef-workstation-app", version: "v0.1.79"
 # /DO NOT MODIFY


### PR DESCRIPTION
This bumps the RuboCop engine from 0.83 -> 0.85 with a large number of
autocorrection bug fixes and it also includes a critical new cop for
detecting a major breaking change in Chef 16.

Signed-off-by: Tim Smith <tsmith@chef.io>