### PR TITLE
Remove hugo and go version from netlify config

### DIFF
--- a/docs-chef-io/netlify.toml
+++ b/docs-chef-io/netlify.toml
@@ -1,9 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.91.2"
   HUGO_ENABLEGITINFO = "true"
-  GO_VERSION = "1.15"
   NODE_ENV = "development"
 
 [build.processing]


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Remove hugo and go version from netlify config. It's easier to set these parameters from the Netlify web UI and there's a bug in the current specified version that's breaking PR builds.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
