### PR TITLE
config_rb & knife exec updates for user & user keys global endpoints #2240

### DIFF
--- a/docs-chef-io/content/workstation/config_rb.md
+++ b/docs-chef-io/content/workstation/config_rb.md
@@ -50,7 +50,7 @@ This configuration file has the following settings:
   ```
 
   {{< note >}}
-  If changes need to be made to any global end points like user or user keys, add `--server-url` flag pointing to `https://localhost/`.
+  If changes need to be made to any global end points like user or user keys, use [`knife exec`]({{< relref "workstation/knife_exec" >}}) with the `--server-url` flag to set `chef_server_url` to `https://localhost/`.
   {{< /note >}}
 
 `chef_zero.enabled`

--- a/docs-chef-io/content/workstation/config_rb.md
+++ b/docs-chef-io/content/workstation/config_rb.md
@@ -49,6 +49,10 @@ This configuration file has the following settings:
   chef_server_url 'https://localhost/organizations/ORG_NAME'
   ```
 
+  {{< note >}}
+  If changes need to be made to any global end points like user or user keys, add `--server-url` flag pointing to `https://localhost/`.
+  {{< /note >}}
+
 `chef_zero.enabled`
 : Enable chef-zero. This setting requires `local_mode` to be set to `true`. Default value: `false`. For example:
 

--- a/docs-chef-io/content/workstation/knife_exec.md
+++ b/docs-chef-io/content/workstation/knife_exec.md
@@ -199,6 +199,14 @@ To list all of the available search indexes, enter:
 knife exec -E 'puts api.get("search").keys'
 ```
 
+**Operations on Users and User Keys**
+
+To change any global end points like user or user keys, use the `--server-url` flag:
+
+``` bash
+knife exec -E 'api.delete("/users/myuser/keys/user33")' --server-url https://
+```
+
 **Query for multiple attributes**
 
 To query a node for multiple attributes using a Ruby script named


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

<!--- Provide a short summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
chef_server_url should be https://hostname instead of http://hostname/organizations/orgname/
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Knife exec uses the chef_server_url from knife.rb.

If changes need to be made to any global end points like user or user keys,
chef_server_url needs to be updated to https://hostname instead of http://hostname/organizations/orgname/

or a flag for --chef_server_url http:// should be included in the command line.
eg: knife exec -E 'api.delete("/users/myuser/keys/user33")' --server-url https://
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
