### PR TITLE
Remove macOS 10.13 from the build matrix

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -14,8 +14,7 @@ builder-to-testers-map:
     - el-7-x86_64
     - el-8-x86_64
     - amazon-2-x86_64
-  mac_os_x-10.13-x86_64:
-    - mac_os_x-10.13-x86_64
+  mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11.0-x86_64


### PR DESCRIPTION
We support N-2 for macOS releases

Signed-off-by: Tim Smith <tsmith@chef.io>