### PR TITLE
docs: Remove --admin from knife client create docs

### DIFF
--- a/docs-chef-io/content/workstation/knife_client.md
+++ b/docs-chef-io/content/workstation/knife_client.md
@@ -72,10 +72,6 @@ knife client create CLIENT_NAME (options)
 
 This argument has the following options:
 
-`-a`, `--admin`
-
-:   Create a client as an admin client.
-
 `-f FILE`, `--file FILE`
 
 :   Save a private key to the specified file name.


### PR DESCRIPTION
## Description

Per the help message from knife itself, this is not an option any longer.

```bash
♠ chef --version
Chef Workstation version: 21.1.222
Chef Infra Client version: 16.9.16

♠ knife client create --help
knife client create CLIENTNAME (options)
    -s, --server-url URL             Chef Infra Server URL.
        --chef-zero-host HOST        Host to start Chef Infra Zero on.
        --chef-zero-port PORT        Port (or port range) to start Chef Infra Zero on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works.
        --key KEY                    Chef Infra Server API client key.
        --[no-]color                 Use colored output, defaults to enabled.
    -c, --config CONFIG              The configuration file to use.
        --config-option OPTION=VALUE Override a single configuration option.
        --defaults                   Accept default values for all questions.
    -d, --disable-editing            Do not open EDITOR, just accept the data as is.
    -e, --editor EDITOR              Set the editor to use for interactive commands.
    -E, --environment ENVIRONMENT    Set the Chef Infra Client environment (except for in searches, where this will be flagrantly ignored).
    -f, --file FILE                  Write the private key to a file if the Chef Infra Server generated one.
        --[no-]fips                  Enable FIPS mode.
    -F, --format FORMAT              Which format to use for output. (valid options: 'summary', 'text', 'json', 'yaml', or 'pp')
        --[no-]listen                Whether a local mode (-z) server binds to a port.
    -z, --local-mode                 Point knife commands at local repository instead of Chef Infra Server.
    -u, --user USER                  Chef Infra Server API client username.
    -k, --prevent-keygen             Prevent Chef Infra Server from generating a default key pair for you. Cannot be passed with --public-key.
        --print-after                Show the data after a destructive operation.
        --profile PROFILE            The credentials profile to select.
    -p, --public-key FILE            Set the initial default key for the client from a file on disk (cannot pass with --prevent-keygen).
        --validator                  Create the client as a validator.
    -V, --verbose                    More verbose output. Use twice (-VV) for additional verbosity and three times (-VVV) for maximum verbosity.
    -v, --version                    Show Chef Infra Client version.
    -y, --yes                        Say yes to all prompts for confirmation.
    -h, --help                       Show this help message.
```

## Related Issue

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
