### PR TITLE
Use the chef_workstation shortcode consistently

### DIFF
--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -14,16 +14,7 @@ aliases = ["/install_workstation.html", "/install_dk.html", "/workstation_window
     weight = 20
 +++
 
-Start your infrastructure automation quickly and easily with [Chef Workstation](/workstation/). Chef Workstation gives you everything you need to get started with Chef - ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software - all in one easy-to-install package.
-
-Chef Workstation includes:
-
-- Chef Infra Client
-- Chef InSpec
-- Chef Habitat
-- chef and knife command line tools
-- Testing tools such as Test Kitchen and Cookstyle
-- Everything else needed to author cookbooks and upload them to the Chef Infra Server
+{{% chef_workstation %}}
 
 ## Supported Platforms
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>


## Description

Uses the shortcode from https://github.com/chef/chef-web-docs/pull/3030 consistently. The updated shortcode contains a description of WS and an updated list of its contents. We need to sync the go module from chef-web-docs & then this should work perfectly.
