### PR TITLE
Require Ubuntu 18.04 or later

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -18,8 +18,7 @@ builder-to-testers-map:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   windows-2012r2-x86_64:

--- a/docs-chef-io/content/workstation/config_yml_kitchen.md
+++ b/docs-chef-io/content/workstation/config_yml_kitchen.md
@@ -603,8 +603,8 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: centos-7
   - name: centos-8
 
@@ -669,7 +669,7 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
     attributes:
       chef-server:
         api_fqdn: backend.chef-server.com

--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -50,7 +50,7 @@ Supported Host Operating Systems:
 </tr>
 <tr class="even">
 <td>Ubuntu</td>
-<td>16.04, 18.04, 20.04</td>
+<td>18.04, 20.04</td>
 </tr>
 <tr class="odd">
 <td>Debian</td>

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -26,12 +26,8 @@ provisioner:
 # prior built artifacts in pkg/ which is shared across VMs
 platforms:
   - name: centos-7
-  - name: centos-8
   - name: debian-9
-  - name: debian-10
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
-  - name: ubuntu-20.04
   - name: windows-2012r2-standard
     provisioner:
       attributes:


### PR DESCRIPTION
Ubuntu 16.04 is EOL now

Signed-off-by: Tim Smith <tsmith@chef.io>