### PR TITLE
Enable FIPS builds for RHEL and Windows systems

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -52,3 +52,7 @@ workers 10
 # ------------------------------
 arch = (ENV["OMNIBUS_WINDOWS_ARCH"] || "").downcase
 windows_arch %w{x86 x64}.include?(arch) ? arch.to_sym : :x86
+
+# Build in FIPS compatability mode
+# ------------------------------
+fips_mode (ENV["OMNIBUS_FIPS_MODE"] || "").casecmp("true") >= 0


### PR DESCRIPTION
## Description
This only adds support for our Ruby tools, giving us parity with the
level of FIPS support in ChefDK. Adding FIPS support to the Electron or
Golang apps requires another custom implementation.

Already performed an ad-hoc build and manually tested on a Centos box.

## Related Issue
Fixes #316 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
