### PR TITLE
Remove obsolete delivery related subcommand

### DIFF
--- a/docs-chef-io/content/workstation/ctl_chef.md
+++ b/docs-chef-io/content/workstation/ctl_chef.md
@@ -520,55 +520,6 @@ Recipe: code_generator::cookbook
     - create new file /Users/grantmc/Desktop/chef-repo/test-cookbook/recipes/default.rb
 ```
 
-## chef generate build-cookbook
-
-Use the `chef generate build-cookbook` subcommand to generate a delivery
-configuration file and build cookbook.
-
-### Syntax
-
-This subcommand has the following syntax:
-
-``` bash
-chef generate build-cookbook COOKBOOK_PATH/COOKBOOK_NAME (options)
-```
-
-### Options
-
-This subcommand has the following options:
-
-`-g GENERATOR_COOKBOOK_PATH`, `--generator-cookbook GENERATOR_COOKBOOK_PATH`
-
-: The path at which a cookbook named `code_generator` is located. This cookbook is used by the `chef generate` subcommands to generate cookbooks, cookbook files, templates, attribute files, and so on. Default value: `lib/chef-dk/skeletons`, under which is the default `code_generator` cookbook that is included as part of Chef Workstation.
-
-`-C COPYRIGHT`, `--copyright COPYRIGHT`
-
-: Specify the copyright holder for copyright notices in generated files. Default value: `The Authors`
-
-`-m EMAIL`, `--email EMAIL`
-
-: Specify the email address of the author. Default value: `you@example.com`.
-
-`-a KEY=VALUE`, `--generator-arg KEY=VALUE`
-
-: Sets a property named `KEY` to the given `VALUE` on the generator context object in the generator cookbook. This allows custom generator cookbooks to accept optional user input on the command line.
-
-`-I LICENSE`, `--license LICENSE`
-
-: Sets the license. Valid values are `all_rights`, `apache2`, `mit`, `gplv2`, or `gplv3`. Default value: `all_rights`.
-
-`-h`, `--help`
-
-: Show help for the command.
-
-`-v`, `--version`
-
-: The Chef Infra Client version.
-
-### Examples
-
-None.
-
 ## chef generate file
 
 Use the `chef generate file` subcommand to generate a file in the


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
The `delivery` CLI is now obsolete. The delivery workflow related `chef generate build-cookbook` command needs to be removed from the documentation.

## Related Issue
https://github.com/chef/chef-workstation/issues/2540
https://github.com/chef/chef-web-docs/issues/3704

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
