### PR TITLE
Remove curl as a default component in the verify tests

### DIFF
--- a/omnibus/verification/spec/unit/verify_spec.rb
+++ b/omnibus/verification/spec/unit/verify_spec.rb
@@ -52,7 +52,6 @@ describe ChefWorkstation::Command::Verify do
       "inspec",
       "git",
       "delivery-cli",
-      "curl",
     ]
   end
 


### PR DESCRIPTION
This doesn't work like this

Signed-off-by: Tim Smith <tsmith@chef.io>