### PR TITLE
attempt to keep rb-fsevent version in sync.

### DIFF
--- a/omnibus/config/software/rb-fsevent-gem.rb
+++ b/omnibus/config/software/rb-fsevent-gem.rb
@@ -19,7 +19,7 @@
 # only supports SDK version >= 10.9, so we must rebuild and install.
 
 name "rb-fsevent-gem"
-default_version "master"
+default_version "0.11.1" # IMPORTANT: must be in sync with components/gems/Gemfile.lock
 
 source git: "https://github.com/thibaudgg/rb-fsevent.git"
 

--- a/omnibus/config/software/rb-fsevent-gem.rb
+++ b/omnibus/config/software/rb-fsevent-gem.rb
@@ -19,7 +19,9 @@
 # only supports SDK version >= 10.9, so we must rebuild and install.
 
 name "rb-fsevent-gem"
-default_version "0.11.1" # IMPORTANT: must be in sync with components/gems/Gemfile.lock
+
+# IMPORTANT: this must be in sync with the components/gems/Gemfile.lock version, currently 0.11.1
+default_version "e46390c4a12d26288e44c42539594e90a7c6fc46"
 
 source git: "https://github.com/thibaudgg/rb-fsevent.git"
 


### PR DESCRIPTION
## Description
If the rb-fsevent gem version noted in `components/gems/Gemfile.lock` is older than the HEAD of master branch in the repo referred in `omnibus/config/software/rb-fsevent-gem.rb`, then this results in a pre-compiled bundle plus recompiled bundle getting packaged in Chef Workstation. Some commands fail on MacOS. 

This is an attempt to maintain static reference to commit corresponding to the version noted in Gemfile.lock.

## Related Issue
https://github.com/chef/chef-workstation/pull/2580

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
