### PR TITLE
Update omnibus-software to cleanup empty gem dirs

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 399369c70d19eaf3ee035da1e4a14bd79b21381d
+  revision: 5845cc16179cc7e94d5768fa4009afccff45275f
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.349.0)
+    aws-partitions (1.350.0)
     aws-sdk-core (3.104.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
We're shipping several dozen empty gem dirs in the install that have to
be installed every time. This PR cleans that all up.

Signed-off-by: Tim Smith <tsmith@chef.io>