### PR TITLE
Build packages specifically on RHEL 8

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -13,8 +13,9 @@ builder-to-testers-map:
     - debian-10-x86_64
   el-7-x86_64:
     - el-7-x86_64
-    - el-8-x86_64
     - amazon-2-x86_64
+  el-8-x86_64:
+    - el-8-x86_64
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 237c0a49b458da92cc6cdfbc488b8455f848f1c4
+  revision: c172afb1399eb676e86f6f8c155fe747e0312f38
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 6d109b6cd7bf35e4d0f4ca0bb5378b1d430e44df
+  revision: 9ffcd89d078b3467be0480b138841ee82dd2d5d4
   branch: master
   specs:
-    omnibus (8.1.14)
+    omnibus (8.1.15)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)
@@ -33,17 +33,17 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.478.0)
-    aws-sdk-core (3.117.0)
+    aws-partitions (1.481.0)
+    aws-sdk-core (3.118.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.44.0)
-      aws-sdk-core (~> 3, >= 3.112.0)
+    aws-sdk-kms (1.45.0)
+      aws-sdk-core (~> 3, >= 3.118.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.96.1)
-      aws-sdk-core (~> 3, >= 3.112.0)
+    aws-sdk-s3 (1.97.0)
+      aws-sdk-core (~> 3, >= 3.118.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.4)
@@ -65,12 +65,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.13.16)
+    chef (16.14.1)
       addressable
       bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
-      chef-config (= 16.13.16)
-      chef-utils (= 16.13.16)
+      chef-config (= 16.14.1)
+      chef-utils (= 16.14.1)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -102,12 +102,12 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
-    chef (16.13.16-universal-mingw32)
+    chef (16.14.1-universal-mingw32)
       addressable
       bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
-      chef-config (= 16.13.16)
-      chef-utils (= 16.13.16)
+      chef-config (= 16.14.1)
+      chef-utils (= 16.14.1)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -151,17 +151,17 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.13.16)
+    chef-config (16.14.1)
       addressable
-      chef-utils (= 16.13.16)
+      chef-utils (= 16.14.1)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
-    chef-telemetry (1.0.29)
+    chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (16.13.16)
+    chef-utils (16.14.1)
     chef-vault (4.1.0)
     chef-zero (15.0.7)
       ffi-yajl (~> 2.2)
@@ -191,7 +191,7 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.15.3)
@@ -212,7 +212,7 @@ GEM
     highline (2.0.3)
     httpclient (2.8.3)
     iniparse (1.5.0)
-    inspec-core (4.38.3)
+    inspec-core (4.38.9)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -345,7 +345,7 @@ GEM
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     rubyntlm (0.6.3)
     rubyzip (2.3.2)
     sawyer (0.8.2)
@@ -381,7 +381,7 @@ GEM
     toml-rb (2.0.1)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.3.0)
-    train-core (3.7.4)
+    train-core (3.8.1)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)


### PR DESCRIPTION
This further optimizes these builds and fixes incorrect package names
that included el7 in their filenames

Signed-off-by: Tim Smith <tsmith@chef.io>