### PR TITLE
Removes admin flag

### DIFF
--- a/docs-chef-io/content/workstation/config_rb_optional_settings.md
+++ b/docs-chef-io/content/workstation/config_rb_optional_settings.md
@@ -553,9 +553,6 @@ settings that are handled by the `knife ssh` subcommand.
 The following `knife client create` settings can be added to the
 config.rb file:
 
-`knife[:admin]`
-
-: Adds the the `--admin` option.
 
 `knife[:file]`
 
@@ -1208,10 +1205,13 @@ file:
 The following `knife user create` settings can be added to the config.rb
 file:
 
+<<<<<<< HEAD
 `knife[:admin]`
 
 : Adds the the `--admin` option.
 
+=======
+>>>>>>> 3a9966a7 (Removes admin flag)
 `knife[:file]`
 
 : Adds the the `--file` option.

--- a/docs-chef-io/content/workstation/config_rb_optional_settings.md
+++ b/docs-chef-io/content/workstation/config_rb_optional_settings.md
@@ -1205,13 +1205,6 @@ file:
 The following `knife user create` settings can be added to the config.rb
 file:
 
-<<<<<<< HEAD
-`knife[:admin]`
-
-: Adds the the `--admin` option.
-
-=======
->>>>>>> 3a9966a7 (Removes admin flag)
 `knife[:file]`
 
 : Adds the the `--file` option.

--- a/docs-chef-io/content/workstation/knife_client.md
+++ b/docs-chef-io/content/workstation/knife_client.md
@@ -69,10 +69,6 @@ knife client create CLIENT_NAME (options)
 
 This argument has the following options:
 
-`-a`, `--admin`
-
-: Create a client as an admin client.
-
 `-f FILE`, `--file FILE`
 
 : Save a private key to the specified file name.

--- a/docs-chef-io/content/workstation/knife_user.md
+++ b/docs-chef-io/content/workstation/knife_user.md
@@ -43,11 +43,7 @@ knife user create USERNAME DISPLAY_NAME FIRST_NAME LAST_NAME EMAIL PASSWORD (opt
 
 This argument has the following options:
 
-`-a`, `--admin`
-
-: Create a client as an admin client.
-
-`-f FILE_NAME`, `--file FILE_NAME`
+`-f FILE`, `--file FILE`
 
 : Save a private key to the specified file name.
 
@@ -55,7 +51,7 @@ This argument has the following options:
 
 : The user password.
 
-`--user-key FILE_NAME`
+`--user-key FILENAME`
 
 : The path to a file that contains the public key. If this option is not specified, the Chef Infra Server will generate a public/private key pair.
 
@@ -72,7 +68,7 @@ The following examples show how to use this knife subcommand:
 **Create a user**
 
 ``` bash
-knife user create rbirdman "Radio Birdman" Radio Birdman radio@bird.man -f /keys/radio_birdman
+knife user create tbucatar "Tamira Bucatar" tbucatar@example.com -f /keys/tbucatar
 ```
 
 ## delete
@@ -98,7 +94,7 @@ The following examples show how to use this knife subcommand:
 **Delete a user**
 
 ``` bash
-knife user delete "Steve Danno"
+knife user delete "Arjun Koch"
 ```
 
 ## edit
@@ -330,7 +326,7 @@ The following examples show how to use this knife subcommand:
 **Regenerate the RSA key-pair**
 
 ``` bash
-knife user reregister "Robert Younger"
+knife user reregister "Arjun Koch"
 ```
 
 ## show
@@ -359,10 +355,10 @@ The following examples show how to use this knife subcommand:
 
 **Show user data**
 
-To view a user named `Dennis Teck`, enter:
+To view a user named `Tamira Bucatar`, enter:
 
 ``` bash
-knife user show "Dennis Teck"
+knife user show "Tamira Bucatar"
 ```
 
 to return something like:
@@ -370,7 +366,7 @@ to return something like:
 ``` bash
 chef_type: user
 json_class:  Chef::User
-name:      Dennis Teck
+name:        Tamira Bucatar
 public_key:
 ```
 
@@ -380,7 +376,7 @@ To view information in JSON format, use the `-F` common option as part
 of the command like this:
 
 ``` bash
-knife user show "Dennis Teck" -F json
+knife user show "Tamira Bucatar" -F json
 ```
 
 (Other formats available include `text`, `yaml`, and `pp`, e.g.


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

The `--admin` option was removed for `user create` but wasn't removed from the docs. The current draft may go too far and still needs compared to the code.


## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
