### PR TITLE
Add headless/ws-appless windows install instructions

### DIFF
--- a/www/content/workstation/install_workstation.md
+++ b/www/content/workstation/install_workstation.md
@@ -133,6 +133,21 @@ Alternately, install Chef Workstation using Homebrew:
 3.  **Optional:** Set the default shell. On Microsoft Windows it is
     strongly recommended to use Windows PowerShell instead of `cmd.exe`.
 
+#### Headless Unattended Install
+
+
+"Headless" systems are configured to operate without a monitor (the "head") keyboard, and mouse.  They are usually controlled over a network connection.
+
+To install Chef Workstation on a headless Windows system, 
+exclude the Chef Workstation App from auto-starting on login, use the following
+command in Windows PowerShell or `cmd.exe`.  Replace `MsiPath` with the path of
+the downloaded Chef Workstation installer.
+
+```
+msiexec /q /i MsiPath ADDLOCAL=ALL REMOVE=ChefWSApp
+```
+
+
 #### Spaces and Directories
 
 {{% ws_windows_spaces_and_directories %}}

--- a/www/content/workstation/install_workstation.md
+++ b/www/content/workstation/install_workstation.md
@@ -138,8 +138,8 @@ Alternately, install Chef Workstation using Homebrew:
 
 "Headless" systems are configured to operate without a monitor (the "head") keyboard, and mouse.  They are usually controlled over a network connection.
 
-To install Chef Workstation on a headless Windows system, 
-exclude the Chef Workstation App from auto-starting on login, use the following
+To install Chef Workstation on a headless Windows system,
+exclude the Chef Workstation App from auto-starting on login by using the following
 command in Windows PowerShell or `cmd.exe`.  Replace `MsiPath` with the path of
 the downloaded Chef Workstation installer.
 


### PR DESCRIPTION
Add instructions to install Workstation without enabling Workstation App to a headless/unattended Windows environment. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
