### PR TITLE
Extend the chocolatey.org push timeout to 60 minutes

### DIFF
--- a/.expeditor/third-party-packages.pipeline.yml
+++ b/.expeditor/third-party-packages.pipeline.yml
@@ -11,6 +11,7 @@ steps:
         docker:
           host_os: windows
           environment:
+    timeout_in_minutes: 60
 
   - label: ":mac: :github: Create PR to update Homebrew/homebrew-cask"
     command:


### PR DESCRIPTION
It just throws 404s for a LONG time

Signed-off-by: Tim Smith <tsmith@chef.io>