### PR TITLE
Fix Homebrew PR creation

### DIFF
--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -12,16 +12,18 @@ steps:
           host_os: windows
           environment:
 
-  # - label: ":mac_os_x: :github: Create PR to update Homebrew/homebrew-cask"
-  #   command:
-  #     - bash .expeditor/create_pr_for_homebrew.sh
-  #   expeditor:
-  #     accounts:
-  #       - github/chef
-  #     secrets:
-  #       GITHUB_TOKEN:
-  #         account: github/chef
-  #         field: token
-  #   executor:
-  #     docker:
-  #        image: homebrew/brew
+  - label: ":mac: :github: Create PR to update Homebrew/homebrew-cask"
+    command:
+      - bash .expeditor/create_pr_for_homebrew.sh
+    expeditor:
+      accounts:
+        - github/chef
+      secrets:
+        CHEF_CI_GITHUB_AUTH_TOKEN:
+          path: account/static/github/chef-ci
+          field: token
+        GITHUB_TOKEN:
+          account: github/chef
+          field: token
+      executor:
+        macos:


### PR DESCRIPTION
* switch to the macos executor, because the non-ES linuxbrew image is
  not a permitted to access expeditor secrets.
* Updates buildkite emoji alias to be :mac:
* mac-compatibility fixes for sed usage.
* Fix PR request to set maintainer_can_modify to false. This otherwise
  fails the PR with a message about the non-existent field
  `fork_collab`, possibly because the account creating the branch
  (chef-ci) doesn't have proper push access to the branch, triggering
  an odd validation failure from GH API.  Ref: https://github.com/octokit/rest.js/issues/490
* fix indentation issue in third party package pipeline yml (tball,
squashed)

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

