### PR TITLE
Stop producing macOS 10.14 packages

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -17,8 +17,7 @@ builder-to-testers-map:
     - amazon-2-x86_64
   el-8-x86_64:
     - el-8-x86_64
-  mac_os_x-10.14-x86_64:
-    - mac_os_x-10.14-x86_64
+  mac_os_x-10.15-x86_64:
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64

--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -38,7 +38,7 @@ Supported Host Operating Systems:
 </tr>
 <tr class="odd">
 <td>Apple macOS</td>
-<td>10.14, 10.15, 11, 12</td>
+<td>10.15, 11, 12</td>
 </tr>
 <tr class="even">
 <td>Microsoft Windows</td>


### PR DESCRIPTION
We support N-2 macOS releases which is now 12, 11, and 10.15.

Signed-off-by: Tim Smith <tsmith@chef.io>