### PR TITLE
Remove macOS 10.13 from the docs

### DIFF
--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -47,7 +47,7 @@ Supported Host Operating Systems:
 </tr>
 <tr class="odd">
 <td>Apple macOS</td>
-<td>10.13, 10.14, 10.15, 11.0</td>
+<td>10.14, 10.15, 11.0</td>
 </tr>
 <tr class="even">
 <td>Microsoft Windows</td>


### PR DESCRIPTION
We don't support this anymore

Signed-off-by: Tim Smith <tsmith@chef.io>