### PR TITLE
Use built-in action for CDN purge

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -64,7 +64,7 @@ subscriptions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
       - bash:.expeditor/publish-release-notes.sh
-      - bash:.expeditor/purge-cdn.sh
+      - purge_packages_chef_io_fastly:{{channel}}/{{product_key}}/latest
       - bash:.expeditor/announce-release.sh
       # - built_in:tag_docker_image
       # publish to third party package managers that have a dependency

--- a/.expeditor/purge-cdn.sh
+++ b/.expeditor/purge-cdn.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eou pipefail
-
-echo "Purging '${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest' Surrogate Key group from Fastly"
-curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" "https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${EXPEDITOR_CHANNEL}/${EXPEDITOR_PRODUCT_KEY}/latest"


### PR DESCRIPTION
## Description
This new action was added since we last promoted and we are required
to use the built-in rather than a bash script now.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
