### PR TITLE
Simplify our inspec dep in the gemfile

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -60,8 +60,7 @@ group(:omnibus_package) do
   gem "fauxhai-ng", ">= 8.7"
 
   # inspec
-  gem "inspec-bin", "~> 4.23" # the actual inspec CLI binary
-  gem "inspec", "~> 4.23"
+  gem "inspec-bin", "~> 4.23"
 
   # test-kitchen and plugins
   gem "test-kitchen", ">= 2.7"

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -1074,7 +1074,6 @@ DEPENDENCIES
   fauxhai-ng (>= 8.7)
   ffi-libarchive
   guard
-  inspec (~> 4.23)
   inspec-bin (~> 4.23)
   kitchen-azurerm (>= 1.3)
   kitchen-digitalocean (>= 0.11)


### PR DESCRIPTION
inspec-bin deps on inspec. there's no need to dep on both

Signed-off-by: Tim Smith <tsmith@chef.io>