### PR TITLE
Remove the EOL Push Jobs Client

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -178,9 +178,6 @@ subscriptions:
   - workload: ruby_gem_published:knife-opc-*
     actions:
        - bash:.expeditor/update_dep.sh
-  - workload: ruby_gem_published:knife-push-*
-    actions:
-       - bash:.expeditor/update_dep.sh
   - workload: ruby_gem_published:knife-tidy-*
     actions:
        - bash:.expeditor/update_dep.sh
@@ -227,9 +224,6 @@ subscriptions:
     actions:
        - bash:.expeditor/update_dep.sh
   - workload: ruby_gem_published:ohai-*
-    actions:
-       - bash:.expeditor/update_dep.sh
-  - workload: ruby_gem_published:opscode-pushy-client-*
     actions:
        - bash:.expeditor/update_dep.sh
   - workload: ruby_gem_published:test-kitchen-*

--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -96,7 +96,6 @@ group(:omnibus_package) do
   # chef-telemetry previously pulled in an unecessary library (http)
   gem "chef-telemetry", ">= 1.0.8"
 
-  gem "mixlib-versioning"
   gem "artifactory"
   gem "mixlib-archive", ">= 1.0"
   gem "net-ssh", ">= 4.2.0"

--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -93,16 +93,11 @@ group(:omnibus_package) do
   gem "chef-cli", ">= 3.0.4"
   gem "chef-apply", ">= 0.4.16"
 
-  # For Delivery build node
-  gem "mixlib-versioning"
-  gem "artifactory"
-  gem "opscode-pushy-client", ">= 2.100"
-  gem "ffi-rzmq-core"
-  gem "knife-push"
-
   # chef-telemetry previously pulled in an unecessary library (http)
   gem "chef-telemetry", ">= 1.0.8"
 
+  gem "mixlib-versioning"
+  gem "artifactory"
   gem "mixlib-archive", ">= 1.0"
   gem "net-ssh", ">= 4.2.0"
   gem "listen"

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -398,10 +398,6 @@ GEM
     ffi (1.14.2-x86-mingw32)
     ffi-libarchive (1.0.4)
       ffi (~> 1.0)
-    ffi-rzmq (2.0.7)
-      ffi-rzmq-core (>= 1.0.7)
-    ffi-rzmq-core (1.0.7)
-      ffi
     ffi-win32-extensions (1.0.4)
       ffi
     ffi-yajl (2.3.4)
@@ -560,9 +556,6 @@ GEM
       google-api-client (>= 0.23.9, < 0.43.0)
       knife-cloud (>= 4.0.0)
     knife-opc (0.4.7)
-    knife-push (2.0.1)
-      addressable
-      chef (>= 15.0)
     knife-tidy (2.1.2)
     knife-vcenter (5.0.5)
       chef (>= 15.11)
@@ -686,11 +679,6 @@ GEM
       plist (~> 3.1)
       train-core
       wmi-lite (~> 1.0)
-    opscode-pushy-client (2.100.0)
-      chef (>= 15.0, < 17.0)
-      ffi-rzmq
-      ohai (>= 15.0, < 17.0)
-      uuidtools
     optimist (3.0.1)
     os (1.1.1)
     parallel (1.20.1)
@@ -1023,7 +1011,6 @@ DEPENDENCIES
   ed25519
   fauxhai-ng (~> 8)
   ffi-libarchive
-  ffi-rzmq-core
   guard
   inspec (~> 4.23)
   inspec-bin (~> 4.23)
@@ -1041,7 +1028,6 @@ DEPENDENCIES
   knife-ec2 (>= 1.0.28)
   knife-google (>= 4.2.7)
   knife-opc (>= 0.4.1)
-  knife-push
   knife-tidy (>= 2.0.9)
   knife-vcenter (>= 3.0.1)
   knife-vsphere (>= 4.1.1)
@@ -1055,7 +1041,6 @@ DEPENDENCIES
   net-ssh (>= 4.2.0)
   nokogiri (>= 1.10.10, < 1.11)
   ohai (>= 16.7)
-  opscode-pushy-client (>= 2.100)
   pry
   pry-byebug
   pry-remote

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -1037,7 +1037,6 @@ DEPENDENCIES
   minitest (= 5.13.0)
   mixlib-archive (>= 1.0)
   mixlib-install
-  mixlib-versioning
   net-ssh (>= 4.2.0)
   nokogiri (>= 1.10.10, < 1.11)
   ohai (>= 16.7)

--- a/docs-chef-io/content/workstation/ctl_chef.md
+++ b/docs-chef-io/content/workstation/ctl_chef.md
@@ -236,7 +236,6 @@ which returns the following output:
 *** LOCAL GEMS ***
 
 knife-opc (0.3.2)
-knife-push (1.0.2)
 knife-windows (1.9.0)
 ```
 

--- a/docs-chef-io/content/workstation/knife.md
+++ b/docs-chef-io/content/workstation/knife.md
@@ -340,7 +340,6 @@ Chef maintains the following plugins which ship with Chef Workstation:
 -   `knife-lpar`
 -   `knife-opc`
 -   `knife-openstack`
--   `knife-push`
 -   `knife-rackspace`
 -   `knife-reporting`
 -   `knife-vcenter`
@@ -348,6 +347,4 @@ Chef maintains the following plugins which ship with Chef Workstation:
 
 ### Community Knife Plugins
 
-Knife plugins written by Chef community members can be found on
-Supermarket under [Knife
-Plugins](https://supermarket.chef.io/tools?type=knife_plugin).
+Knife plugins written by Chef community members can be found on Supermarket under [Knife Plugins](https://supermarket.chef.io/tools?type=knife_plugin).

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -136,11 +136,6 @@ do_install() {
     appbundle "chef-vault" "changelog"
     wrap_ruby_bin "chef-vault"
 
-    appbundle "opscode-pushy-client" "changelog"
-    wrap_ruby_bin "pushy-client"
-    wrap_ruby_bin "push-apply"
-    wrap_ruby_bin "pushy-service-manager"
-
     appbundle chef-apply "changelog,docs,debug" # really, chef-run
     wrap_ruby_bin "chef-run"
   )

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -77,7 +77,7 @@ build do
   appbundle "berkshelf", lockdir: project_dir, gem: "berkshelf", without: %w{changelog build docs debug development}, env: env
 
   # Note - 'chef-apply' gem provides 'chef-run', not 'chef-apply' which ships with chef-bin...
-  %w{chef-bin chef-apply chef-vault ohai opscode-pushy-client cookstyle}.each do |gem|
+  %w{chef-bin chef-apply chef-vault ohai cookstyle}.each do |gem|
     appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -38,9 +38,6 @@ dependency "libarchive"
 # For berkshelf
 dependency "libarchive"
 
-# For opscode-pushy-client
-dependency "libzmq"
-
 # for train
 dependency "google-protobuf"
 

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -75,9 +75,7 @@ if [ "$moved" = "1" ]; then
   echo ""
 fi
 
-
-
-binaries="chef-run berks chef chef-cli chef-analyze chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client hab"
+binaries="chef-run berks chef chef-cli chef-analyze chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai chef-client hab"
 for binary in $binaries; do
   ln -sf "$INSTALLER_DIR/bin/$binary" $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"
 done

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -11,7 +11,7 @@ is_darwin()
 
 cleanup_symlinks() {
   # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
-  # leftovers from older versions.
+  # leftovers from older versions. We keep the push jobs values here to cleanup old releases
   workstation_binaries="berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
   binaries="chef-run chef-workstation-app $workstation_binaries chef-analyze hab"
 

--- a/omnibus/verification/spec/unit/verify_spec.rb
+++ b/omnibus/verification/spec/unit/verify_spec.rb
@@ -50,7 +50,6 @@ describe ChefWorkstation::Command::Verify do
       "package installation",
       "openssl",
       "inspec",
-      "opscode-pushy-client",
       "git",
       "delivery-cli",
     ]
@@ -60,7 +59,7 @@ describe ChefWorkstation::Command::Verify do
     expect(command_instance.run(command_options)).to eq(expected_exit_code)
   end
 
-  it "defines berks, tk, chef and chef-cli components by default" do
+  it "defines berks, test kitchen, chef and chef-cli components by default" do
     expected_components = default_components
     expect(command_instance.components).not_to be_empty
     expect(command_instance.components.map(&:name)).to match_array(expected_components)

--- a/omnibus/verification/verify.rb
+++ b/omnibus/verification/verify.rb
@@ -401,16 +401,6 @@ module ChefWorkstation
         end
       end
 
-      add_component "opscode-pushy-client" do |c|
-        c.gem_base_dir = "opscode-pushy-client"
-
-        c.smoke_test do
-          tmpdir do |cwd|
-            sh("#{bin("pushy-client")} -v", cwd: cwd)
-          end
-        end
-      end
-
       attr_reader :verification_threads
       attr_reader :verification_results
       attr_reader :verification_status


### PR DESCRIPTION
Remove the push jobs client and knife-push since Push Jobs is EOL as of 12/31/2020.

Signed-off-by: Tim Smith <tsmith@chef.io>