### PR TITLE
Don't document setting ohai properties in config.rb

### DIFF
--- a/docs-chef-io/content/workstation/config_rb.md
+++ b/docs-chef-io/content/workstation/config_rb.md
@@ -332,16 +332,6 @@ Some organizations choose to have all data bags use the same secret and secret f
 `knife[:secret_file]`
 : The path to the file that contains the encryption key.
 
-### Ohai Settings (Not Recommended)
-
-Some settings are better left to Ohai, which gets the value at the start of a Chef Infra Client run:
-
-`knife[:server_name]`
-: Same as `node_name`. Recommended configuration is to allow Ohai to collect this value during each Chef Infra Client run.
-
-`node_name`
-: Same as `knife[:server_name]`. Recommended configuration is to allow Ohai to collect this value during each Chef Infra Client run.
-
 {{< warning >}}
 
 Review the full list of [optional settings](/workstation/config_rb_optional_settings/) that can be added to the `config.rb` file. Many of these optional settings should not be added to the `config.rb` file. The reasons for not adding them can vary. For example, using `--yes` as a default in the `config.rb` file causes knife to always assume that "Y" is the response to any prompt, which may lead to undesirable outcomes. Other settings, such as `--hide-healthy`(used only with the `knife status` subcommand) or `--bare-directories` (used only with the `knife list` subcommand) probably aren't used often enough (and in the same exact way) to justify adding them to the `config.rb` file. In general, if the optional settings are not listed on <span class="title-ref">the main </span><span class="title-ref">config.rb</span>[topic](/workstation/config_rb/), then add settings only after careful consideration. Do not use optional settings in a production environment until after the setting's performance has been validated in a safe testing environment.


### PR DESCRIPTION
This is a terrible thing that no one should do. We even tell them not to do it here.

Signed-off-by: Tim Smith <tsmith@chef.io>