### PR TITLE
Redirect to chef-server-ctl commands

### DIFF
--- a/docs-chef-io/content/workstation/plugin_knife_opc.md
+++ b/docs-chef-io/content/workstation/plugin_knife_opc.md
@@ -20,9 +20,11 @@ Chef Server 12.
 
 Administrator permissions are required to add, remove, or edit users. To
 manage organizations, or change a user's assignment to an organization,
-the pivotal key is required. To grant a user administrator permissions,
-use `chef-server-ctl grant-server-admin-permissions USER_NAME` on the
-Chef Infra Server. [See chef-server-ctl for
+the pivotal key is required. Rather than using the knife-opc plugin
+commands below, which are an implementation detail, use the equivalent 
+"user-" and "org-" subcommands directly on the Chef Infra Server. 
+Those wrappered subcommands already have the needed permissions applied and access 
+to sensitive commands will then be centralized. [See chef-server-ctl for
 details](/ctl_chef_server/).
 
 {{< /note >}}


### PR DESCRIPTION

Signed-off-by: Sean Horn <horn@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Use the equivalent, already functioning chef-server-ctl org- and user- subcommands rather than getting mired in permissions setting and issues running commands as non-pivotal users


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
- [X] Docs

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
