### PR TITLE
Reduce the size of the Chef Workstation package / install

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 6909d445b211528dc3c56b66813bca78dc22d213
+  revision: 41ddd2e5d20a95fc9ee8344a9cdd57f85dfe47b1
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: fdca423b097bfdabc765320aa15f7b392501b7ed
+  revision: f8f202cdffe5a77aed4c4884f302a38be3eabc64
   branch: master
   specs:
-    omnibus (7.0.18)
+    omnibus (7.0.19)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar (>= 3.3)
@@ -32,8 +32,8 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.342.0)
-    aws-sdk-core (3.104.0)
+    aws-partitions (1.348.0)
+    aws-sdk-core (3.104.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -41,8 +41,8 @@ GEM
     aws-sdk-kms (1.36.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.74.0)
-      aws-sdk-core (~> 3, >= 3.102.1)
+    aws-sdk-s3 (1.75.0)
+      aws-sdk-core (~> 3, >= 3.104.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.1)
@@ -64,12 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.2.73)
+    chef (16.3.45)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.2.73)
-      chef-utils (= 16.2.73)
+      chef-config (= 16.3.45)
+      chef-utils (= 16.3.45)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -85,7 +85,7 @@ GEM
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 3.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 4.0)
       net-ssh (>= 4.2, < 7)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -96,14 +96,15 @@ GEM
       syslog-logger (~> 1.6)
       train-core (~> 3.2, >= 3.2.28)
       train-winrm (>= 0.2.5)
+      tty-prompt (~> 0.21)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (16.2.73-universal-mingw32)
+    chef (16.3.45-universal-mingw32)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.2.73)
-      chef-utils (= 16.2.73)
+      chef-config (= 16.3.45)
+      chef-utils (= 16.3.45)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -114,13 +115,13 @@ GEM
       ffi-yajl (~> 2.2)
       highline (>= 1.6.9, < 3)
       iniparse (~> 1.4)
-      iso8601 (~> 0.12.1)
+      iso8601 (>= 0.12.1, < 0.14)
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 3.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 4.0)
       net-ssh (>= 4.2, < 7)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -131,6 +132,7 @@ GEM
       syslog-logger (~> 1.6)
       train-core (~> 3.2, >= 3.2.28)
       train-winrm (>= 0.2.5)
+      tty-prompt (~> 0.21)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
@@ -145,15 +147,15 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.2.73)
+    chef-config (16.3.45)
       addressable
-      chef-utils (= 16.2.73)
+      chef-utils (= 16.3.45)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
     chef-sugar (5.1.9)
-    chef-utils (16.2.73)
+    chef-utils (16.3.45)
     chef-vault (4.0.1)
     chef-zero (15.0.0)
       ffi-yajl (~> 2.2)
@@ -191,7 +193,7 @@ GEM
     iniparse (1.5.0)
     iostruct (0.0.4)
     ipaddress (0.8.3)
-    iso8601 (0.12.3)
+    iso8601 (0.13.0)
     jmespath (1.4.0)
     json (2.3.1)
     kitchen-vagrant (1.6.1)
@@ -224,8 +226,10 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.8)
-    mixlib-shellout (3.0.9)
-    mixlib-shellout (3.0.9-universal-mingw32)
+    mixlib-shellout (3.1.2)
+      chef-utils
+    mixlib-shellout (3.1.2-universal-mingw32)
+      chef-utils
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.12)
@@ -247,7 +251,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (16.2.3)
+    ohai (16.3.2)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
@@ -263,15 +267,13 @@ GEM
     pastel (0.7.4)
       equatable (~> 0.6)
       tty-color (~> 0.5)
-    pedump (0.5.4)
+    pedump (0.6.1)
       awesome_print
       iostruct (>= 0.0.4)
       multipart-post (>= 2.0.0)
-      progressbar
       rainbow
       zhexdump (>= 0.0.2)
     plist (3.5.0)
-    progressbar (1.10.1)
     proxifier (1.0.3)
     public_suffix (4.0.5)
     rack (2.2.3)
@@ -295,7 +297,7 @@ GEM
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (2.5.3)
+    test-kitchen (2.5.4)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
       license-acceptance (~> 1.0, >= 1.0.11)
@@ -336,7 +338,7 @@ GEM
       tty-cursor (~> 0.7)
       tty-screen (~> 0.7)
       wisper (~> 2.0.0)
-    tty-screen (0.8.0)
+    tty-screen (0.8.1)
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -128,4 +128,14 @@ build do
       end
     end
   end
+
+  # remove the chef specs we don't run as this is a large number of files
+  block "Removing functional / integration / stress specs from chef" do
+    target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems/chef-*/spec/{integration,functional,stress}".tr('\\', "/")
+
+    Dir.glob(target_dir).each do |f|
+      puts "Deleting unused spec dir #{f}"
+      FileUtils.remove_dir(f)
+    end
+  end
 end


### PR DESCRIPTION
Some of this is work from omnibus-software itself and some of it is part of the omnibus config specific to workstation:

1) Update cacerts to the latest release. This revokes some certs
2) Update curl from 7.68.0 to 7.71.1 which includes a large number of bug fixes. We've also updated our curl omnibus config to remove support for gopher, imap, imaps, pop3, pop3s, smtp, and smtps protocols, which makes the binary a bit smaller (~40k).
3) the bzcat binary is no longer being built with libarchive which drops install size by ~250k
4) The unused chef functional/integration/stress specs are removed from the install in the cleanup definition.  This is 242 files / 1.9 megs on disk

Overall this removes 243 files and 2.2 megs on disk.