### PR TITLE
Replace docs for hide-healthy with hide-by-mins

### DIFF
--- a/www/content/workstation/config_rb.md
+++ b/www/content/workstation/config_rb.md
@@ -494,7 +494,7 @@ settings](/workstation/config_rb_optional_settings/) that can be added to the
 the `config.rb` file. The reasons for not adding them can vary. For
 example, using `--yes` as a default in the `config.rb` file will cause
 knife to always assume that "Y" is the response to any prompt, which may
-lead to undesirable outcomes. Other settings, such as `--hide-healthy`
+lead to undesirable outcomes. Other settings, such as `--hide-by-mins`
 (used only with the `knife status` subcommand) or `--bare-directories`
 (used only with the `knife list` subcommand) probably aren't used often
 enough (and in the same exact way) to justify adding them to the

--- a/www/content/workstation/config_rb_optional_settings.md
+++ b/www/content/workstation/config_rb_optional_settings.md
@@ -32,7 +32,7 @@ Many optional settings should not be added to the config.rb file. The
 reasons for not adding them can vary. For example, using `--yes` as a
 default in the config.rb file will cause knife to always assume that "Y"
 is the response to any prompt, which may lead to undesirable outcomes.
-Other settings, such as `--hide-healthy` (used only with the
+Other settings, such as `--hide-by-mins` (used only with the
 `knife status` subcommand) or `--bare-directories` (used only with the
 `knife list` subcommand) probably aren't used often enough (and in the
 same exact way) to justify adding them to the config.rb file. In
@@ -1224,9 +1224,9 @@ The following `knife ssh` settings can be added to the config.rb file:
 The following `knife status` settings can be added to the config.rb
 file:
 
-`knife[:hide_healthy]`
+`knife[:hide_by_mins]`
 
-:   Adds the the `--hide-healthy` option.
+:   Adds the the `--hide-by-mins` option.
 
 `knife[:run_list]`
 

--- a/www/content/workstation/knife_status.md
+++ b/www/content/workstation/knife_status.md
@@ -44,14 +44,6 @@ This subcommand has the following options:
     within the last specified number of minutes. The number of minutes
     to hide is provided as an integer, such as `--hide-by-mins 10`.
 
-`-H`, `--hide-healthy`
-
-:   Hide nodes on which a Chef Infra Client run has occurred within the
-    previous hour.
-
-    Deprecated in favor of the `--hide-by-mins` option in Chef Client
-    12.6 and above.
-
 `-l`, `--long`
 
 :   Display all attributes in the output and show the output as JSON.
@@ -93,19 +85,6 @@ to return something like:
 ``` bash
 422492 hours ago, runner-1-432.lxc, centos 6.8.
 27 hours ago, union-3-432.lxc, centos 7.3.1611.
-```
-
-On systems running Chef Client 12.5 or prior:
-
-``` bash
-knife status --hide-healthy
-```
-
-to return something like:
-
-``` bash
-1 hour ago, i-256f884f, ubuntu 12.04, ec2-67-202-63-102.compute-1.amazonaws.com, 67.202.63.102, role[web].
-1 hour ago, i-a47823c9, ubuntu 10.04, ec2-174-129-127-206.compute-1.amazonaws.com, 184.129.143.111, role[lb].
 ```
 
 **View status using a query**


### PR DESCRIPTION
Hide healthy has been deprecated for many many years and is gone with
Chef Infra Client 15.

Signed-off-by: Tim Smith <tsmith@chef.io>