### PR TITLE
Use Expeditor to get docs lint configs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -243,6 +243,6 @@ subscriptions:
        - bash:.expeditor/update_dep.sh
   - workload: pull_request_merged:chef/chef-web-docs:main:*
     actions:
-       - bash:.expeditor/update_docs_lints.sh:
-         only_if_modified:
-         - .markdownlint.yaml
+    - bash:.expeditor/update_docs_lints.sh:
+        only_if_modified:
+          - .markdownlint.yaml

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -241,3 +241,8 @@ subscriptions:
   - workload: ruby_gem_published:docker-api
     actions:
        - bash:.expeditor/update_dep.sh
+  - workload: pull_request_merged:chef/chef-web-docs:main:*
+    actions:
+       - bash:.expeditor/update_docs_lints.sh:
+         only_if_modified:
+         - .markdownlint.yaml

--- a/.expeditor/update_docs_lints.sh
+++ b/.expeditor/update_docs_lints.sh
@@ -1,0 +1,25 @@
+set -eou pipefail
+
+branch="expeditor/update_docs_lints_${EXPEDITOR_REPO}_${EXPEDITOR_DATE}"
+repo=${EXPEDITOR_REPO##*/}
+git checkout -b "$branch"
+
+# Wait
+sleep 60
+
+# submit pull request to chef/releng-services
+
+git add .
+
+# give a friendly message for the commit and make sure it's noted for any future
+# audit of our codebase that no DCO sign-off is needed for this sort of PR since
+#it contains no intellectual property
+
+dco_safe_git_commit "Updating ${repo} docs lints to ${EXPEDITOR_DATE}."
+
+open_pull_request
+
+# Get back to main and cleanup the leftovers - any changed files left over at
+# the end of this script will get committed to main.
+git checkout -
+git branch -D "$branch"

--- a/.expeditor/update_docs_lints.sh
+++ b/.expeditor/update_docs_lints.sh
@@ -1,7 +1,6 @@
 set -eou pipefail
 
-branch="expeditor/update_docs_lints_${EXPEDITOR_REPO}_${EXPEDITOR_DATE}"
-repo=${EXPEDITOR_REPO##*/}
+branch="expeditor/update_docs_lints"
 git checkout -b "$branch"
 
 # Wait
@@ -15,7 +14,7 @@ git add .
 # audit of our codebase that no DCO sign-off is needed for this sort of PR since
 #it contains no intellectual property
 
-dco_safe_git_commit "Updating ${repo} docs lints to ${EXPEDITOR_DATE}."
+dco_safe_git_commit "Update $EXPEDITOR_REPO docs lints."
 
 open_pull_request
 


### PR DESCRIPTION
We need to single-source the documentation lint configurations.

## Description
Adds an expeditor config and a script to get the remote files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
