### PR TITLE
Fix menu in section in workstation pages

### DIFF
--- a/docs-chef-io/content/workstation/plugin_knife.md
+++ b/docs-chef-io/content/workstation/plugin_knife.md
@@ -6,7 +6,7 @@ aliases = ["/plugin_knife.html"]
 product = ["workstation"]
 
 [menu]
-  [menu.infra]
+  [menu.workstation]
     title = "Cloud Plugins"
     identifier = "chef_workstation/extension_apis/knife_plugins/plugin_knife.md Cloud Plugins"
     parent = "chef_workstation/extension_apis/knife_plugins"

--- a/docs-chef-io/content/workstation/plugin_knife_custom.md
+++ b/docs-chef-io/content/workstation/plugin_knife_custom.md
@@ -6,7 +6,7 @@ aliases = ["/plugin_knife_custom.html"]
 product = ["workstation"]
 
 [menu]
-  [menu.infra]
+  [menu.workstation]
     title = "Writing Custom Plugins"
     identifier = "chef_workstation/extension_apis/knife_plugins/plugin_knife_custom.md Writing Custom Plugins"
     parent = "chef_workstation/extension_apis/knife_plugins"


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

These pages should be in the workstation menu, not the infra menu.

Related PRs: 
- chef/chef-web-docs#3423
- chef/chef-web-docs#3454

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
