### PR TITLE
Remove the mention of the chef-vault cookbook and gem installation

### DIFF
--- a/docs-chef-io/content/workstation/chef_vault.md
+++ b/docs-chef-io/content/workstation/chef_vault.md
@@ -23,17 +23,7 @@ Chef Vault is included in Chef Workstation and Chef Infra Client by way of the
 
 {{< note >}}
 
-Chef Vault does not currently support alternate keying mechanisms like
-GPG and Amazon KMS.
-
-{{< /note >}}
-
-- For more information about using the chef-vault cookbook, its helper methods and resources, see <https://github.com/chef-cookbooks/chef-vault>
-
-The chef-vault cookbook is maintained by Chef Software. Use it along
-with Chef Vault itself. This cookbook adds the `chef_vault_item`
-helper method to the Chef Infra Language and the `chef_vault_secret` resource.
-Use them both in recipes to work with data bag secrets.
+Chef Vault does not currently support alternate keying mechanisms like GPG and Amazon KMS.
 
 {{< warning >}}
 
@@ -55,10 +45,6 @@ Neither PUB key nor PRIV key:: nested asn1 error
 ```
 
 {{< /warning >}}
-
-## Installation
-
-The Chef Workstation ships with the latest release of the `chef-vault` gem.
 
 ### Configuring config.rb for Chef Vault
 


### PR DESCRIPTION
The cookbook is dead now that we ship the resources / helpers in Chef
Infra Client itself. Also why are we talking about installation in the
Workstation docs. That's just a waste of space.

Signed-off-by: Tim Smith <tsmith@chef.io>