### PR TITLE
Remove the yard dependency

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -25,7 +25,6 @@ group(:omnibus_package, :development, :test) do
 
   gem "rake", "= 13.0.1" # prevent double rake as of 12.2020
   gem "pry"
-  gem "yard"
   gem "guard"
   gem "cookstyle", ">= 7.8"
   gem "ffi-libarchive"

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -1045,7 +1045,6 @@ GEM
       winrm (~> 2.0)
     wisper (2.0.1)
     wmi-lite (1.0.5)
-    yard (0.9.26)
 
 PLATFORMS
   ruby
@@ -1121,7 +1120,6 @@ DEPENDENCIES
   windows-pr
   winrm-elevated
   winrm-fs
-  yard
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
There's really no reason to ship yard in Chef Workstation and it's a
pretty big dep

Signed-off-by: Tim Smith <tsmith@chef.io>