### PR TITLE
Added support for chef main wrapper for m1

### DIFF
--- a/omnibus/config/software/main-chef-wrapper.rb
+++ b/omnibus/config/software/main-chef-wrapper.rb
@@ -38,6 +38,9 @@ build do
         f.write("@ECHO OFF\n\"%~dpn0.exe\" %*")
       end
     end
+  elsif macos? && arm?
+    # apple silicon
+    GOOS=darwin GOARCH=arm64  go "build -o #{install_dir}/bin/chef", env: env
   else
     # Unix systems has no extention
     go "build -o #{install_dir}/bin/chef", env: env

--- a/omnibus/config/software/main-chef-wrapper.rb
+++ b/omnibus/config/software/main-chef-wrapper.rb
@@ -40,7 +40,9 @@ build do
     end
   elsif macos? && arm?
     # apple silicon
-    GOOS=darwin GOARCH=arm64  go "build -o #{install_dir}/bin/chef", env: env
+    env["GOOS"]   = "darwin"
+    env["GOARCH"] = "arm64"
+    go "build -o #{install_dir}/bin/chef", env: env
   else
     # Unix systems has no extention
     go "build -o #{install_dir}/bin/chef", env: env


### PR DESCRIPTION
Signed-off-by: nitin sanghi <er.nitin.sanghi@gmail.com>

 chef main wrapper build using native os and arch support 

## Description
 Currently build happing for using default os and arch we are now supporting mac m1 chip as darwin arm64 build for go build in chef main wrapper

## Related Issue
 [issue]( https://github.com/chef/chef-workstation/issues/2519)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  Chore (non-breaking change that does not add functionality or fix an issue)


