### PR TITLE
libarchive version updated to 3.5.1

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -9,7 +9,7 @@ override "delivery-cli", version: "0.0.54"
 override "chef-workstation-app", version: "v0.1.109"
 # /DO NOT MODIFY
 
-override "libarchive", version: "3.5.0"
+override "libarchive", version: "3.5.1"
 override "libffi", version: "3.3"
 override "libiconv", version: "1.16"
 override "liblzma", version: "5.2.5"


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta <nikhilgupta2102@gmail.com>

Added the sha for libarchive version 3.5.1 and make it to the default version in omnibus-software repo and pulling here the updates

## Description
[https://github.com/chef/chef-workstation/blob/master/omnibus_overrides.rb#L12](url)
Updated the libarchive version to 3.5.1

## Related Issue
[https://github.com/chef/chef-workstation/issues/1618](url)

