### PR TITLE
Removing 386 arc to support go 1.15 with hab build

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -14,7 +14,7 @@ function build_cross_platform() {
   ( cd /src/components/main-chef-wrapper || exit 1
     gox -output="../../bin/chef_{{.OS}}_{{.Arch}}" \
         -os="darwin linux windows" \
-        -arch="amd64 386"
+        -arch="amd64"
   )
 }
 


### PR DESCRIPTION
Signed-off-by: Mudassar Shafique <15931574+mudash@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is not a supported arch for any OS. And with golang 15.1 it's  
giving us build errors on darwin/386, which is now unsupported.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
