### PR TITLE
Fix main-chef-wrapper Go cross platform build that is part of verify pipeline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -41,11 +41,7 @@ subscriptions:
             - "Expeditor: Skip Changelog"
             - "Expeditor: Skip All"
             - "Aspect: Documentation"
-<<<<<<< HEAD
       # The git commit happens here
-=======
-    # The git commit happens here
->>>>>>> a58b6e54 (Fixing expeditor config validation failure)
       - bash:.expeditor/push-git-tag.sh:
           only_if: bash:.expeditor/determine_version.sh
           post_commit: true
@@ -55,10 +51,6 @@ subscriptions:
             - "Expeditor: Skip All"
             - "Aspect: Documentation"
           only_if: bash:.expeditor/determine_version.sh
-<<<<<<< HEAD
-=======
-
->>>>>>> a58b6e54 (Fixing expeditor config validation failure)
   - workload: artifact_published:unstable:chef-workstation:{{version_constraint}}
     actions:
       - trigger_pipeline:docker/build

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -239,3 +239,4 @@ subscriptions:
   - workload: ruby_gem_published:docker-api
     actions:
        - bash:.expeditor/update_dep.sh
+

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -41,7 +41,11 @@ subscriptions:
             - "Expeditor: Skip Changelog"
             - "Expeditor: Skip All"
             - "Aspect: Documentation"
+<<<<<<< HEAD
       # The git commit happens here
+=======
+    # The git commit happens here
+>>>>>>> a58b6e54 (Fixing expeditor config validation failure)
       - bash:.expeditor/push-git-tag.sh:
           only_if: bash:.expeditor/determine_version.sh
           post_commit: true
@@ -51,6 +55,10 @@ subscriptions:
             - "Expeditor: Skip All"
             - "Aspect: Documentation"
           only_if: bash:.expeditor/determine_version.sh
+<<<<<<< HEAD
+=======
+
+>>>>>>> a58b6e54 (Fixing expeditor config validation failure)
   - workload: artifact_published:unstable:chef-workstation:{{version_constraint}}
     actions:
       - trigger_pipeline:docker/build

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -239,4 +239,3 @@ subscriptions:
   - workload: ruby_gem_published:docker-api
     actions:
        - bash:.expeditor/update_dep.sh
-

--- a/components/main-chef-wrapper/.studiorc
+++ b/components/main-chef-wrapper/.studiorc
@@ -8,6 +8,12 @@ source "$(hab pkg path chef/studio-common)/bin/studio-common"
 # switch all go commands to use the vendor/ directory
 export GOFLAGS="-mod=vendor"
 
+# Specify where to put 'go installed' binaries
+export GOBIN=/src/bin
+
+# Make 'go installed' binaries available in the PATH
+export PATH="$GOBIN:$PATH"
+
 function build_cross_platform() {
   install_if_missing core/go go
   install_if_missing core/gox gox

--- a/components/main-chef-wrapper/.studiorc
+++ b/components/main-chef-wrapper/.studiorc
@@ -19,8 +19,7 @@ function build_cross_platform() {
   install_if_missing core/gox gox
   ( cd /src || exit 1
     gox -output="../../bin/chef_{{.OS}}_{{.Arch}}" \
-        -os="darwin linux windows" \
-        -arch="amd64"
+        -osarch="darwin/amd64 linux/amd64 windows/amd64"
   )
 }
 

--- a/components/main-chef-wrapper/.studiorc
+++ b/components/main-chef-wrapper/.studiorc
@@ -20,8 +20,7 @@ function build_cross_platform() {
   go mod vendor
   ( cd /src || exit 1
     gox -output="../../bin/chef_{{.OS}}_{{.Arch}}" \
-        -os="darwin linux windows" \
-        -arch="amd64"
+        -osarch="darwin/amd64 linux/amd64 windows/amd64"
   )
 }
 

--- a/components/main-chef-wrapper/.studiorc
+++ b/components/main-chef-wrapper/.studiorc
@@ -20,7 +20,8 @@ function build_cross_platform() {
   go mod vendor
   ( cd /src || exit 1
     gox -output="../../bin/chef_{{.OS}}_{{.Arch}}" \
-        -osarch="darwin/amd64 linux/amd64 windows/amd64"
+        -os="darwin linux windows" \
+        -arch="amd64"
   )
 }
 

--- a/components/main-chef-wrapper/.studiorc
+++ b/components/main-chef-wrapper/.studiorc
@@ -17,6 +17,7 @@ export PATH="$GOBIN:$PATH"
 function build_cross_platform() {
   install_if_missing core/go go
   install_if_missing core/gox gox
+  go mod vendor
   ( cd /src || exit 1
     gox -output="../../bin/chef_{{.OS}}_{{.Arch}}" \
         -osarch="darwin/amd64 linux/amd64 windows/amd64"


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Updated the cross platform build script to have `go mod vendor` run prior to `gox`
A few environment variables are present in same file in chef-analyze repo. Adding here for consistency.

## Related Issue
https://github.com/chef/chef-workstation/issues/2274

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
