### PR TITLE
Ensure `brew` is up to date before using it

### DIFF
--- a/.expeditor/create_pr_for_homebrew.sh
+++ b/.expeditor/create_pr_for_homebrew.sh
@@ -59,6 +59,13 @@ echo "--- Debug: git diff of patched files follows"
 
 git diff
 
+echo "--- Upgrading Homebrew"
+# This ensures we stay consistent with the embedded erew style rules
+# that can change over time. If we get out of sync, we end up with
+# autocorrected changes that aren't compatible with what homebrew-cask's
+# CI is running.
+brew update
+
 echo "--- Verifying Cask"
 
 brew cask style --fix ./Casks/chef-workstation.rb

--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -1,16 +1,16 @@
 steps:
-  - label: ":chocolate_bar: Publish Chocolatey package"
-    command:
-      - powershell .expeditor/publish_to_chocolatey.ps1
-    expeditor:
-      secrets:
-        CHOCO_API_KEY:
-          path: account/static/chocolatey/chef-ci
-          field: api_key
-      executor:
-        docker:
-          host_os: windows
-          environment:
+  # - label: ":chocolate_bar: Publish Chocolatey package"
+  #   command:
+  #     - powershell .expeditor/publish_to_chocolatey.ps1
+  #   expeditor:
+  #     secrets:
+  #       CHOCO_API_KEY:
+  #         path: account/static/chocolatey/chef-ci
+  #         field: api_key
+  #     executor:
+  #       docker:
+  #         host_os: windows
+  #         environment:
 
   - label: ":mac: :github: Create PR to update Homebrew/homebrew-cask"
     command:


### PR DESCRIPTION
This prevents mismatches in the behaviors of the `brew` validations
across our PR-creation script and homebrew-cask's PR validation.


(verification in progress)

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
