### PR TITLE
Make sure macOS detection works even if the string changes

### DIFF
--- a/omnibus/files/uninstall-scripts/uninstall_chef_workstation
+++ b/omnibus/files/uninstall-scripts/uninstall_chef_workstation
@@ -14,7 +14,7 @@ error_exit()
 
 is_darwin()
 {
-  uname -v | grep "^Darwin" 2>&1 >/dev/null
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
 }
 
 if is_darwin; then

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -7,7 +7,7 @@ version="${VERSION:-latest}"
 
 is_darwin()
 {
-  uname -v | grep "^Darwin" >/dev/null 2>&1
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
 }
 
 echo "--- Installing $channel $product $version"

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -33,7 +33,7 @@ error_exit()
 
 is_darwin()
 {
-  uname -v | grep "^Darwin" >/dev/null 2>&1
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
 }
 
 if is_darwin; then

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -6,7 +6,7 @@
 
 is_darwin()
 {
-  uname -v | grep "^Darwin" 2>&1 >/dev/null
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
 }
 
 cleanup_symlinks() {

--- a/omnibus/package-scripts/chef-workstation/preinst
+++ b/omnibus/package-scripts/chef-workstation/preinst
@@ -14,7 +14,7 @@ error_exit()
 
 is_darwin()
 {
-  uname -v | grep "^Darwin" 2>&1 >/dev/null
+  uname -a | grep "^Darwin" 2>&1 >/dev/null
 }
 
 if is_darwin; then


### PR DESCRIPTION
uname -a is far more reliable here for detecting Darwin.

Signed-off-by: Tim Smith <tsmith@chef.io>