### PR TITLE
Appbundle chef-zero, mixlib-install, and fauxhai

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -56,7 +56,7 @@ group(:omnibus_package) do
 
   # chefspec
   gem "chefspec", ">= 9.2"
-  gem "fauxhai-ng", ">= 8.7"
+  gem "fauxhai-ng", ">= 8.7.1"
 
   # inspec
   gem "inspec-bin", "~> 4.23"

--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -433,7 +433,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    fauxhai-ng (8.7.0)
+    fauxhai-ng (8.7.1)
       net-ssh
     ffi (1.15.0)
     ffi (1.15.0-x64-mingw32)
@@ -1070,7 +1070,7 @@ DEPENDENCIES
   dep_selector
   docker-api (>= 2.0)
   ed25519
-  fauxhai-ng (>= 8.7)
+  fauxhai-ng (>= 8.7.1)
   ffi-libarchive
   guard
   inspec-bin (~> 4.23)

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -130,7 +130,7 @@ do_install() {
     appbundle "berkshelf" "changelog,debug,docs,development"
     wrap_ruby_bin "berks"
 
-    appbundle cookstyle "changelog"
+    appbundle cookstyle "changelog,docs,profiling,rubocop_gems,development,debug"
     wrap_ruby_bin "cookstyle"
 
     appbundle "chef-vault" "changelog"
@@ -138,6 +138,15 @@ do_install() {
 
     appbundle chef-apply "changelog,docs,debug" # really, chef-run
     wrap_ruby_bin "chef-run"
+
+    appbundle mixlib-install "test,chefstyle,debug"
+    wrap_ruby_bin "mixlib-install"
+
+    appbundle fauxhai
+    wrap_ruby_bin "fauxhai"
+
+    appbundle chef-zero "pedant,development,debug"
+    wrap_ruby_bin "chef-zero"
   )
 
   if [ "$(readlink /usr/bin/env)" = "$(pkg_interpreter_for core/coreutils bin/env)" ]; then

--- a/omnibus/config/software/gems.rb
+++ b/omnibus/config/software/gems.rb
@@ -70,12 +70,16 @@ build do
   appbundle "foodcritic", lockdir: project_dir, gem: "chef_deprecations", without: %w{development test}, env: env
   appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs development integration}, env: env
   appbundle "inspec", lockdir: project_dir, gem: "inspec-bin", without: %w{deploy tools maintenance integration}, env: env
-  appbundle "chef-run", lockdir: project_dir, gem: "chef-apply", without: %w{changelog docs debug}, env: env
-  appbundle "chef-cli", lockdir: project_dir, gem: "chef-cli", without: %w{changelog docs debug}, env: env
+  appbundle "chef-run", lockdir: project_dir, gem: "chef-apply", without: %w{development docs debug}, env: env
+  appbundle "chef-cli", lockdir: project_dir, gem: "chef-cli", without: %w{development profile test}, env: env
   appbundle "berkshelf", lockdir: project_dir, gem: "berkshelf", without: %w{changelog build docs debug development}, env: env
+  appbundle "mixlib-install", lockdir: project_dir, gem: "mixlib-install", without: %w{test chefstyle debug}, env: env
+  appbundle "chef-zero", lockdir: project_dir, gem: "chef-zero", without: %w{pedant development debug}, env: env
+  appbundle "cookstyle", lockdir: project_dir, gem: "cookstyle", without: %w{docs profiling rubocop_gems development debug}, env: env
+  appbundle "fauxhai", lockdir: project_dir, gem: "fauxhai-ng", env: env
 
   # Note - 'chef-apply' gem provides 'chef-run', not 'chef-apply' which ships with chef-bin...
-  %w{chef-bin chef-apply chef-vault ohai cookstyle}.each do |gem|
+  %w{chef-bin chef-apply chef-vault ohai}.each do |gem|
     appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 

--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -75,7 +75,7 @@ if [ "$moved" = "1" ]; then
   echo ""
 fi
 
-binaries="chef-run berks chef chef-cli chef-analyze chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai chef-client hab"
+binaries="chef-run berks chef chef-cli chef-analyze chef-apply chef-shell chef-solo chef-vault cookstyle delivery foodcritic inspec kitchen knife ohai chef-client hab chef-zero mixlib-install fauxhai"
 for binary in $binaries; do
   ln -sf "$INSTALLER_DIR/bin/$binary" $PREFIX/bin || error_exit "Cannot link $binary to $PREFIX/bin"
 done
@@ -137,6 +137,6 @@ fi
 
 echo ""
 echo "Thank you for installing Chef Workstation!"
-echo "You can find some tips on getting started at https://docs.chef.io/workstation/"
+echo "You can find some tips on getting started at https://docs.chef.io/workstation/getting_started/"
 echo ""
 exit 0

--- a/omnibus/package-scripts/chef-workstation/postrm
+++ b/omnibus/package-scripts/chef-workstation/postrm
@@ -12,7 +12,7 @@ is_darwin()
 cleanup_symlinks() {
   # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
   # leftovers from older versions. We keep the push jobs values here to cleanup old releases
-  workstation_binaries="berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client"
+  workstation_binaries="berks chef chef-cli chef-apply chef-shell chef-solo chef-vault cookstyle dco delivery foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager chef-client mixlib-install chef-zero fauxhai"
   binaries="chef-run chef-workstation-app $workstation_binaries chef-analyze hab"
 
   for binary in $binaries; do


### PR DESCRIPTION
This gets us closer to being able to skip the embedded/bin dir

Signed-off-by: Tim Smith <tsmith@chef.io>