### PR TITLE
Remove (wrong) config docs for `chef export`

### DIFF
--- a/docs-chef-io/content/workstation/ctl_chef.md
+++ b/docs-chef-io/content/workstation/ctl_chef.md
@@ -1130,10 +1130,6 @@ None.
 
 {{% ctl_chef_export_syntax %}}
 
-#### Configuration Settings
-
-{{% ctl_chef_export_config %}}
-
 #### Options
 
 {{% ctl_chef_export_options %}}


### PR DESCRIPTION
## Description

The docs that describe configuration for `chef export` are incorrect. All of the config settings described are either irrelevant or refer to obsolete settings that are dangerous to use. In particular setting `policy_document_native_api` to `false` as the docs say will break everything.

## Related Issue

Most of the problematic text is in chef-web-docs, which is fixed here: https://github.com/chef/chef-web-docs/pull/2927

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
