### PR TITLE
Add GEM_HOME to environment variables to allow external gem installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 ARG CHANNEL=stable
 ARG VERSION=22.1.778
 ENV DEBIAN_FRONTEND=noninteractive \
+    GEM_HOME=/root/.chefdk/gem/ruby/3.0.0 \
     PATH=/opt/chef-workstation/bin:/opt/chef-workstation/embedded/bin:/root/.chefdk/gem/ruby/3.0.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Run the entire container with the default locale to be en_US.UTF-8


### PR DESCRIPTION
Signed-off-by: Patrick Schaumburg <pschaumburg@tecracer.de>
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
On behalf of Patrick Schaumburg - ref https://github.com/chef/chef-workstation/pull/2537

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
