### PR TITLE
Update the Ruby windows platforms for the components

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -125,7 +125,7 @@ end
 gem "chefstyle", group: :test
 
 # Ensure support for push-client on Windows
-platforms :mswin, :mingw do
+platforms :mswin, :mswin64, :mingw, :x64_mingw do
   gem "rdp-ruby-wmi"
   gem "windows-pr"
   gem "win32-api"


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In x64 machines the components for windows platforms are not installing due to mismatch  in platforms. Adding the x64 platforms so that these gems will be installed on x64 machines as well.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/kitchen-vcenter/pull/169

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
