### PR TITLE
Remove ruby-prof gem

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -120,11 +120,6 @@ group(:omnibus_package) do
   gem "mdl", ">= 0.7.0"
 end
 
-# Everything except AIX
-group(:ruby_prof) do
-  gem "ruby-prof"
-end
-
 # Everything except Windows
 group(:ruby_shadow) do
   gem "ruby-shadow", platform: :ruby

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -783,8 +783,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.1.1)
       parser (>= 2.7.1.5)
-    ruby-prof (1.4.2)
-    ruby-prof (1.4.2-x64-mingw32)
     ruby-progressbar (1.10.1)
     ruby-shadow (2.5.0)
     rubyntlm (0.6.2)
@@ -1088,7 +1086,6 @@ DEPENDENCIES
   rake (>= 13.0.1)
   rb-readline
   rdp-ruby-wmi
-  ruby-prof
   ruby-shadow
   stove (>= 7.1.6)
   test-kitchen (>= 2.7)


### PR DESCRIPTION
This is bundled with chef itself for super low level debugging of the client that I suspect next to no one has ever done. You shouldn't even be running that on the workstation install so this is just a waste of 5 megs on Windows.

Signed-off-by: Tim Smith <tsmith@chef.io>