### PR TITLE
Support artifact_published workload data

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -11,11 +11,13 @@
 
 set -evx
 
+GEM_NAME="${EXPEDITOR_GEM_NAME:-${EXPEDITOR_PRODUCT_KEY:?Could not find gem name}}"
+
 function new_gem_included() {
-  git diff | grep -E '^\+' | grep "${EXPEDITOR_GEM_NAME} (${EXPEDITOR_VERSION})"
+  git diff | grep -E '^\+' | grep "${GEM_NAME} (${EXPEDITOR_VERSION})"
 }
 
-branch="expeditor/${EXPEDITOR_GEM_NAME}_${EXPEDITOR_VERSION}"
+branch="expeditor/${GEM_NAME}_${EXPEDITOR_VERSION}"
 git checkout -b "$branch"
 
 pushd components/gems
@@ -24,10 +26,10 @@ for (( i=1; i<=$tries; i+=1 )); do
   bundle lock --update --add-platform ruby x64-mingw32 x86-mingw32
   new_gem_included && break || sleep 20
   if [ $i -eq $tries ]; then
-    echo "Searching for '${EXPEDITOR_GEM_NAME} (${EXPEDITOR_VERSION})' ${i} times and did not find it"
+    echo "Searching for '${GEM_NAME} (${EXPEDITOR_VERSION})' ${i} times and did not find it"
     exit 1
   else
-    echo "Searched ${i} times for '${EXPEDITOR_GEM_NAME} (${EXPEDITOR_VERSION})'"
+    echo "Searched ${i} times for '${GEM_NAME} (${EXPEDITOR_VERSION})'"
   fi
 done
 popd
@@ -36,7 +38,7 @@ git add .
 
 # give a friendly message for the commit and make sure it's noted for any future audit of our codebase that no
 # DCO sign-off is needed for this sort of PR since it contains no intellectual property
-git commit --message "Bump $EXPEDITOR_GEM_NAME to $EXPEDITOR_VERSION" --message "This pull request was triggered automatically via Expeditor when $EXPEDITOR_GEM_NAME $EXPEDITOR_VERSION was promoted to Rubygems." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
+git commit --message "Bump $GEM_NAME to $EXPEDITOR_VERSION" --message "This pull request was triggered automatically via Expeditor when $GEM_NAME $EXPEDITOR_VERSION was promoted to Rubygems." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
 
 open_pull_request "$EXPEDITOR_BRANCH"
 


### PR DESCRIPTION
Look for env vars from both artifact_published and ruby_gem_published.

Signed-off-by: Tom Duffield <tom@chef.io>