### PR TITLE
Reduce @docs-team PR approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*                           @chef/chef-workstation-owners @chef/chef-workstation-approvers @chef/chef-workstation-reviewers
+*                           @chef/chef-workstation-owners @chef/chef-workstation-approvers  @chef/chef-workstation-reviewers
 .expeditor/                 @chef/jex-team
-*.md                        @chef/docs-team
+README.md                   @chef/docs-team
 components/chef-cli/i18n/** @chef/user-experience
-docs-chef-io                @chef/docs-team
+docs-chef-io/               @chef/docs-team


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

Alert docs team for docs-related PRS.

## Description

Docs currently gets notifications for changes to any `.md` files, which is probably unhelpful for everyone involved. This PR adds us to changes in the repo README.md and to `docs-chef-io/`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
