### PR TITLE
Replace chefdk installs instead of failing

### DIFF
--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -23,7 +23,7 @@ homepage      "https://chef.sh"
 license "Chef EULA"
 license_file "CHEF-EULA.md"
 
-conflict "chefdk"
+replace "chefdk"
 
 # Defaults to C:/chef-workstation on Windows
 # and /opt/chef-workstation on all other platforms


### PR DESCRIPTION
Previously we wanted to prevent accidentally upgrading from DK. A this
point we want to make the upgrade easy. Change the conflict to a replace
so that this package can replace the old packages without errors.

Here's the old error:

```
[root@iZrj996x25ht5omuhhzod7Z ~]# rpm -i chef-workstation-21.2.292-1.el7.x86_64.rpm
warning: chef-workstation-21.2.292-1.el7.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
error: Failed dependencies:
	chefdk conflicts with chef-workstation-21.2.292-1.el7.x86_64
```

Signed-off-by: Tim Smith <tsmith@chef.io>