### PR TITLE
Build azure compute and network SDKs from our fork

### DIFF
--- a/omnibus/config/software/azure-sdk.rb
+++ b/omnibus/config/software/azure-sdk.rb
@@ -1,0 +1,35 @@
+#
+# Copyright:: Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "azure-sdk"
+default_version "master"
+
+source git: "https://github.com/chef/azure-sdk-for-ruby.git"
+
+license "MIT"
+license_file "https://raw.githubusercontent.com/chef/azure-sdk-for-ruby/master/LICENSE.txt"
+
+dependency "ruby"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  gem "build azure_mgmt_compute.gemspec", env: env, cwd: "#{project_dir}/management/azure_mgmt_compute"
+  gem "install azure_mgmt_compute-*.gem --no-document --ignore-dependencies", env: env, cwd: "#{project_dir}/management/azure_mgmt_compute"
+
+  gem "build azure_mgmt_network.gemspec", env: env, cwd: "#{project_dir}/management/azure_mgmt_network"
+  gem "install azure_mgmt_network-*.gem --no-document --ignore-dependencies", env: env, cwd: "#{project_dir}/management/azure_mgmt_network"
+end

--- a/omnibus/config/software/azure-sdk.rb
+++ b/omnibus/config/software/azure-sdk.rb
@@ -27,9 +27,8 @@ dependency "ruby"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "build azure_mgmt_compute.gemspec", env: env, cwd: "#{project_dir}/management/azure_mgmt_compute"
-  gem "install azure_mgmt_compute-*.gem --no-document --ignore-dependencies", env: env, cwd: "#{project_dir}/management/azure_mgmt_compute"
-
-  gem "build azure_mgmt_network.gemspec", env: env, cwd: "#{project_dir}/management/azure_mgmt_network"
-  gem "install azure_mgmt_network-*.gem --no-document --ignore-dependencies", env: env, cwd: "#{project_dir}/management/azure_mgmt_network"
+  %w{compute key_vault network resources security storage}.each do |gem_name|
+    gem "build azure_mgmt_#{gem_name}.gemspec", env: env, cwd: "#{project_dir}/management/azure_mgmt_#{gem_name}"
+    gem "install azure_mgmt_#{gem_name}-*.gem --no-document --ignore-dependencies", env: env, cwd: "#{project_dir}/management/azure_mgmt_#{gem_name}"
+  end
 end

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -55,6 +55,11 @@ dependency "rb-fsevent-gem" if mac_os_x?
 # in its gemspec.
 dependency "docker-api"
 
+# The azure SDK includes files for every possible API version since 2015.
+# All of our usage is against the "latest" profile which allows us to remove
+# 2.5+ million lines of API code we don't need
+dependency "azure-sdk"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -9,10 +9,10 @@ override "delivery-cli", version: "0.0.54"
 override "chef-workstation-app", version: "v0.1.80"
 # /DO NOT MODIFY
 
-override "libarchive", version: "3.4.2"
+override "libarchive", version: "3.4.3"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
-override "liblzma", version: "5.2.4"
+override "liblzma", version: "5.2.5"
 override "libxml2", version: "2.9.10"
 override "libxslt", version: "1.1.34"
 override "libyaml", version: "0.1.7"


### PR DESCRIPTION
This should reduce about 2.5 million lines of SDK code we install.

Signed-off-by: Tim Smith <tsmith@chef.io>