### PR TITLE
Bump Chef to 16.8.9 and chef-workstation-app to 0.1.103

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -50,8 +50,8 @@ group(:omnibus_package) do
   # gems to Rubygems now, so letting this float on latest should always give us the latest
   # stable release. May have to re-pin around major version bumping time, or during patch
   # fixes.
-  gem "chef", "= 16.7.61"
-  gem "chef-bin", "= 16.7.61"
+  gem "chef", "= 16.8.9"
+  gem "chef-bin", "= 16.8.9"
   gem "ohai", ">= 16.7"
   gem "cheffish", ">= 16.0"
 

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -205,12 +205,12 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
     byebug (11.1.3)
-    chef (16.7.61)
+    chef (16.8.9)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.7.61)
-      chef-utils (= 16.7.61)
+      chef-config (= 16.8.9)
+      chef-utils (= 16.8.9)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -221,6 +221,7 @@ GEM
       ffi-yajl (~> 2.2)
       highline (>= 1.6.9, < 3)
       iniparse (~> 1.4)
+      inspec-core (~> 4.23)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
@@ -228,7 +229,7 @@ GEM
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 4.0)
-      net-ssh (>= 4.2, < 7)
+      net-ssh (>= 5.1, < 7)
       net-ssh-multi (~> 1.2, >= 1.2.1)
       ohai (~> 16.0)
       pastel
@@ -241,12 +242,12 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (~> 2.1.5)
-    chef (16.7.61-universal-mingw32)
+    chef (16.8.9-universal-mingw32)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.7.61)
-      chef-utils (= 16.7.61)
+      chef-config (= 16.8.9)
+      chef-utils (= 16.8.9)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -257,6 +258,7 @@ GEM
       ffi-yajl (~> 2.2)
       highline (>= 1.6.9, < 3)
       iniparse (~> 1.4)
+      inspec-core (~> 4.23)
       iso8601 (>= 0.12.1, < 0.14)
       license-acceptance (>= 1.0.5, < 3)
       mixlib-archive (>= 0.4, < 2.0)
@@ -265,7 +267,7 @@ GEM
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 4.0)
-      net-ssh (>= 4.2, < 7)
+      net-ssh (>= 5.1, < 7)
       net-ssh-multi (~> 1.2, >= 1.2.1)
       ohai (~> 16.0)
       pastel
@@ -303,8 +305,8 @@ GEM
       train-core (~> 3.0)
       train-winrm
       tty-spinner
-    chef-bin (16.7.61)
-      chef (= 16.7.61)
+    chef-bin (16.8.9)
+      chef (= 16.8.9)
     chef-cli (3.0.33)
       addressable (>= 2.3.5, < 2.8)
       chef (>= 15.0)
@@ -317,9 +319,9 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
       pastel (~> 0.7)
       solve (> 2.0, < 5.0)
-    chef-config (16.7.61)
+    chef-config (16.8.9)
       addressable
-      chef-utils (= 16.7.61)
+      chef-utils (= 16.8.9)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -328,7 +330,7 @@ GEM
       chef-config
       concurrent-ruby (~> 1.0)
       ffi-yajl (~> 2.2)
-    chef-utils (16.7.61)
+    chef-utils (16.8.9)
     chef-vault (4.1.0)
     chef-zero (15.0.3)
       ffi-yajl (~> 2.2)
@@ -1005,9 +1007,9 @@ DEPENDENCIES
   artifactory
   bcrypt_pbkdf (>= 1.1.0.rc1)
   berkshelf (>= 7.0.10)
-  chef (= 16.7.61)
+  chef (= 16.8.9)
   chef-apply (>= 0.4.16)
-  chef-bin (= 16.7.61)
+  chef-bin (= 16.8.9)
   chef-cli (>= 3.0.4)
   chef-telemetry (>= 1.0.8)
   chef_deprecations (>= 0.1.1)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -6,7 +6,7 @@
 
 override "chef-analyze", version: "0.1.101"
 override "delivery-cli", version: "0.0.54"
-override "chef-workstation-app", version: "v0.1.102"
+override "chef-workstation-app", version: "v0.1.103"
 # /DO NOT MODIFY
 
 override "libarchive", version: "3.5.0"


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>