### PR TITLE
Remove ChefSpec from the workstation description

### DIFF
--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -22,7 +22,7 @@ Chef Workstation includes:
 - Chef InSpec
 - Chef Habitat
 - chef and knife command line tools
-- Testing tools such as Test Kitchen, ChefSpec, and Cookstyle
+- Testing tools such as Test Kitchen and Cookstyle
 - Everything else needed to author cookbooks and upload them to the Chef Infra Server
 
 ## Supported Platforms


### PR DESCRIPTION
We don't want to list this anymore

Signed-off-by: Tim Smith <tsmith@chef.io>