### PR TITLE
Get docs lint config files, for precommit use

### DIFF
--- a/.expeditor/update_docs_lints.sh
+++ b/.expeditor/update_docs_lints.sh
@@ -9,6 +9,8 @@ sleep 300
 # get the file from chef-web-docs
 
 get_github_file chef/chef-web-docs main .markdownlint.yaml > .markdownlint.yaml
+get_github_file chef/chef-web-docs main .vale.ini > .vale.ini
+get_github_file chef/chef-web-docs main cspell.json > cspell.json
 
 # add changes
 git add .


### PR DESCRIPTION
Signed-off-by: Kimberly Garmoe <kgarmoe@chef.io>

You'll need to manually update StylePath in `.vale.ini` to `docs-chef-io/<PRODUCT>/chef-web-docs/tools/vale` until someone has the time to sort out a better solution.
