### PR TITLE
Fix Chef Workstation App not being properly bundled

### DIFF
--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -48,7 +48,7 @@ else
 
   build do
     mkdir app_install_path
-    copy relative_path, app_install_path
+    copy cache_dir, app_install_path
   end
 end
 

--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -48,7 +48,7 @@ else
 
   build do
     mkdir app_install_path
-    copy cache_dir, app_install_path
+    copy project_dir, app_install_path
   end
 end
 


### PR DESCRIPTION
Relative_path is not working for the copying of files from the zip. Changing to use project_dir instead 

Signed-off-by: Michael Maslanka <maslanka@progress.com>