### PR TITLE
Add the habitat binary to the Workstation package

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -71,6 +71,9 @@ subscriptions:
       # on this artifact's availability
       - trigger_pipeline:third-party-packages
 
+  - workload: habitat-sh/habitat:master_completed:project_promoted:habitat-sh/habitat:master:stable:*
+    actions:
+      - bash:.expeditor/update_habitat.sh
   - workload: chef/chef-workstation-app:master_completed:pull_request_merged:chef/chef-workstation-app:master:*
     actions:
       - bash:.expeditor/update_chef-workstation-app_to_latest.sh

--- a/.expeditor/update_habitat.sh
+++ b/.expeditor/update_habitat.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#
+# Copyright:: Copyright (c) 2020 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################################
+# What is this script?
+#
+# Chef Workstation uses Expeditor (internal CI bot) to manage the bundled
+# version of the the Chef Habitat CLI. This script will be run by Expeditor
+# when a new version of habitat is published to the stable channel, to ensure that
+# Workstation is updated to and validated with the most recent stable version of
+# Chef Habitat.
+############################################################################
+
+set -evx
+
+BASE_URL="http://packages.chef.io/files/stable/habitat/latest"
+winsha=$(curl "$BASE_URL/hab-x86_64-windows.zip.sha256sum" --silent | cut -d ' ' -f 1)
+darwinsha=$(curl "$BASE_URL/hab-x86_64-darwin.zip.sha256sum" --silent | cut -d ' ' -f 1)
+linsha=$(curl "$BASE_URL/hab-x86_64-linux.tar.gz.sha256sum" --silent | cut -d ' ' -f 1)
+sw_def_file="omnibus/config/software/habitat.rb"
+
+MANIFEST_URL="$BASE_URL/manifest.json"
+MANIFEST=$(curl --silent "$MANIFEST_URL")
+version=$(jq -r '.version'<<< "$MANIFEST")
+
+sed -i -r "s/windows_sha= .*/windows_sha = \"$winsha\"/" $sw_def_file
+sed -i -r "s/linux_sha= .*/linux_sha = \"$linsha\"/" $sw_def_file
+sed -i -r "s/darwin_sha = .*/darwin_sha = \"$darwinsha\"/" $sw_def_file
+sed -i -r "s/^version \".*/version \"$version\"/" $sw_def_file
+
+branch="expeditor/hab-${version}"
+git checkout -b "$branch"
+git add $sw_def_file
+git commit --message "Bump habitat to $version." --message "This pull request was triggered automatically via Expeditor when habitat v. $version was merged to master." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+open_pull_request
+
+# Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
+git checkout -
+git branch -D "$branch"
+

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -48,6 +48,8 @@ instance_eval(IO.read(overrides_path), overrides_path)
 
 dependency "preparation"
 
+dependency "habitat"
+
 if windows?
   dependency "git-windows"
 else

--- a/omnibus/config/software/habitat.rb
+++ b/omnibus/config/software/habitat.rb
@@ -1,0 +1,57 @@
+#
+# Copyright:: Copyright (c) 2020 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "habitat"
+default_version "latest"
+license :project_license
+skip_transitive_dependency_licensing true
+
+# DO NOT MODIFY: version and checksums are populated by workstation/.expeditor/update_habitat.sh
+version "1.6.56"
+linux_sha = "a87f4ff7558f23724289e2c5a9b75920da364818167f63b26411be5a8b344800"
+darwin_sha = "42b6c417b88351e0b8ce99cb6ebcc104bbb5bc819ffc795f980d1201068035e6"
+windows_sha = "648157f1db680233b676725d3142ef118e5a77da000209a532fb54ff153b57dd"
+# END DO NOT MODIFY
+
+if windows?
+  suffix = "windows.zip"
+  sha256 = windows_sha
+elsif linux?
+  suffix = "linux.tar.gz"
+  sha256 = linux_sha
+elsif mac?
+  suffix = "darwin.zip"
+  sha256 = darwin_sha
+else
+  raise "habitat dep is only available for windows, linux, and mac"
+end
+
+source url: "https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-#{suffix}",
+  sha256: sha256
+
+build do
+  # 'block' is needed to prevent evaluating the ruby code
+  # before the project_dir contains the extracted package.
+  block "Relocating habitat" do
+    dest = File.join(install_dir, "bin")
+    # We don't just copy the bin itself because on Windows additional
+    # supporting DLLs are included.
+    Dir.glob("#{project_dir}/hab-*/*").each do |f|
+      copy f, dest
+    end
+  end
+end

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -26,15 +26,19 @@ git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 
 $Env:CHEF_LICENSE = "accept-no-persist"
+$Env:HAB_LICENSE = "accept-no-persist"
 
-Write-Output "--- Ensure the 'chef' cli works (chef env)"
+Write-Output "--- Verifying commands"
+Write-Output " * chef env"
 chef env
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-Write-Output "--- Ensure the 'chef-analyze' cli works (chef-analyze help)"
-# TODO @afiune delete this when we release chef-analyze to the users.
-$Env:CHEF_FEAT_ANALYZE = "true"
-chef-analyze help
+Write-Output " * chef report"
+chef report help
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+Write-Output " * hab help"
+hab help
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "--- Run the verification suite"

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -37,13 +37,17 @@ git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 
 export CHEF_LICENSE="accept-no-persist"
+export HAB_LICENSE="accept-no-persist"
 
 echo "--- Ensure the 'chef' cli works (chef env)"
 chef env
 
-echo "--- Ensure the 'chef-analyze' cli works (chef-analyze help)"
-# TODO @afiune delete this when we release chef-analyze to the users.
-CHEF_FEAT_ANALYZE="true" chef-analyze help
+echo "--- Ensure the 'chef report' subcommand cli works (chef report help)"
+chef report help
+
+echo "--- Ensure that 'hab' cli is avaliable"
+hab help
+
 
 # Verify that the chef-workstation-app was installed (MacOS only)
 if is_darwin; then

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -1,4 +1,22 @@
 #!/bin/sh
+
+#
+# Copyright:: Copyright (c) 2020 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #
 # Perform necessary setup steps
 # after package is installed.
@@ -25,8 +43,41 @@ else
     PREFIX="/usr"
 fi
 
-binaries="chef-run berks chef chef-cli chef-analyze chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
 
+hab_target_path="$PREFIX/bin/hab"
+if [ -L "$hab_target_path" ]; then
+  # If the link exists, always remove it because we replace it later in script anyway.
+  loc=$(readlink "$hab_target_path")
+  case $loc in
+    *chef-workstation*)
+      # We own this path, so we're not taking it over from another install.
+      ;;
+    *)
+      takeover="1"
+  esac
+elif [ -f "$hab_target_path" ]; then
+  # Preserve the original target path
+  mv "$hab_target_path" "$hab_target_path.orig"
+  takeover="1"
+  moved="1"
+fi
+
+if [ "$takeover" = "1" ]; then
+  echo ""
+  echo "NOTE: Chef Habitat on this node is now managed by Chef Workstation."
+  echo "      Future Workstation updates will always include the latest stable"
+  echo "      Habitat release."
+  echo ""
+fi
+
+if [ "$moved" = "1" ]; then
+  echo "      Original habitat binary has been moved to '$hab_target_path.orig'"
+  echo ""
+fi
+
+
+
+binaries="chef-run berks chef chef-cli chef-analyze chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client hab"
 for binary in $binaries; do
   ln -sf "$INSTALLER_DIR/bin/$binary" $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"
 done
@@ -85,6 +136,6 @@ fi
 
 echo ""
 echo "Thank you for installing Chef Workstation!"
-echo "You can find some tips on getting started at https://chef.sh/"
+echo "You can find some tips on getting started at https://docs.chef.io/workstation/"
 echo ""
 exit 0

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -13,7 +13,7 @@ cleanup_symlinks() {
   # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
   # leftovers from older versions.
   workstation_binaries="berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
-  binaries="chef-run chef-workstation-app $workstation_binaries chef-analyze"
+  binaries="chef-run chef-workstation-app $workstation_binaries chef-analyze hab"
 
   for binary in $binaries; do
     rm -f "$PREFIX/bin/$binary"

--- a/omnibus/verification/verify.rb
+++ b/omnibus/verification/verify.rb
@@ -243,7 +243,6 @@ module ChefWorkstation
           end
         end
       end
-
       add_component "fauxhai-ng" do |c|
         c.gem_base_dir = "fauxhai-ng"
         c.smoke_test { sh("#{embedded_bin("gem")} list fauxhai-ng") }
@@ -289,6 +288,7 @@ module ChefWorkstation
             sh!("#{usr_bin_path("ohai")} -v")
             sh!("#{usr_bin_path("foodcritic")} -V")
             sh!("#{usr_bin_path("inspec")} version")
+            sh!("#{usr_bin_path("hab")} --version")
           end
 
           # Test blocks are expected to return a Mixlib::ShellOut compatible


### PR DESCRIPTION
We want to ensure that Workstation includes all of the tools required to
manage infrastructure - Chef Habitat is a key part of that.

- This adds a software definition to include the pre-built
  Chef Habitat 'hab' binary for each supported platform at WS build-time,
  in the same way we bundle workstation-app. We can visit switching this
  to build the binary instead of downloading pre-built in future
  iterations.
- It adds an update script to update the definition to the latest stable
  version of habitat.
- it adds an expeditor workload to trigger that script when a stable hab
is published.
- it adds a post-inst step that checks for conflicting `hab` install and
warns the operator thta WS should now manage the install.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
