### PR TITLE
Add Amazon Linux 2 as a supported OS

### DIFF
--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -41,6 +41,10 @@ Supported Host Operating Systems:
 </tr>
 </thead>
 <tbody>
+<tr class="even">
+<td>Amazon Linux</td>
+<td>2.x</td>
+</tr>
 <tr class="odd">
 <td>Apple macOS</td>
 <td>10.13, 10.14, 10.15, 11.0</td>


### PR DESCRIPTION
We added this a while back

Signed-off-by: Tim Smith <tsmith@chef.io>