### PR TITLE
Discard workstation directory in compiler flags when building git

### DIFF
--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -85,6 +85,9 @@ build do
     config_hash["HAVE_LIBCHARSET_H"] = "YesPlease"
     config_hash["HAVE_STRINGS_H"] = "YesPlease"
     config_hash["USE_ST_TIMESPEC"] = "YesPlease"
+    env["CFLAGS"] = "-O3 -D_FORTIFY_SOURCE=2 -fstack-protector"
+    env["CPPFLAGS"] = "-O3 -D_FORTIFY_SOURCE=2 -fstack-protector"
+    env["CXXFLAGS"] = "-O3 -D_FORTIFY_SOURCE=2 -fstack-protector"
   end
 
   erb source: "config.mak.erb",


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
The `git` compilation would fail due to incorrect header file being looked up in workstation include folder. Specifically while compiling git, the workstation include folder has been excluded and only other compiler flags kept. This isn't likely the ideal fix as that would require a way to give precedence to current folder while looking up header file. 

## Related Issue
https://github.com/chef/chef-workstation/issues/2442
useful reference of similar [issue](https://trac.macports.org/ticket/61628)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
