### PR TITLE
Fix Edit on GitHub links

### DIFF
--- a/docs-chef-io/content/workstation/_index.md
+++ b/docs-chef-io/content/workstation/_index.md
@@ -12,7 +12,7 @@ aliases = ["/about_workstation.html", "/about_chefdk.html", "/chef_dk.html", "/a
     weight = 10
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/_index.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/_index.md)
 
 {{% chef_workstation %}}
 

--- a/docs-chef-io/content/workstation/berkshelf.md
+++ b/docs-chef-io/content/workstation/berkshelf.md
@@ -12,7 +12,7 @@ aliases = ["/berkshelf.html", "/berkshelf/"]
     weight = 10
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/berkshelf.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/berkshelf.md)
 
 Berkshelf is a dependency manager for Chef cookbooks. With it, you can
 easily depend on community cookbooks and have them safely included in

--- a/docs-chef-io/content/workstation/chef-workstation-app.md
+++ b/docs-chef-io/content/workstation/chef-workstation-app.md
@@ -10,7 +10,7 @@ draft = false
     weight = 61
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/chef-workstation-app.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chef-workstation-app.md)
 
 # About Chef Workstation App
 

--- a/docs-chef-io/content/workstation/chef_run.md
+++ b/docs-chef-io/content/workstation/chef_run.md
@@ -10,7 +10,7 @@ draft = false
     weight = 31
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/chef_run.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chef_run.md)
 
 chef-run is a tool to execute ad-hoc tasks on one or more target nodes
 using Chef Infra Client. To start with, familiarize yourself with `chef-run`'s

--- a/docs-chef-io/content/workstation/chef_shell.md
+++ b/docs-chef-io/content/workstation/chef_shell.md
@@ -12,7 +12,7 @@ aliases = ["/chef_shell.html", "/chef_shell/"]
     weight = 40
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/ctl_chef_shell.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/ctl_chef_shell.md)
 
 {{% chef_shell_summary %}}
 

--- a/docs-chef-io/content/workstation/chef_vault.md
+++ b/docs-chef-io/content/workstation/chef_vault.md
@@ -12,7 +12,7 @@ aliases = ["/chef_vault.html", "/chef_vault/"]
     weight = 50
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/chef_vault.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chef_vault.md)
 
 `chef-vault` is a Ruby Gem that is included in Chef Workstation and Chef
 Infra Client. Chef Vault lets you encrypt a data bag item using asymmetric keys.

--- a/docs-chef-io/content/workstation/chefspec.md
+++ b/docs-chef-io/content/workstation/chefspec.md
@@ -12,7 +12,7 @@ aliases = ["/chefspec.html", "/chefspec/"]
     weight = 60
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/chefspec.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chefspec.md)
 
 {{% chefspec_summary %}}
 

--- a/docs-chef-io/content/workstation/config.md
+++ b/docs-chef-io/content/workstation/config.md
@@ -10,7 +10,7 @@ draft = false
     weight = 50
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/config.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config.md)
 
 
 # Configuration

--- a/docs-chef-io/content/workstation/config_rb.md
+++ b/docs-chef-io/content/workstation/config_rb.md
@@ -12,7 +12,7 @@ aliases = ["/config_rb.html", "/config_rb_knife.html", "/config_rb/"]
     weight = 40
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/config_rb.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config_rb.md)
 
 {{< warning >}}
 

--- a/docs-chef-io/content/workstation/config_rb_optional_settings.md
+++ b/docs-chef-io/content/workstation/config_rb_optional_settings.md
@@ -12,7 +12,7 @@ aliases = ["/config_rb_optional_settings.html", "/config_rb_knife_optional_setti
     weight = 80
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/config_rb_optional_settings.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config_rb_optional_settings.md)
 
 In addition to the default settings in a knife config.rb file, there are
 other subcommand-specific settings that can be added. When a subcommand

--- a/docs-chef-io/content/workstation/config_yml_kitchen.md
+++ b/docs-chef-io/content/workstation/config_yml_kitchen.md
@@ -12,7 +12,7 @@ aliases = ["/config_yml_kitchen.html", "/config_yml_kitchen/"]
     weight = 30
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/config_yml_kitchen.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config_yml_kitchen.md)
 
 Use [Test Kitchen](https://kitchen.ci/) to automatically test cookbook
 data across any combination of platforms and test suites:

--- a/docs-chef-io/content/workstation/cookstyle.md
+++ b/docs-chef-io/content/workstation/cookstyle.md
@@ -12,7 +12,7 @@ aliases = ["/cookstyle.html", "/rubocop.html", "/cookstyle/"]
     weight = 90
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/cookstyle.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/cookstyle.md)
 
 Cookstyle is a code linting tool that helps you write better Chef Infra
 cookbooks by detecting and automatically correcting style, syntax, and

--- a/docs-chef-io/content/workstation/ctl_chef_apply.md
+++ b/docs-chef-io/content/workstation/ctl_chef_apply.md
@@ -12,7 +12,7 @@ aliases = ["/ctl_chef_apply.html", "/ctl_chef_apply/"]
     weight = 30
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/ctl_chef_apply.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/ctl_chef_apply.md)
 
 chef-apply is an executable program that runs a single recipe from the
 command line:

--- a/docs-chef-io/content/workstation/ctl_kitchen.md
+++ b/docs-chef-io/content/workstation/ctl_kitchen.md
@@ -12,7 +12,7 @@ aliases = ["/ctl_kitchen.html", "/ctl_kitchen/"]
     weight = 20
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/ctl_kitchen.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/ctl_kitchen.md)
 
 {{% ctl_kitchen_summary %}}
 

--- a/docs-chef-io/content/workstation/ctl_push_jobs_client.md
+++ b/docs-chef-io/content/workstation/ctl_push_jobs_client.md
@@ -12,7 +12,7 @@ aliases = ["/ctl_push_jobs_client.html", "/ctl_push_jobs_client/"]
     weight = 140
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/ctl_push_jobs_client.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/ctl_push_jobs_client.md)
 
 {{% push_jobs_summary %}}
 

--- a/docs-chef-io/content/workstation/foodcritic.md
+++ b/docs-chef-io/content/workstation/foodcritic.md
@@ -12,7 +12,7 @@ aliases = ["/foodcritic.html", "/foodcritic/"]
     weight = 110
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/foodcritic.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/foodcritic.md)
 
 {{< warning >}}
 

--- a/docs-chef-io/content/workstation/getting_started.md
+++ b/docs-chef-io/content/workstation/getting_started.md
@@ -12,7 +12,7 @@ aliases = ["/workstation_setup.html", "/chefdk_setup.html", "/workstation.html",
     weight = 40
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/getting_started.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/getting_started.md)
 
 This guide contains common configuration options used when setting up a
 new Chef Workstation installation. If you do not have Chef Workstation

--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -12,7 +12,7 @@ aliases = ["/install_workstation.html", "/install_dk.html", "/workstation_window
     weight = 30
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/install_workstation.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/install_workstation.md)
 
 Start your infrastructure automation quickly and easily with [Chef
 Workstation](https://www.chef.sh/) . Chef Workstation gives you

--- a/docs-chef-io/content/workstation/kitchen.md
+++ b/docs-chef-io/content/workstation/kitchen.md
@@ -12,7 +12,7 @@ aliases = ["/kitchen.html", "/kitchen/"]
     weight = 10
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/kitchen.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/kitchen.md)
 
 {{% test_kitchen %}}
 

--- a/docs-chef-io/content/workstation/knife.md
+++ b/docs-chef-io/content/workstation/knife.md
@@ -12,7 +12,7 @@ aliases = ["/knife.html", "/knife_using.html", "/knife/"]
     weight = 10
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife.md)
 
 knife is a command-line tool that provides an interface between a local
 chef-repo and the Chef Infra Server. knife helps users to manage:

--- a/docs-chef-io/content/workstation/knife_azure.md
+++ b/docs-chef-io/content/workstation/knife_azure.md
@@ -11,7 +11,7 @@ aliases = ["/knife_azure.html", "/knife_azure/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_azure.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_azure.md)
 
 ## Knife Azure Overview
 

--- a/docs-chef-io/content/workstation/knife_azurerm.md
+++ b/docs-chef-io/content/workstation/knife_azurerm.md
@@ -11,7 +11,7 @@ aliases = ["/knife_azurerm.html", "/knife_azurerm/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_azurerm.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_azurerm.md)
 
 ## Knife Azure Overview
 

--- a/docs-chef-io/content/workstation/knife_bootstrap.md
+++ b/docs-chef-io/content/workstation/knife_bootstrap.md
@@ -11,7 +11,7 @@ aliases = ["/knife_bootstrap.html", "/knife_bootstrap/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_bootstrap.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_bootstrap.md)
 
 {{% chef_client_bootstrap_node %}}
 

--- a/docs-chef-io/content/workstation/knife_client.md
+++ b/docs-chef-io/content/workstation/knife_client.md
@@ -11,7 +11,7 @@ aliases = ["/knife_client.html", "/knife_client/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_client.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_client.md)
 
 {{% knife_client_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_configure.md
+++ b/docs-chef-io/content/workstation/knife_configure.md
@@ -11,7 +11,7 @@ aliases = ["/knife_configure.html", "/knife_configure/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_configure.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_configure.md)
 
 {{% knife_configure_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_cookbook.md
+++ b/docs-chef-io/content/workstation/knife_cookbook.md
@@ -11,7 +11,7 @@ aliases = ["/knife_cookbook.html", "/knife_cookbook/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_cookbook.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_cookbook.md)
 
 {{% cookbooks_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_cookbook_site.md
+++ b/docs-chef-io/content/workstation/knife_cookbook_site.md
@@ -11,7 +11,7 @@ aliases = ["/knife_cookbook_site.html", "/knife_cookbook_site/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_cookbook_site.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_cookbook_site.md)
 
 {{% supermarket_api_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_data_bag.md
+++ b/docs-chef-io/content/workstation/knife_data_bag.md
@@ -11,7 +11,7 @@ aliases = ["/knife_data_bag.html", "/knife_data_bag/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_data_bag.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_data_bag.md)
 
 {{% data_bag %}}
 

--- a/docs-chef-io/content/workstation/knife_delete.md
+++ b/docs-chef-io/content/workstation/knife_delete.md
@@ -11,7 +11,7 @@ aliases = ["/knife_delete.html", "/knife_delete/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_delete.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_delete.md)
 
 {{% knife_delete_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_deps.md
+++ b/docs-chef-io/content/workstation/knife_deps.md
@@ -11,7 +11,7 @@ aliases = ["/knife_deps.html", "/knife_deps/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_deps.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_deps.md)
 
 {{% knife_deps_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_diff.md
+++ b/docs-chef-io/content/workstation/knife_diff.md
@@ -11,7 +11,7 @@ aliases = ["/knife_diff.html", "/knife_diff/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_diff.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_diff.md)
 
 {{% knife_diff_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_download.md
+++ b/docs-chef-io/content/workstation/knife_download.md
@@ -11,7 +11,7 @@ aliases = ["/knife_download.html", "/knife_download/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_download.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_download.md)
 
 {{% knife_download_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_edit.md
+++ b/docs-chef-io/content/workstation/knife_edit.md
@@ -11,7 +11,7 @@ aliases = ["/knife_edit.html", "/knife_edit/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_edit.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_edit.md)
 
 {{% knife_edit_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_environment.md
+++ b/docs-chef-io/content/workstation/knife_environment.md
@@ -11,7 +11,7 @@ aliases = ["/knife_environment.html", "/knife_environment/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_environment.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_environment.md)
 
 {{% environment %}}
 

--- a/docs-chef-io/content/workstation/knife_exec.md
+++ b/docs-chef-io/content/workstation/knife_exec.md
@@ -11,7 +11,7 @@ aliases = ["/knife_exec.html", "/knife_exec/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_exec.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_exec.md)
 
 {{% knife_exec_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_list.md
+++ b/docs-chef-io/content/workstation/knife_list.md
@@ -11,7 +11,7 @@ aliases = ["/knife_list.html", "/knife_list/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_list.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_list.md)
 
 {{% knife_list_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_node.md
+++ b/docs-chef-io/content/workstation/knife_node.md
@@ -11,7 +11,7 @@ aliases = ["/knife_node.html", "/knife_node/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_node.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_node.md)
 
 {{% node %}}
 

--- a/docs-chef-io/content/workstation/knife_options.md
+++ b/docs-chef-io/content/workstation/knife_options.md
@@ -12,7 +12,7 @@ aliases = ["/knife_options.html", "/knife_options/"]
     weight = 30
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_options.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_options.md)
 
 The following options can be run with all knife subcommands and
 plug-ins:

--- a/docs-chef-io/content/workstation/knife_raw.md
+++ b/docs-chef-io/content/workstation/knife_raw.md
@@ -11,7 +11,7 @@ aliases = ["/knife_raw.html", "/knife_raw/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_raw.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_raw.md)
 
 {{% knife_raw_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_recipe_list.md
+++ b/docs-chef-io/content/workstation/knife_recipe_list.md
@@ -11,7 +11,7 @@ aliases = ["/knife_recipe_list.html", "/knife_recipe_list/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_recipe_list.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_recipe_list.md)
 
 {{% knife_recipe_list_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_role.md
+++ b/docs-chef-io/content/workstation/knife_role.md
@@ -11,7 +11,7 @@ aliases = ["/knife_role.html", "/knife_role/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_role.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_role.md)
 
 {{% role %}}
 

--- a/docs-chef-io/content/workstation/knife_search.md
+++ b/docs-chef-io/content/workstation/knife_search.md
@@ -11,7 +11,7 @@ aliases = ["/knife_search.html", "/knife_search/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_search.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_search.md)
 
 {{% search %}}
 

--- a/docs-chef-io/content/workstation/knife_serve.md
+++ b/docs-chef-io/content/workstation/knife_serve.md
@@ -11,7 +11,7 @@ aliases = ["/knife_serve.html", "/knife_serve/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_serve.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_serve.md)
 
 {{% knife_serve_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_setup.md
+++ b/docs-chef-io/content/workstation/knife_setup.md
@@ -12,7 +12,7 @@ aliases = ["/knife_setup.html", "/knife_setup/"]
     weight = 20
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_setup.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_setup.md)
 
 The knife command line tool must be configured to communicate with the
 Chef Infra Server as well as any other infrastructure within your

--- a/docs-chef-io/content/workstation/knife_show.md
+++ b/docs-chef-io/content/workstation/knife_show.md
@@ -11,7 +11,7 @@ aliases = ["/knife_show.html", "/knife_show/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_show.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_show.md)
 
 {{% knife_show_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_ssh.md
+++ b/docs-chef-io/content/workstation/knife_ssh.md
@@ -11,7 +11,7 @@ aliases = ["/knife_ssh.html", "/knife_ssh/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_ssh.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_ssh.md)
 
 {{% knife_ssh_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_ssl_check.md
+++ b/docs-chef-io/content/workstation/knife_ssl_check.md
@@ -11,7 +11,7 @@ aliases = ["/knife_ssl_check.html", "/knife_ssl_check/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_ssl_check.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_ssl_check.md)
 
 {{% knife_ssl_check_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_ssl_fetch.md
+++ b/docs-chef-io/content/workstation/knife_ssl_fetch.md
@@ -11,7 +11,7 @@ aliases = ["/knife_ssl_fetch.html", "/knife_ssl_fetch/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_ssl_fetch.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_ssl_fetch.md)
 
 {{% knife_ssl_fetch_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_status.md
+++ b/docs-chef-io/content/workstation/knife_status.md
@@ -11,7 +11,7 @@ aliases = ["/knife_status.html", "/knife_status/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_status.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_status.md)
 
 {{% knife_status_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_supermarket.md
+++ b/docs-chef-io/content/workstation/knife_supermarket.md
@@ -11,7 +11,7 @@ aliases = ["/knife_supermarket.html", "/plugin_knife_supermarket.html", "/knife_
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_supermarket.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_supermarket.md)
 
 The `knife supermarket` subcommand is used to interact with cookbooks
 that are located in on the public Supermarket as well as private Chef

--- a/docs-chef-io/content/workstation/knife_tag.md
+++ b/docs-chef-io/content/workstation/knife_tag.md
@@ -11,7 +11,7 @@ aliases = ["/knife_tag.html", "/knife_tag/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_tag.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_tag.md)
 
 {{% chef_tags %}}
 

--- a/docs-chef-io/content/workstation/knife_upload.md
+++ b/docs-chef-io/content/workstation/knife_upload.md
@@ -11,7 +11,7 @@ aliases = ["/knife_upload.html", "/knife_upload/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_upload.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_upload.md)
 
 {{% knife_upload_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_user.md
+++ b/docs-chef-io/content/workstation/knife_user.md
@@ -11,7 +11,7 @@ aliases = ["/knife_user.html", "/knife_user/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_user.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_user.md)
 
 {{% knife_user_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_windows.md
+++ b/docs-chef-io/content/workstation/knife_windows.md
@@ -11,7 +11,7 @@ aliases = ["/knife_windows.html", "/knife_windows/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_windows.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_windows.md)
 
 ## Knife Windows Overview
 

--- a/docs-chef-io/content/workstation/knife_xargs.md
+++ b/docs-chef-io/content/workstation/knife_xargs.md
@@ -11,7 +11,7 @@ aliases = ["/knife_xargs.html", "/knife_xargs/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/knife_xargs.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_xargs.md)
 
 {{% knife_xargs_summary %}}
 

--- a/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md
+++ b/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md
@@ -12,7 +12,7 @@ aliases = ["/plugin_kitchen_vagrant.html", "/plugin_kitchen_vagrant/"]
     weight = 40
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/plugin_kitchen_vagrant.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md)
 
 {{% test_kitchen_driver_vagrant %}}
 

--- a/docs-chef-io/content/workstation/plugin_knife_opc.md
+++ b/docs-chef-io/content/workstation/plugin_knife_opc.md
@@ -11,7 +11,7 @@ aliases = ["/plugin_knife_opc.html", "/plugin_knife_opc/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/plugin_knife_opc.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/plugin_knife_opc.md)
 
 The `knife opc` subcommand is used to manage organizations and users in
 Chef Server 12.

--- a/docs-chef-io/content/workstation/privacy.md
+++ b/docs-chef-io/content/workstation/privacy.md
@@ -10,7 +10,7 @@ draft = false
     weight = 20
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/privacy.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/privacy.md)
 
 In order to continually improve Chef Workstation, we collect information to help us identify bugs and understand how people interact with Chef Workstation.
 

--- a/docs-chef-io/content/workstation/troubleshooting.md
+++ b/docs-chef-io/content/workstation/troubleshooting.md
@@ -10,7 +10,7 @@ draft = false
     weight = 60
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/troubleshooting.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/troubleshooting.md)
 
 ## Chef Workstation Logs
 

--- a/docs-chef-io/content/workstation/upgrade_lab.md
+++ b/docs-chef-io/content/workstation/upgrade_lab.md
@@ -10,7 +10,7 @@ aliases = ["/workstation/upgrade_labs/"]
     parent = "chef_workstation"
     weight = 35
 +++
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/www/content/workstation/upgrade_lab.md)
+[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/upgrade_lab.md)
 
 Chef Software's Upgrade Lab provides an isolated cookbook development environment and in-line support to help you upgrade your system, so you can stop using legacy Chef Infra and start using modern Chef Infra.
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

All the Edit on GitHub links are bad. They direct to the old docs subdirectory `www` instead of `docs-chef-io`. 
This fixes them.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
