### PR TITLE
Update the habitat promotion subscription again

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -72,7 +72,7 @@ subscriptions:
       # publish to third party package managers that have a dependency
       # on this artifact's availability
       - trigger_pipeline:third-party-packages
-  - workload: buildkite_build_passed:habitat-sh/habitat:master:finish_release:*
+  - workload: habitat-sh/habitat:master_completed:project_promoted:habitat-sh/habitat:master:current:*
     actions:
       - bash:.expeditor/update_habitat.sh
   - workload: chef/chef-workstation-app:master_completed:pull_request_merged:chef/chef-workstation-app:master:*


### PR DESCRIPTION
This should eliminate the failures on each merge to habitat that we're
seeing right now

Signed-off-by: Tim Smith <tsmith@chef.io>