### PR TITLE
Add a dep on win32-security to resolve failures in kitchen-vcenter

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -132,4 +132,5 @@ platforms :mswin, :mingw do
   gem "win32-mutex"
   gem "win32-process", ">= 0.9.0" # resolves Ruby 2.7 warnings
   gem "win32-service", ">= 2.1.5" # 2.1.5 resolves ffi warnings
+  gem "win32-security" # remove this once https://github.com/eitoball/net-ping/pull/32 is merged
 end

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.4)
+    activesupport (5.2.4.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -14,7 +14,7 @@ GEM
     artifactory (3.0.15)
     ast (2.4.2)
     aws-eventstream (1.1.0)
-    aws-partitions (1.424.0)
+    aws-partitions (1.426.0)
     aws-sdk-apigateway (1.59.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
@@ -48,7 +48,7 @@ GEM
     aws-sdk-cloudhsmv2 (1.32.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-cloudtrail (1.32.0)
+    aws-sdk-cloudtrail (1.33.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-cloudwatch (1.49.0)
@@ -107,7 +107,7 @@ GEM
     aws-sdk-eks (1.47.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-elasticache (1.52.0)
+    aws-sdk-elasticache (1.53.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-elasticbeanstalk (1.41.0)
@@ -116,7 +116,7 @@ GEM
     aws-sdk-elasticloadbalancing (1.30.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-elasticloadbalancingv2 (1.58.0)
+    aws-sdk-elasticloadbalancingv2 (1.59.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-elasticsearchservice (1.48.0)
@@ -733,16 +733,16 @@ GEM
       tty-color (~> 0.5)
     plist (3.6.0)
     proxifier (1.0.3)
-    pry (0.13.1)
+    pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.8.0)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
+      pry (~> 0.10)
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
-    pry-stack_explorer (0.6.0)
+    pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
     public_suffix (4.0.6)
@@ -1011,6 +1011,9 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.9.0)
       ffi (>= 1.0.0)
+    win32-security (0.5.0)
+      ffi
+      ffi-win32-extensions
     win32-service (2.2.0)
       ffi
       ffi-win32-extensions
@@ -1113,6 +1116,7 @@ DEPENDENCIES
   win32-event
   win32-mutex
   win32-process (>= 0.9.0)
+  win32-security
   win32-service (>= 2.1.5)
   windows-pr
   winrm-elevated


### PR DESCRIPTION
This is due to the way the net-ping gemspec is structured at the moment:

It's resolved by https://github.com/eitoball/net-ping/pull/32

Signed-off-by: Tim Smith <tsmith@chef.io>