### PR TITLE
Rollback unf_ext to 0.0.7.6

### DIFF
--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -990,9 +990,7 @@ GEM
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.7)
-    unf_ext (0.0.7.7-x64-mingw32)
-    unf_ext (0.0.7.7-x86-mingw32)
+    unf_ext (0.0.7.6)
     unicode-display_width (2.0.0)
     unicode_utils (1.4.0)
     uuidtools (2.2.0)


### PR DESCRIPTION
The 0.0.7.7 version isn't compatible with ruby-3.0 on windows (which
makes it a bit of a puzzle that this even built and shipped...)

(I also sorta doubt this "works" on windows, but there's nothing we can do about it, and
this causes the gem depsolver to not immediately puke)