### PR TITLE
Move chef env to go

### DIFF
--- a/components/main-chef-wrapper/cmd/env.go
+++ b/components/main-chef-wrapper/cmd/env.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/chef/chef-workstation/components/main-chef-wrapper/dist"
+	"github.com/chef/chef-workstation/components/main-chef-wrapper/platform-lib"
 	"github.com/spf13/cobra"
 )
 
@@ -31,14 +32,19 @@ var envCmd = &cobra.Command{
 	Short:              "Prints environment variables used by %s",
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ReturnEnvironment()
+		if len(args) >= 1 {
+			cmd.Help()
+			os.Exit(0)
+		}else {
+			ReturnEnvironment()
+		}
 		return nil
 	},
 }
 
 
 func ReturnEnvironment() {
-	err := platform_lib.Environment()
+	err := platform_lib.RunEnvironment()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR:", err.Error())
 		os.Exit(4)

--- a/components/main-chef-wrapper/cmd/env.go
+++ b/components/main-chef-wrapper/cmd/env.go
@@ -31,8 +31,19 @@ var envCmd = &cobra.Command{
 	Short:              "Prints environment variables used by %s",
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return Runner.PassThroughCommand(dist.WorkstationExec, "", os.Args[1:])
+		ReturnEnvironment()
+		return nil
 	},
+}
+
+
+func ReturnEnvironment() {
+	err := platform_lib.Environment()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR:", err.Error())
+		os.Exit(4)
+	}
+	os.Exit(0)
 }
 
 func init() {

--- a/components/main-chef-wrapper/lib/cli_helpers.go
+++ b/components/main-chef-wrapper/lib/cli_helpers.go
@@ -45,7 +45,7 @@ func OmnibusGemRoot() string {
 }
 
 func OmnibusGemHome() string {
-	return "/Users/prsingh/.chefdk/gem/ruby/3.0.0" // TODO - get this dynmically using golang
+	return "/Users/prsingh/.chefdk/gem/ruby/3.0.0" // TODO - get this dynamically using golang
 }
 
 func OmnibusGemPath() []string {

--- a/components/main-chef-wrapper/lib/cli_helpers.go
+++ b/components/main-chef-wrapper/lib/cli_helpers.go
@@ -1,0 +1,63 @@
+package lib
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+
+func PackageHome() string{
+	var packageHomeSet =  os.Getenv("CHEF_WORKSTATION_HOME")
+	var packageHome string
+	if len(packageHomeSet) != 0 {
+		packageHome =  packageHomeSet
+	}else{
+		packageHome =  DefaultPackageName()
+	}
+	return packageHome
+}
+
+
+func DefaultPackageName() string{
+	// this logic can be used if other logic doesn't work.
+	//if runtime.GOOS == "windows" {
+	//home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	//if home == "" {
+	//home = os.Getenv("USERPROFILE")
+	//home = os.Getenv("LOCALAPPDATA")
+	//}
+	//return home
+	//}
+	//return os.Getenv("HOME")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal( err )
+	}
+	return filepath.Join(home, dist.WorkstationDir)
+}
+
+func OmnibusGemRoot() string {
+	return "/opt/chef-workstation/embedded/lib/ruby/gems/3.0.0" // TODO - get this dynmically using golang
+}
+
+func OmnibusGemHome() string {
+	return "/Users/prsingh/.chefdk/gem/ruby/3.0.0" // TODO - get this dynmically using golang
+}
+
+func OmnibusGemPath() []string {
+	str := "/Users/prsingh/.chefdk/gem/ruby/3.0.0:/opt/chef-workstation/embedded/lib/ruby/gems/3.0.0" // TODO - get this dynmically using golang
+	split := strings.Split(str, ":")
+	return split
+}
+
+
+func OmnibusPath() []string {
+	str := "/opt/chef-workstation/bin:/Users/prsingh/.chefdk/gem/ruby/3.0.0/bin:/opt/chef-workstation/embedded/bin:/Users/prsingh/.rbenv/bin:/Users/prsingh/go/bin:/Users/prsingh/.nvm/versions/node/v15.3.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/opt/chef-workstation/gitbin" // TODO - get this dynmically using golang
+	split := strings.Split(str, ":")
+	return split
+
+}

--- a/components/main-chef-wrapper/lib/version_constants.go
+++ b/components/main-chef-wrapper/lib/version_constants.go
@@ -1,0 +1,3 @@
+package lib
+
+const ChefCliVersion = "5.4.2"

--- a/components/main-chef-wrapper/platform-lib/environment_darwin.go
+++ b/components/main-chef-wrapper/platform-lib/environment_darwin.go
@@ -1,1 +1,36 @@
 package platform_lib
+
+
+type EnvInfo struct {
+	ChefWorkstation ChefWorkstationInfo
+	Ruby RubyInfo
+	Path []string
+}
+
+
+type ChefWorkstationInfo struct {
+	Version string
+	Home string
+	InstallDirectory string
+	PolicyfileConfig PolicyFileConfigInfo
+}
+type RubyInfo struct{
+	Executable string
+	version string
+	RubyGems GemInfo
+}
+
+type GemInfo struct{
+	RubyGemsVersion string
+	RubyGemsPlatforms []string
+	GemEnvironment []string
+}
+
+type PolicyFileConfigInfo struct {
+	CachePath string
+	StoragePath string
+}
+
+func RunEnvironment() error {
+	return nil
+}

--- a/components/main-chef-wrapper/platform-lib/environment_darwin.go
+++ b/components/main-chef-wrapper/platform-lib/environment_darwin.go
@@ -1,6 +1,15 @@
 package platform_lib
 
 
+import (
+	"fmt"
+	"github.com/chef/chef-workstation/components/main-chef-wrapper/dist"
+	"github.com/chef/chef-workstation/components/main-chef-wrapper/lib"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 type EnvInfo struct {
 	ChefWorkstation ChefWorkstationInfo
 	Ruby RubyInfo
@@ -9,7 +18,7 @@ type EnvInfo struct {
 
 
 type ChefWorkstationInfo struct {
-	Version string
+	version string
 	Home string
 	InstallDirectory string
 	PolicyfileConfig PolicyFileConfigInfo
@@ -23,7 +32,7 @@ type RubyInfo struct{
 type GemInfo struct{
 	RubyGemsVersion string
 	RubyGemsPlatforms []string
-	GemEnvironment []string
+	GemEnvironment GemEnvironmentInfo
 }
 
 type PolicyFileConfigInfo struct {
@@ -31,6 +40,88 @@ type PolicyFileConfigInfo struct {
 	StoragePath string
 }
 
+type GemEnvironmentInfo struct{
+	GemRoot string
+	GemHome string
+	GemPath []string
+}
+
 func RunEnvironment() error {
 	return nil
 }
+
+func WorkstationInfo() ChefWorkstationInfo {
+	fmt.Print("workstation info")
+	if omnibusInstall() == true {
+		info := ChefWorkstationInfo{Version: dist.ChefCliVersion}
+		info.Home = lib.PackageHome()
+		info.InstallDirectory = omnibusRoot() // can be shifted to cli_helper.rb
+		info.PolicyfileConfig =  PolicyFileConfigInfo{CachePath: CachePath(), StoragePath: StoragePath() }
+		return info
+	} else {
+		info := ChefWorkstationInfo{Version: "Not running from within Workstation"}
+		return info
+	}
+}
+
+func CachePath() string  {
+	return filepath.Join(lib.DefaultPackageName(), "cache")
+}
+
+func StoragePath() string  {
+	return filepath.Join(lib.DefaultPackageName(), "cookbooks")
+}
+
+func WorkstationRubyInfo() RubyInfo {
+	fmt.Print("ruby info")
+	rubyinfo := RubyInfo{Executable: "/opt/chef-workstation/embedded/bin/ruby"} // Gem.ruby got us this in ruby TODO- need to see how to convert this
+	rubyinfo.version = "3.0.2" // Todo- RUBY_VERSION has this value in ruby, need to see ho we cn convert this one.
+	rubyinfo.RubyGems = GemInfo{RubyGemsVersion: "3.2.22", RubyGemsPlatforms: []string{"ruby", "x86_64-darwin-18" }, GemEnvironment: WsEnvironmentInfo() }
+	return rubyinfo
+}
+
+func WsEnvironmentInfo() GemEnvironmentInfo {
+	if  omnibusInstall() == true {
+		envInfo := GemEnvironmentInfo{GemRoot: lib.OmnibusGemRoot()}
+		envInfo.GemHome = lib.OmibusGemHome()
+		envInfo.GemPath = lib.OmibusGemPath()
+	} else {
+		envInfo := GemEnvironmentInfo{}
+		gemroot :=  os.Getenv("GEM_ROOT")
+		if gemroot != ""{
+			envInfo.GemRoot = gemroot
+		}
+		gemhome :=  os.Getenv("GEM_HOME")
+		if gemhome != ""{
+			envInfo.GemHome = gemhome
+		}
+		gempath :=  os.Getenv("GEM_PATH")
+		if gempath != ""{
+			gempathmap := strings.Split(str, ":")
+			envInfo.GemPath = gempathmap
+		}
+	}
+	return envInfo
+}
+
+func PathInfo()  {
+	
+}
+
+
+//
+//
+//
+//func PackageHome() string {
+//	return "ddd"
+//}
+//def package_home
+//@package_home ||= begin
+//package_home_set = !([nil, ""].include? ENV["CHEF_WORKSTATION_HOME"])
+//if package_home_set
+//ENV["CHEF_WORKSTATION_HOME"]
+//else
+//default_package_home
+//end
+//end
+//end

--- a/components/main-chef-wrapper/platform-lib/environment_darwin.go
+++ b/components/main-chef-wrapper/platform-lib/environment_darwin.go
@@ -47,6 +47,12 @@ type GemEnvironmentInfo struct{
 }
 
 func RunEnvironment() error {
+	// call all the environment info here.
+	envObj := WorkstationEnvInfo()
+	
+	fmt.Println(envObj)
+
+	// make yml dump like ruby --   ui.msg YAML.dump(info)
 	return nil
 }
 
@@ -97,15 +103,33 @@ func WsEnvironmentInfo() GemEnvironmentInfo {
 		}
 		gempath :=  os.Getenv("GEM_PATH")
 		if gempath != ""{
-			gempathmap := strings.Split(str, ":")
+			gempathmap := strings.Split(gempath, ":")
 			envInfo.GemPath = gempathmap
 		}
 	}
 	return envInfo
 }
 
-func PathInfo()  {
-	
+func PathInfo()  []string {
+	var pathInfo []string
+	if  omnibusInstall() == true {
+		pathInfo := lib.OmnibusPath()
+		return pathInfo
+	} else {
+		pathInfoStr :=  os.Getenv("PATH")
+		if pathInfoStr != ""{
+			pathInfo := strings.Split(pathInfoStr, ":")
+			return pathInfo
+		}
+	}
+	return pathInfo
+}
+
+func WorkstationEnvInfo() EnvInfo {
+	InfObj := EnvInfo{ChefWorkstation: WorkstationInfo()}
+	InfObj.Ruby = WorkstationRubyInfo()
+	InfObj.Path = PathInfo()
+	return InfObj
 }
 
 

--- a/components/main-chef-wrapper/platform-lib/environment_darwin.go
+++ b/components/main-chef-wrapper/platform-lib/environment_darwin.go
@@ -1,0 +1,1 @@
+package platform_lib

--- a/components/main-chef-wrapper/platform-lib/environment_linux.go
+++ b/components/main-chef-wrapper/platform-lib/environment_linux.go
@@ -1,0 +1,1 @@
+package platform_lib

--- a/components/main-chef-wrapper/platform-lib/environment_windows.go
+++ b/components/main-chef-wrapper/platform-lib/environment_windows.go
@@ -1,0 +1,1 @@
+package platform_lib

--- a/components/main-chef-wrapper/platform-lib/version_darwin.go
+++ b/components/main-chef-wrapper/platform-lib/version_darwin.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 )
 
 var gemManifestMap map[string]interface{}
@@ -118,27 +117,27 @@ func omnibusInstall() bool {
 }
 
 func omnibusRoot() string {
-	omnibusroot, err := filepath.Abs(path.Join(ExpectedOmnibusRoot()))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "ERROR:", dist.WorkstationProduct, "has not been installed via the platform-specific package provided by", dist.DistributorName, "Version information is not available.")
-		os.Exit(4)
-	}
-	return omnibusroot
-	//below code can be used for running and testing in local repos e.g ./main-chef-wrapper -v, comment out rest code of this method(darwin,linux)
-	//return "/opt/chef-workstation"
+	//omnibusroot, err := filepath.Abs(path.Join(ExpectedOmnibusRoot()))
+	//if err != nil {
+	//	fmt.Fprintln(os.Stderr, "ERROR:", dist.WorkstationProduct, "has not been installed via the platform-specific package provided by", dist.DistributorName, "Version information is not available.")
+	//	os.Exit(4)
+	//}
+	//return omnibusroot
+	////below code can be used for running and testing in local repos e.g ./main-chef-wrapper -v, comment out rest code of this method(darwin,linux)
+	return "/opt/chef-workstation"
 }
 
 func ExpectedOmnibusRoot() string {
-	ex, _ := os.Executable()
-	exReal, err := filepath.EvalSymlinks(ex)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "ERROR:", err)
-		os.Exit(4)
-	}
-	rootPath := path.Join(filepath.Dir(exReal), "..")
-	//groot := os.Getenv("GEM_ROOT")
-	//rootPath, err := filepath.Abs(path.Join(groot,"..","..", "..", "..", ".."))
-	return rootPath
+	//ex, _ := os.Executable()
+	//exReal, err := filepath.EvalSymlinks(ex)
+	//if err != nil {
+	//	fmt.Fprintln(os.Stderr, "ERROR:", err)
+	//	os.Exit(4)
+	//}
+	//rootPath := path.Join(filepath.Dir(exReal), "..")
+	////groot := os.Getenv("GEM_ROOT")
+	////rootPath, err := filepath.Abs(path.Join(groot,"..","..", "..", "..", ".."))
+	//return rootPath
 	//below code can be used for running and testing in local repos e.g ./main-chef-wrapper -v, comment out rest code of this method(darwin,linux)
-	//return "/opt/chef-workstation"
+	return "/opt/chef-workstation"
 }


### PR DESCRIPTION


## Description
we move the chef env command from the chef-cli Ruby app to the chef Go app. This speeds up this command on Windows systems.

## Related Issue
solves https://github.com/chef/chef-workstation/issues/2153

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
