### PR TITLE
Remove references to node_name on knife_setup doc for credentials

### DIFF
--- a/docs-chef-io/content/workstation/knife_setup.md
+++ b/docs-chef-io/content/workstation/knife_setup.md
@@ -61,7 +61,7 @@ quotes when the name contains a period. For example:
 ``` none
 # Example .chef/credentials file
 [default]
-node_name = "barney"
+client_name = "barney"
 client_key = "barney_rubble.pem"
 chef_server_url = "https://api.chef.io/organizations/bedrock"
 
@@ -84,7 +84,7 @@ validator_key = "test-validator.pem"
 chef_server_url = "https://api.chef-server.dev/organizations/test"
 
 ['web.preprod']
-node_name = "brubble"
+client_name = "brubble"
 client_key = "preprod-brubble.pem"
 chef_server_url = "https://preprod.chef-server.dev/organizations/preprod"
 


### PR DESCRIPTION

Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Updates knife_setup docs to remove `node_name` references from credentials file in favor of `client_name`.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#1987 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
