### PR TITLE
Fix ordering of purge built-in

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -64,11 +64,11 @@ subscriptions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
       - bash:.expeditor/publish-release-notes.sh
-      - purge_packages_chef_io_fastly:{{channel}}/{{product_key}}/latest
       - bash:.expeditor/announce-release.sh
       # - built_in:tag_docker_image
       # publish to third party package managers that have a dependency
       # on this artifact's availability
+      - purge_packages_chef_io_fastly:{{channel}}/{{product_key}}/latest
       - trigger_pipeline:third-party-packages
 
   - workload: habitat-sh/habitat:master_completed:project_promoted:habitat-sh/habitat:master:stable:*


### PR DESCRIPTION
Corrects validation error because default ordering of purge is after commit
but default ordering of bash is pre-commit.

ref: https://expeditor.chef.io/docs/reference/status-checks/#config-002


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
