### PR TITLE
Upgrade groups in appbundling and avoid double minitest

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,9 +21,9 @@ group(:omnibus_package, :development, :test) do
   # Require a minimum version that is packaged in the Ruby install, so we do
   # not install old unecessary versions. When we bump Ruby we need to look
   # at these pins and adjust them.
-  gem "rake", ">= 13.0.1"
-  gem "minitest", ">= 5.13.0"
+  gem "minitest", "= 5.13.0"
 
+  gem "rake", ">= 13.0.1"
   gem "pry"
   gem "yard"
   gem "guard"

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     aws-sdk-dynamodb (1.49.1)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-ec2 (1.168.0)
+    aws-sdk-ec2 (1.169.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.31.1)
@@ -125,7 +125,7 @@ GEM
     aws-sdk-organizations (1.17.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-rds (1.87.0)
+    aws-sdk-rds (1.88.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-redshift (1.44.1)
@@ -140,7 +140,7 @@ GEM
     aws-sdk-route53resolver (1.15.1)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.69.0)
+    aws-sdk-s3 (1.69.1)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -156,7 +156,7 @@ GEM
     aws-sdk-sns (1.25.1)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.27.1)
+    aws-sdk-sqs (1.28.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ssm (1.82.0)
@@ -627,7 +627,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitar (0.9)
-    minitest (5.14.1)
+    minitest (5.13.0)
     mixlib-archive (1.0.5)
       mixlib-log
     mixlib-archive (1.0.5-universal-mingw32)
@@ -1076,7 +1076,7 @@ DEPENDENCIES
   knife-windows (>= 3.0.11)
   listen
   mdl (>= 0.7.0)
-  minitest (>= 5.13.0)
+  minitest (= 5.13.0)
   mixlib-archive (>= 1.0)
   mixlib-install
   mixlib-versioning

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.34.1)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.69.0)
+    aws-sdk-s3 (1.69.1)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -98,11 +98,11 @@ build do
   appbundle "chef", lockdir: project_dir, gem: "chef", without: %w{docgen chefstyle omnibus_package}, env: env
 
   appbundle "foodcritic", lockdir: project_dir, gem: "foodcritic", without: %w{development test}, env: env
-  appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs development}, env: env
+  appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs development integration}, env: env
   appbundle "inspec", lockdir: project_dir, gem: "inspec-bin", without: %w{deploy tools maintenance integration}, env: env
   appbundle "chef-run", lockdir: project_dir, gem: "chef-apply", without: %w{changelog docs debug}, env: env
   appbundle "chef-cli", lockdir: project_dir, gem: "chef-cli", without: %w{changelog docs debug}, env: env
-  appbundle "berkshelf", lockdir: project_dir, gem: "berkshelf", without: %w{changelog docs debug development}, env: env
+  appbundle "berkshelf", lockdir: project_dir, gem: "berkshelf", without: %w{changelog build docs debug development}, env: env
 
   # Note - 'chef-apply' gem provides 'chef-run', not 'chef-apply' which ships with chef-bin...
   %w{chef-bin chef-apply chef-vault ohai opscode-pushy-client cookstyle}.each do |gem|


### PR DESCRIPTION
Pin minitest to 5.13 to avoid the warnings that 5.13 and 5.14.1 has been activated. Due to how we handle gems we need to make sure we avoid this.