### PR TITLE
Fix chef workstation app software definition

### DIFF
--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -36,6 +36,17 @@ platform_name = if macos?
 source_url = "https://packages.chef.io/files/unstable/chef-workstation-app/#{version}/chef-workstation-app-#{version}-#{platform_name}.zip"
 app_install_path = "#{install_dir}/components/chef-workstation-app"
 
+# These electron dependencies are pulled in/created
+# by this build. They may have dependencies that aren't met
+# on the install target - in which case the tray application
+# will not be runnable.  That does not affect the rest of
+# the chef-workstation installation, so we will whitelist the
+# dependencies to allow it to continue in any case.
+if linux?
+  whitelist_file(%r{components/chef-workstation-app/libGLESv2\.so})
+  whitelist_file(%r{components/chef-workstation-app/chef-workstation-app})
+end
+
 # The macOS zip file is weird. We can't really expand it because it expands directly into the .app.
 # To get around this we download it as a zip and unzip it as part of postinst.
 if macos?

--- a/omnibus/config/software/chef-workstation-app.rb
+++ b/omnibus/config/software/chef-workstation-app.rb
@@ -59,7 +59,7 @@ else
 
   build do
     mkdir app_install_path
-    copy project_dir, app_install_path
+    copy "#{project_dir}/*", app_install_path
   end
 end
 


### PR DESCRIPTION
Whitelist node-related binaries in the chef-workstation-app software definition

Fix copy's source path in chef-workstation-app software definition
