### PR TITLE
Update omnibus-software to remove extra bins

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 5845cc16179cc7e94d5768fa4009afccff45275f
+  revision: e1c3d2839fe49e732aaf9edc8ebf708f12846ff3
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.350.0)
+    aws-partitions (1.351.0)
     aws-sdk-core (3.104.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
Remove lzma and bzip2 binaries that we don't actually need. These just
come in via deps for libarchive. These take up space, have to be virus
scanned, and potentially include CVEs we later have to patch.

Signed-off-by: Tim Smith <tsmith@chef.io>