### PR TITLE
Replace edit on github links in MD pages with partial

### DIFF
--- a/docs-chef-io/Makefile
+++ b/docs-chef-io/Makefile
@@ -8,6 +8,7 @@ clean_all:
 preview_netlify: chef_web_docs
 	cp -R content/* chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/content
 	cp -R static/* chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/static
+	cp -R config.toml chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/
 	pushd chef-web-docs && make assets; hugo --buildFuture --gc --minify && popd
 
 serve: chef_web_docs

--- a/docs-chef-io/archetypes/default.md
+++ b/docs-chef-io/archetypes/default.md
@@ -2,12 +2,14 @@
 title = "{{ replace .Name "-" " " | title }}"
 draft = true
 
+gh_repo = "chef-workstation"
+
 publishDate = ""
 
 [menu]
   [menu.workstation]
     title = "{{ replace .Name "-" " " | title }}"
-    identifier = "chef_workstation/{{ .Name }}.md {{ replace .Name "-" " " | title }}"
+    identifier = "chef_workstation/{{ replace .Name "-" " " | title }}"
     parent = "chef_workstation"
     weight = 10
 +++

--- a/docs-chef-io/config.toml
+++ b/docs-chef-io/config.toml
@@ -1,0 +1,2 @@
+[params.chef-workstation]
+gh_path = "https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/"

--- a/docs-chef-io/content/workstation/_index.md
+++ b/docs-chef-io/content/workstation/_index.md
@@ -2,6 +2,8 @@
 title = "About Chef Workstation"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/about_workstation.html", "/about_chefdk.html", "/chef_dk.html", "/about_workstation/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/about_workstation.html", "/about_chefdk.html", "/chef_dk.html", "/a
     parent = "chef_workstation"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/_index.md)
 
 {{% chef_workstation %}}
 

--- a/docs-chef-io/content/workstation/berkshelf.md
+++ b/docs-chef-io/content/workstation/berkshelf.md
@@ -2,6 +2,8 @@
 title = "About Berkshelf"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/berkshelf.html", "/berkshelf/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/berkshelf.html", "/berkshelf/"]
     parent = "chef_workstation/chef_workstation_tools"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/berkshelf.md)
 
 Berkshelf is a dependency manager for Chef cookbooks. With it, you can
 easily depend on community cookbooks and have them safely included in

--- a/docs-chef-io/content/workstation/chef-workstation-app.md
+++ b/docs-chef-io/content/workstation/chef-workstation-app.md
@@ -2,6 +2,8 @@
 title = "Chef Workstation App"
 draft = false
 
+gh_repo = "chef-workstation"
+
 [menu]
   [menu.workstation]
     title = "Chef Workstation App"
@@ -9,8 +11,6 @@ draft = false
     parent = "chef_workstation/chef_workstation_tools"
     weight = 61
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chef-workstation-app.md)
 
 # About Chef Workstation App
 

--- a/docs-chef-io/content/workstation/chef_run.md
+++ b/docs-chef-io/content/workstation/chef_run.md
@@ -2,6 +2,8 @@
 title = "chef-run (executable)"
 draft = false
 
+gh_repo = "chef-workstation"
+
 [menu]
   [menu.workstation]
     title = "chef-run (executable)"
@@ -9,8 +11,6 @@ draft = false
     parent = "chef_workstation/chef_workstation_tools"
     weight = 31
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chef_run.md)
 
 chef-run is a tool to execute ad-hoc tasks on one or more target nodes
 using Chef Infra Client. To start with, familiarize yourself with `chef-run`'s

--- a/docs-chef-io/content/workstation/chef_shell.md
+++ b/docs-chef-io/content/workstation/chef_shell.md
@@ -2,6 +2,8 @@
 title = "chef-shell (executable)"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/chef_shell.html", "/chef_shell/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/chef_shell.html", "/chef_shell/"]
     parent = "chef_workstation/chef_workstation_tools"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/ctl_chef_shell.md)
 
 {{% chef_shell_summary %}}
 

--- a/docs-chef-io/content/workstation/chef_vault.md
+++ b/docs-chef-io/content/workstation/chef_vault.md
@@ -2,6 +2,8 @@
 title = "Chef Vault"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/chef_vault.html", "/chef_vault/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/chef_vault.html", "/chef_vault/"]
     parent = "chef_workstation/chef_workstation_tools"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chef_vault.md)
 
 `chef-vault` is a Ruby Gem that is included in Chef Workstation and Chef
 Infra Client. Chef Vault lets you encrypt a data bag item using asymmetric keys.

--- a/docs-chef-io/content/workstation/chefspec.md
+++ b/docs-chef-io/content/workstation/chefspec.md
@@ -2,6 +2,8 @@
 title = "ChefSpec"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/chefspec.html", "/chefspec/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/chefspec.html", "/chefspec/"]
     parent = "chef_workstation/chef_workstation_tools"
     weight = 60
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/chefspec.md)
 
 {{% chefspec_summary %}}
 

--- a/docs-chef-io/content/workstation/config.md
+++ b/docs-chef-io/content/workstation/config.md
@@ -2,6 +2,8 @@
 title = "Configure Chef Workstation"
 draft = false
 
+gh_repo = "chef-workstation"
+
 [menu]
   [menu.workstation]
     title = "Configure Chef Workstation"
@@ -9,8 +11,6 @@ draft = false
     parent = "chef_workstation"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config.md)
 
 
 # Configuration

--- a/docs-chef-io/content/workstation/config_rb.md
+++ b/docs-chef-io/content/workstation/config_rb.md
@@ -2,6 +2,8 @@
 title = "config.rb"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/config_rb.html", "/config_rb_knife.html", "/config_rb/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/config_rb.html", "/config_rb_knife.html", "/config_rb/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config_rb.md)
 
 {{< warning >}}
 

--- a/docs-chef-io/content/workstation/config_rb_optional_settings.md
+++ b/docs-chef-io/content/workstation/config_rb_optional_settings.md
@@ -2,6 +2,8 @@
 title = "config.rb Optional Settings"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/config_rb_optional_settings.html", "/config_rb_knife_optional_settings.html", "/config_rb_optional_settings/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/config_rb_optional_settings.html", "/config_rb_knife_optional_setti
     parent = "chef_workstation/chef_workstation_tools"
     weight = 80
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config_rb_optional_settings.md)
 
 In addition to the default settings in a knife config.rb file, there are
 other subcommand-specific settings that can be added. When a subcommand

--- a/docs-chef-io/content/workstation/config_yml_kitchen.md
+++ b/docs-chef-io/content/workstation/config_yml_kitchen.md
@@ -2,6 +2,8 @@
 title = "kitchen.yml"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/config_yml_kitchen.html", "/config_yml_kitchen/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/config_yml_kitchen.html", "/config_yml_kitchen/"]
     parent = "chef_workstation/chef_workstation_tools/test_kitchen"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/config_yml_kitchen.md)
 
 Use [Test Kitchen](https://kitchen.ci/) to automatically test cookbook
 data across any combination of platforms and test suites:

--- a/docs-chef-io/content/workstation/cookstyle/_index.md
+++ b/docs-chef-io/content/workstation/cookstyle/_index.md
@@ -2,6 +2,8 @@
 title = "Cookstyle"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/cookstyle.html", "/rubocop.html", "/cookstyle/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/cookstyle.html", "/rubocop.html", "/cookstyle/"]
     parent = "chef_workstation/chef_workstation_tools/cookstyle"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/cookstyle.md)
 
 Cookstyle is a code linting tool that helps you write better Chef Infra
 cookbooks by detecting and automatically correcting style, syntax, and

--- a/docs-chef-io/content/workstation/ctl_chef.md
+++ b/docs-chef-io/content/workstation/ctl_chef.md
@@ -2,6 +2,8 @@
 title = "chef (executable)"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/ctl_chef.html", "/ctl_chef/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/ctl_chef.html", "/ctl_chef/"]
     parent = "chef_workstation/chef_workstation_tools/chef_(executable)"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/workstation/blob/master/www/content/workstation/ctl_chef.md)
 
 The chef executable is a command-line tool that does the following:
 

--- a/docs-chef-io/content/workstation/ctl_chef_apply.md
+++ b/docs-chef-io/content/workstation/ctl_chef_apply.md
@@ -2,6 +2,8 @@
 title = "chef-apply (executable)"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/ctl_chef_apply.html", "/ctl_chef_apply/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/ctl_chef_apply.html", "/ctl_chef_apply/"]
     parent = "chef_workstation/chef_workstation_tools"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/ctl_chef_apply.md)
 
 chef-apply is an executable program that runs a single recipe from the
 command line:

--- a/docs-chef-io/content/workstation/ctl_kitchen.md
+++ b/docs-chef-io/content/workstation/ctl_kitchen.md
@@ -2,6 +2,8 @@
 title = "kitchen (executable)"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/ctl_kitchen.html", "/ctl_kitchen/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/ctl_kitchen.html", "/ctl_kitchen/"]
     parent = "chef_workstation/chef_workstation_tools/test_kitchen"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/ctl_kitchen.md)
 
 {{% ctl_kitchen_summary %}}
 

--- a/docs-chef-io/content/workstation/foodcritic.md
+++ b/docs-chef-io/content/workstation/foodcritic.md
@@ -2,10 +2,10 @@
 title = "About Foodcritic"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/foodcritic.html", "/foodcritic/"]
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/foodcritic.md)
 
 {{< warning >}}
 

--- a/docs-chef-io/content/workstation/getting_started.md
+++ b/docs-chef-io/content/workstation/getting_started.md
@@ -2,6 +2,8 @@
 title = "Getting Started"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/workstation_setup.html", "/chefdk_setup.html", "/workstation.html", "/workstation_setup/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/workstation_setup.html", "/chefdk_setup.html", "/workstation.html",
     parent = "chef_workstation"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/getting_started.md)
 
 This guide contains common configuration options used when setting up a
 new Chef Workstation installation. If you do not have Chef Workstation

--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -2,6 +2,8 @@
 title = "Install Chef Workstation"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/install_workstation.html", "/install_dk.html", "/workstation_windows.html", "/dk_windows.html", "/install_workstation/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/install_workstation.html", "/install_dk.html", "/workstation_window
     parent = "chef_workstation"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/install_workstation.md)
 
 Start your infrastructure automation quickly and easily with [Chef Workstation](/workstation/). Chef Workstation gives you everything you need to get started with Chef - ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software - all in one easy-to-install package.
 

--- a/docs-chef-io/content/workstation/kitchen.md
+++ b/docs-chef-io/content/workstation/kitchen.md
@@ -2,6 +2,8 @@
 title = "Test Kitchen"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/kitchen.html", "/kitchen/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/kitchen.html", "/kitchen/"]
     parent = "chef_workstation/chef_workstation_tools/test_kitchen"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/kitchen.md)
 
 {{% test_kitchen %}}
 

--- a/docs-chef-io/content/workstation/knife.md
+++ b/docs-chef-io/content/workstation/knife.md
@@ -2,6 +2,8 @@
 title = "About Knife"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife.html", "/knife_using.html", "/knife/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/knife.html", "/knife_using.html", "/knife/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife.md)
 
 knife is a command-line tool that provides an interface between a local
 chef-repo and the Chef Infra Server. knife helps users to manage:

--- a/docs-chef-io/content/workstation/knife_azure.md
+++ b/docs-chef-io/content/workstation/knife_azure.md
@@ -2,6 +2,8 @@
 title = "Knife Azure"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_azure.html", "/knife_azure/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_azure.html", "/knife_azure/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_azure.md knife azure"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_azure.md)
 
 ## Knife Azure Overview
 

--- a/docs-chef-io/content/workstation/knife_azurerm.md
+++ b/docs-chef-io/content/workstation/knife_azurerm.md
@@ -2,6 +2,8 @@
 title = "Knife Azurerm"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_azurerm.html", "/knife_azurerm/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_azurerm.html", "/knife_azurerm/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_azurerm.md knife azurerm"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_azurerm.md)
 
 ## Knife Azure Overview
 

--- a/docs-chef-io/content/workstation/knife_bootstrap.md
+++ b/docs-chef-io/content/workstation/knife_bootstrap.md
@@ -2,6 +2,8 @@
 title = "knife bootstrap"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_bootstrap.html", "/knife_bootstrap/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_bootstrap.html", "/knife_bootstrap/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_bootstrap.md knife bootstrap"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_bootstrap.md)
 
 {{% chef_client_bootstrap_node %}}
 

--- a/docs-chef-io/content/workstation/knife_client.md
+++ b/docs-chef-io/content/workstation/knife_client.md
@@ -2,6 +2,8 @@
 title = "knife client"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_client.html", "/knife_client/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_client.html", "/knife_client/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_client.md knife client"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_client.md)
 
 {{% knife_client_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_configure.md
+++ b/docs-chef-io/content/workstation/knife_configure.md
@@ -2,6 +2,8 @@
 title = "knife configure"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_configure.html", "/knife_configure/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_configure.html", "/knife_configure/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_configure.md knife configure"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_configure.md)
 
 {{% knife_configure_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_cookbook.md
+++ b/docs-chef-io/content/workstation/knife_cookbook.md
@@ -2,6 +2,8 @@
 title = "knife cookbook"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_cookbook.html", "/knife_cookbook/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_cookbook.html", "/knife_cookbook/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_cookbook.md knife cookbook"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_cookbook.md)
 
 {{% cookbooks_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_cookbook_site.md
+++ b/docs-chef-io/content/workstation/knife_cookbook_site.md
@@ -2,6 +2,8 @@
 title = "knife cookbook site"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_cookbook_site.html", "/knife_cookbook_site/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_cookbook_site.html", "/knife_cookbook_site/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_cookbook_site.md knife cookbook site"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_cookbook_site.md)
 
 {{% supermarket_api_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_data_bag.md
+++ b/docs-chef-io/content/workstation/knife_data_bag.md
@@ -2,6 +2,8 @@
 title = "knife data bag"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_data_bag.html", "/knife_data_bag/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_data_bag.html", "/knife_data_bag/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_data_bag.md knife data bag"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_data_bag.md)
 
 {{% data_bag %}}
 

--- a/docs-chef-io/content/workstation/knife_delete.md
+++ b/docs-chef-io/content/workstation/knife_delete.md
@@ -2,6 +2,8 @@
 title = "knife delete"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_delete.html", "/knife_delete/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_delete.html", "/knife_delete/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_delete.md knife delete"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_delete.md)
 
 {{% knife_delete_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_deps.md
+++ b/docs-chef-io/content/workstation/knife_deps.md
@@ -2,6 +2,8 @@
 title = "knife deps"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_deps.html", "/knife_deps/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_deps.html", "/knife_deps/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_deps.md knife deps"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_deps.md)
 
 {{% knife_deps_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_diff.md
+++ b/docs-chef-io/content/workstation/knife_diff.md
@@ -2,6 +2,8 @@
 title = "knife diff"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_diff.html", "/knife_diff/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_diff.html", "/knife_diff/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_diff.md knife diff"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_diff.md)
 
 {{% knife_diff_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_download.md
+++ b/docs-chef-io/content/workstation/knife_download.md
@@ -2,6 +2,8 @@
 title = "knife download"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_download.html", "/knife_download/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_download.html", "/knife_download/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_download.md knife download"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_download.md)
 
 {{% knife_download_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_edit.md
+++ b/docs-chef-io/content/workstation/knife_edit.md
@@ -2,6 +2,8 @@
 title = "knife edit"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_edit.html", "/knife_edit/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_edit.html", "/knife_edit/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_edit.md knife edit"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_edit.md)
 
 {{% knife_edit_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_environment.md
+++ b/docs-chef-io/content/workstation/knife_environment.md
@@ -2,6 +2,8 @@
 title = "knife environment"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_environment.html", "/knife_environment/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_environment.html", "/knife_environment/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_environment.md knife environment"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_environment.md)
 
 {{% environment %}}
 

--- a/docs-chef-io/content/workstation/knife_exec.md
+++ b/docs-chef-io/content/workstation/knife_exec.md
@@ -2,6 +2,8 @@
 title = "knife exec"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_exec.html", "/knife_exec/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_exec.html", "/knife_exec/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_exec.md knife exec"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_exec.md)
 
 {{% knife_exec_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_list.md
+++ b/docs-chef-io/content/workstation/knife_list.md
@@ -2,6 +2,8 @@
 title = "knife list"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_list.html", "/knife_list/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_list.html", "/knife_list/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_list.md knife list"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_list.md)
 
 {{% knife_list_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_node.md
+++ b/docs-chef-io/content/workstation/knife_node.md
@@ -2,6 +2,8 @@
 title = "knife node"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_node.html", "/knife_node/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_node.html", "/knife_node/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_node.md knife node"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_node.md)
 
 {{% node %}}
 

--- a/docs-chef-io/content/workstation/knife_options.md
+++ b/docs-chef-io/content/workstation/knife_options.md
@@ -2,6 +2,8 @@
 title = "Knife Common Options"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_options.html", "/knife_options/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/knife_options.html", "/knife_options/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_options.md)
 
 The following options can be run with all knife subcommands and
 plug-ins:

--- a/docs-chef-io/content/workstation/knife_raw.md
+++ b/docs-chef-io/content/workstation/knife_raw.md
@@ -2,6 +2,8 @@
 title = "knife raw"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_raw.html", "/knife_raw/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_raw.html", "/knife_raw/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_raw.md knife raw"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_raw.md)
 
 {{% knife_raw_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_recipe_list.md
+++ b/docs-chef-io/content/workstation/knife_recipe_list.md
@@ -2,6 +2,8 @@
 title = "knife recipe list"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_recipe_list.html", "/knife_recipe_list/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_recipe_list.html", "/knife_recipe_list/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_recipe_list.md knife recipe list"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_recipe_list.md)
 
 {{% knife_recipe_list_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_role.md
+++ b/docs-chef-io/content/workstation/knife_role.md
@@ -2,6 +2,8 @@
 title = "knife role"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_role.html", "/knife_role/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_role.html", "/knife_role/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_role.md knife role"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_role.md)
 
 {{% role %}}
 

--- a/docs-chef-io/content/workstation/knife_search.md
+++ b/docs-chef-io/content/workstation/knife_search.md
@@ -2,6 +2,8 @@
 title = "knife search"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_search.html", "/knife_search/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_search.html", "/knife_search/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_search.md knife search"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_search.md)
 
 {{% search %}}
 

--- a/docs-chef-io/content/workstation/knife_serve.md
+++ b/docs-chef-io/content/workstation/knife_serve.md
@@ -2,6 +2,8 @@
 title = "knife serve"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_serve.html", "/knife_serve/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_serve.html", "/knife_serve/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_serve.md knife serve"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_serve.md)
 
 {{% knife_serve_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_setup.md
+++ b/docs-chef-io/content/workstation/knife_setup.md
@@ -2,6 +2,8 @@
 title = "Setting up Knife"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_setup.html", "/knife_setup/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/knife_setup.html", "/knife_setup/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_setup.md)
 
 knife is a command-line tool that provides an interface between a local chef-repo and the Chef Infra Server. The knife command line tool must be configured to communicate with the Chef Infra Server as well as any other infrastructure within your organization.
 

--- a/docs-chef-io/content/workstation/knife_show.md
+++ b/docs-chef-io/content/workstation/knife_show.md
@@ -2,6 +2,8 @@
 title = "knife show"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_show.html", "/knife_show/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_show.html", "/knife_show/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_show.md knife show"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_show.md)
 
 {{% knife_show_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_ssh.md
+++ b/docs-chef-io/content/workstation/knife_ssh.md
@@ -2,6 +2,8 @@
 title = "knife ssh"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_ssh.html", "/knife_ssh/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_ssh.html", "/knife_ssh/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_ssh.md knife ssh"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_ssh.md)
 
 {{% knife_ssh_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_ssl_check.md
+++ b/docs-chef-io/content/workstation/knife_ssl_check.md
@@ -2,6 +2,8 @@
 title = "knife ssl check"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_ssl_check.html", "/knife_ssl_check/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_ssl_check.html", "/knife_ssl_check/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_ssl_check.md knife ssl_check"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_ssl_check.md)
 
 {{% knife_ssl_check_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_ssl_fetch.md
+++ b/docs-chef-io/content/workstation/knife_ssl_fetch.md
@@ -2,6 +2,8 @@
 title = "knife ssl_fetch"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_ssl_fetch.html", "/knife_ssl_fetch/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_ssl_fetch.html", "/knife_ssl_fetch/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_ssl_fetch.md knife ssl_fetch"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_ssl_fetch.md)
 
 {{% knife_ssl_fetch_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_status.md
+++ b/docs-chef-io/content/workstation/knife_status.md
@@ -2,6 +2,8 @@
 title = "knife status"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_status.html", "/knife_status/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_status.html", "/knife_status/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_status.md knife status"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_status.md)
 
 {{% knife_status_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_supermarket.md
+++ b/docs-chef-io/content/workstation/knife_supermarket.md
@@ -2,6 +2,8 @@
 title = "knife supermarket"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_supermarket.html", "/plugin_knife_supermarket.html", "/knife_supermarket/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_supermarket.html", "/plugin_knife_supermarket.html", "/knife_
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_supermarket.md knife supermarket"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_supermarket.md)
 
 The `knife supermarket` subcommand is used to interact with cookbooks
 that are located in on the public Supermarket as well as private Chef

--- a/docs-chef-io/content/workstation/knife_tag.md
+++ b/docs-chef-io/content/workstation/knife_tag.md
@@ -2,6 +2,8 @@
 title = "knife tag"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_tag.html", "/knife_tag/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_tag.html", "/knife_tag/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_tag.md knife tag"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_tag.md)
 
 {{% chef_tags %}}
 

--- a/docs-chef-io/content/workstation/knife_upload.md
+++ b/docs-chef-io/content/workstation/knife_upload.md
@@ -2,6 +2,8 @@
 title = "knife upload"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_upload.html", "/knife_upload/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_upload.html", "/knife_upload/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_upload.md knife upload"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_upload.md)
 
 {{% knife_upload_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_user.md
+++ b/docs-chef-io/content/workstation/knife_user.md
@@ -2,6 +2,8 @@
 title = "knife user"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_user.html", "/knife_user/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_user.html", "/knife_user/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_user.md knife user"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_user.md)
 
 {{% knife_user_summary %}}
 

--- a/docs-chef-io/content/workstation/knife_windows.md
+++ b/docs-chef-io/content/workstation/knife_windows.md
@@ -2,6 +2,8 @@
 title = "Knife Windows"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_windows.html", "/knife_windows/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_windows.html", "/knife_windows/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_windows.md knife windows"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_windows.md)
 
 ## Knife Windows Overview
 

--- a/docs-chef-io/content/workstation/knife_xargs.md
+++ b/docs-chef-io/content/workstation/knife_xargs.md
@@ -2,6 +2,8 @@
 title = "knife xargs"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/knife_xargs.html", "/knife_xargs/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/knife_xargs.html", "/knife_xargs/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/knife_xargs.md knife xargs"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/knife_xargs.md)
 
 {{% knife_xargs_summary %}}
 

--- a/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md
+++ b/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md
@@ -2,6 +2,8 @@
 title = "kitchen-vagrant"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/plugin_kitchen_vagrant.html", "/plugin_kitchen_vagrant/"]
 
 [menu]
@@ -11,8 +13,6 @@ aliases = ["/plugin_kitchen_vagrant.html", "/plugin_kitchen_vagrant/"]
     parent = "chef_workstation/chef_workstation_tools/test_kitchen"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md)
 
 {{% test_kitchen_driver_vagrant %}}
 

--- a/docs-chef-io/content/workstation/plugin_knife_opc.md
+++ b/docs-chef-io/content/workstation/plugin_knife_opc.md
@@ -2,6 +2,8 @@
 title = "knife opc"
 draft = false
 
+gh_repo = "chef-workstation"
+
 aliases = ["/plugin_knife_opc.html", "/plugin_knife_opc/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/plugin_knife_opc.html", "/plugin_knife_opc/"]
     identifier = "chef_workstation/chef_workstation_tools/knife/plugin_knife_opc.md knife opc"
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/plugin_knife_opc.md)
 
 The `knife opc` subcommand is used to manage organizations and users in
 Chef Server 12.

--- a/docs-chef-io/content/workstation/privacy.md
+++ b/docs-chef-io/content/workstation/privacy.md
@@ -2,6 +2,8 @@
 title = "Privacy and Telemetry"
 draft = false
 
+gh_repo = "chef-workstation"
+
 [menu]
   [menu.workstation]
     title = "Privacy and Telemetry"
@@ -9,8 +11,6 @@ draft = false
     parent = "chef_workstation"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/privacy.md)
 
 In order to continually improve Chef Workstation, we collect information to help us identify bugs and understand how people interact with Chef Workstation.
 

--- a/docs-chef-io/content/workstation/troubleshooting.md
+++ b/docs-chef-io/content/workstation/troubleshooting.md
@@ -2,6 +2,8 @@
 title = "Troubleshooting"
 draft = false
 
+gh_repo = "chef-workstation"
+
 [menu]
   [menu.workstation]
     title = "Troubleshooting"
@@ -9,8 +11,6 @@ draft = false
     parent = "chef_workstation"
     weight = 60
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/troubleshooting.md)
 
 ## Chef Workstation Logs
 

--- a/docs-chef-io/content/workstation/upgrade_lab.md
+++ b/docs-chef-io/content/workstation/upgrade_lab.md
@@ -1,6 +1,8 @@
 +++
 title = "Upgrade Lab: Chef Infra Client 12 to latest"
 draft = false
+
+gh_repo = "chef-workstation"
 aliases = ["/workstation/upgrade_labs/"]
 
 [menu]
@@ -10,8 +12,6 @@ aliases = ["/workstation/upgrade_labs/"]
     parent = "chef_workstation/chef_workstation_tools"
     weight = 150
 +++
-[\[edit on GitHub\]](https://github.com/chef/chef-workstation/blob/master/docs-chef-io/content/workstation/upgrade_lab.md)
-
 Chef Software's Upgrade Lab provides an isolated cookbook development environment and in-line support to help you upgrade your system, so you can stop using legacy Chef Infra and start using modern Chef Infra.
 
 The Upgrade Lab provides a report of your existing nodes and cookbooks, so you will know the scope of the work and you can identify a good place to start. Upgrade Lab works by capturing any node from the production environment and recreating it locally by generating a repository for that node, which provides you with a sandbox to work through upgrading and testing your cookbooks at a safe distance from your production environment.


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>


## Description
This replaces MD `Edit on GitHub` links with a partial and a config value that generates the same link. 
Nothing should change in the final ouput page files, but we won't have to redo each link every time a page is moved or renamed.

## Related Issue
chef/chef-web-docs#2775

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
