### PR TITLE
Remove RHEL 6 from the build matrix

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -10,8 +10,6 @@ builder-to-testers-map:
   debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64


### PR DESCRIPTION
RHEL 6 goes EOL at the end of November

Signed-off-by: Tim Smith <tsmith@chef.io>