### PR TITLE
Move shortcode files to workstation repo

### DIFF
--- a/docs-chef-io/Makefile
+++ b/docs-chef-io/Makefile
@@ -6,10 +6,12 @@ clean_all:
 	pushd chef-web-docs && make clean_all && popd
 
 preview_netlify: chef_web_docs
-	cp -R content/* chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/content
-	cp -R static/* chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/static
+	rm -rf chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/*
+	cp -R content chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/content
+	cp -R static chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/static
+	cp -R layouts chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/layouts
 	cp -R config.toml chef-web-docs/_vendor/github.com/chef/chef-workstation/docs-chef-io/
-	pushd chef-web-docs && make bundle; hugo --buildFuture --gc --minify && popd
+	pushd chef-web-docs && make bundle; hugo --buildFuture --gc --minify --environment development && popd
 
 serve: chef_web_docs
 	echo "replace github.com/chef/chef-workstation/docs-chef-io => ../" >> chef-web-docs/go.mod

--- a/docs-chef-io/content/workstation/_index.md
+++ b/docs-chef-io/content/workstation/_index.md
@@ -19,7 +19,7 @@ aliases = ["/about_workstation.html", "/about_chefdk.html", "/chef_dk.html", "/a
 
 <!-- markdownlint-disable-file MD033 -->
 
-{{% chef_workstation %}}
+{{% chef-workstation/chef_workstation %}}
 
 Chef Workstation replaces ChefDK, combining all the existing features
 with new features, such as ad-hoc task support and the new Chef

--- a/docs-chef-io/content/workstation/chef_shell.md
+++ b/docs-chef-io/content/workstation/chef_shell.md
@@ -64,7 +64,41 @@ This command has the following options:
 
   {{< warning >}}
 
-  {{% node_ctl_attribute %}}
+  Any other attribute type that is contained in this JSON file will be
+  treated as a `normal` attribute. Setting attributes at other precedence
+  levels is not possible. For example, attempting to update `override`
+  attributes using the `-j` option:
+
+  ```javascript
+  {
+    "name": "dev-99",
+    "description": "Install some stuff",
+    "override_attributes": {
+      "apptastic": {
+        "enable_apptastic": "false",
+        "apptastic_tier_name": "dev-99.bomb.com"
+      }
+    }
+  }
+  ```
+
+  will result in a node object similar to:
+
+  ```javascript
+  {
+    "name": "maybe-dev-99",
+    "normal": {
+      "name": "dev-99",
+      "description": "Install some stuff",
+      "override_attributes": {
+        "apptastic": {
+          "enable_apptastic": "false",
+          "apptastic_tier_name": "dev-99.bomb.com"
+        }
+      }
+    }
+  }
+  ```
 
   {{< /warning >}}
 
@@ -114,11 +148,11 @@ This command has the following options:
 
 ### Debug Existing Recipe
 
-{{< readFile_shortcode file="chef_shell_debug_existing_recipe.md" >}}
+{{% chef_shell_debug_existing_recipe %}}
 
 ### Advanced Debugging
 
-{{< readFile_shortcode file="chef_shell_advanced_debug.md" >}}
+{{% chef_shell_advanced_debug %}}
 
 ## Manipulating Chef Infra Server Data
 
@@ -130,7 +164,7 @@ The following examples show how to use chef-shell.
 
 ### "Hello World"
 
-{{< readFile_shortcode file="chef_shell_example_hello_world.md" >}}
+{{% chef_shell_example_hello_world %}}
 
 ### Get Specific Nodes
 

--- a/docs-chef-io/content/workstation/chefspec.md
+++ b/docs-chef-io/content/workstation/chefspec.md
@@ -16,7 +16,11 @@ aliases = ["/chefspec.html", "/chefspec/"]
 
 <!-- markdownlint-disable-file MD036 -->
 
-{{% chefspec_summary %}}
+Use ChefSpec to simulate the convergence of resources on a node:
+
+- Is an extension of RSpec, a behavior-driven development (BDD)
+    framework for Ruby
+- Is the fastest way to test resources and recipes
 
 ChefSpec is a framework that tests resources and recipes as part of a simulated Chef Infra Client run. ChefSpec tests execute quickly. When used as part of the cookbook authoring workflow, ChefSpec tests are often the first indicator of problems that may exist within a cookbook.
 

--- a/docs-chef-io/content/workstation/config_yml_kitchen.md
+++ b/docs-chef-io/content/workstation/config_yml_kitchen.md
@@ -24,7 +24,7 @@ data across any combination of platforms and test suites:
 - Supports all common testing frameworks that are used by the Ruby community
 - Uses a comprehensive set of base images provided by [Bento](https://github.com/chef/bento)
 
-{{% test_kitchen_yml %}}
+{{% chef-workstation/test_kitchen_yml %}}
 
 {{< note >}}
 
@@ -36,7 +36,7 @@ about Test Kitchen.
 
 ## Syntax
 
-{{% test_kitchen_yml_syntax %}}
+{{% chef-workstation/test_kitchen_yml_syntax %}}
 
 ## Provisioner Settings
 
@@ -418,7 +418,7 @@ kitchen.yml file when the transport is WinRM:
 
 ### Work with Proxies
 
-{{< readFile_shortcode file="test_kitchen_yml_syntax_proxy.md" >}}
+{{% chef-workstation/test_kitchen_yml_syntax_proxy %}}
 
 ## Chef Infra Client Settings
 
@@ -475,19 +475,19 @@ Specific `optional_settings: values` may be specified.
 
 ### Bento
 
-{{% bento %}}
+{{% chef-workstation/bento %}}
 
 ### Drivers
 
-{{% test_kitchen_drivers %}}
+{{% chef-workstation/test_kitchen_drivers %}}
 
 ### kitchen-vagrant
 
-{{% test_kitchen_driver_vagrant %}}
+{{% chef-workstation/test_kitchen_driver_vagrant %}}
 
-{{% test_kitchen_driver_vagrant_settings %}}
+{{% chef-workstation/test_kitchen_driver_vagrant_settings %}}
 
-{{% test_kitchen_driver_vagrant_config %}}
+{{% chef-workstation/test_kitchen_driver_vagrant_config %}}
 
 ## Examples
 

--- a/docs-chef-io/content/workstation/ctl_chef.md
+++ b/docs-chef-io/content/workstation/ctl_chef.md
@@ -633,15 +633,15 @@ None.
 
 ## chef generate repo
 
-{{% ctl_chef_generate_repo %}}
+{{% chef-workstation/ctl_chef_generate_repo %}}
 
 ### Syntax
 
-{{% ctl_chef_generate_repo_syntax %}}
+{{% chef-workstation/ctl_chef_generate_repo_syntax %}}
 
 ### Options
 
-{{% ctl_chef_generate_repo_options %}}
+{{% chef-workstation/ctl_chef_generate_repo_options %}}
 
 ### Examples
 
@@ -686,15 +686,27 @@ None.
 
 ## chef generate profile
 
-{{% ctl_chef_generate_profile %}}
+Use the `chef generate profile` subcommand to generate a [profile](/inspec/profiles/) for the Chef Infra Client's Compliance Phase execution.
 
 ### Syntax
 
-{{% ctl_chef_generate_profile_syntax %}}
+This subcommand has the following syntax:
+
+```bash
+chef generate profile [path/to/cookbook] NAME
+```
 
 ### Options
 
-{{% ctl_chef_generate_profile_options %}}
+This subcommand has the following options:
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Workstation version.
 
 ### Examples
 
@@ -702,15 +714,23 @@ None.
 
 ## chef generate input
 
-{{% ctl_chef_generate_input %}}
+Use the `chef generate input` subcommand to generate an [input](/inspec/inputs/) file for the Chef Infra Client's Compliance Phase execution.
 
 ### Syntax
 
-{{% ctl_chef_generate_input_syntax %}}
+This subcommand has the following syntax:
+
+```bash
+chef generate input [path/to/cookbook] NAME
+```
 
 ### Options
 
-{{% ctl_chef_generate_input_options %}}
+Use the `chef export` subcommand to create a chef-zero-compatible
+chef-repo that contains the cookbooks described by a
+`Policyfile.lock.json` file. After a chef-zero-compatible chef-repo is
+copied to a node, the policy can be applied locally on that machine by
+running `chef-client -z` (local mode).
 
 ### Examples
 
@@ -718,15 +738,27 @@ None.
 
 ## chef generate waiver
 
-{{% ctl_chef_generate_waiver %}}
+Use the `chef generate waiver` subcommand to generate a [waiver](/inspec/waivers/) file for the Chef Infra Client's Compliance Phase execution.
 
 ### Syntax
 
-{{% ctl_chef_generate_waiver_syntax %}}
+This subcommand has the following syntax:
+
+```bash
+chef generate waiver [path/to/cookbook] NAME
+```
 
 ### Options
 
-{{% ctl_chef_generate_waiver_options %}}
+This subcommand has the following options:
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Workstation version.
 
 ### Examples
 
@@ -1013,15 +1045,15 @@ if(Test-Path $PROFILE){ chef shell-init powershell | Add-Content $PROFILE } else
 
 ### chef clean-policy-cookbooks
 
-{{% ctl_chef_clean_policy_cookbooks %}}
+{{% chef-workstation/ctl_chef_clean_policy_cookbooks %}}
 
 #### Syntax
 
-{{% ctl_chef_clean_policy_cookbooks_syntax %}}
+{{% chef-workstation/ctl_chef_clean_policy_cookbooks_syntax %}}
 
 #### Options
 
-{{% ctl_chef_clean_policy_cookbooks_options %}}
+{{% chef-workstation/ctl_chef_clean_policy_cookbooks_options %}}
 
 #### Examples
 
@@ -1029,15 +1061,15 @@ None.
 
 ### chef clean-policy-revisions
 
-{{% ctl_chef_clean_policy_revisions %}}
+{{% chef-workstation/ctl_chef_clean_policy_revisions %}}
 
 #### Syntax
 
-{{% ctl_chef_clean_policy_revisions_syntax %}}
+{{% chef-workstation/ctl_chef_clean_policy_revisions_syntax %}}
 
 #### Options
 
-{{% ctl_chef_clean_policy_revisions_options %}}
+{{% chef-workstation/ctl_chef_clean_policy_revisions_options %}}
 
 #### Examples
 
@@ -1045,15 +1077,15 @@ None.
 
 ### chef delete-policy
 
-{{% ctl_chef_delete_policy %}}
+{{% chef-workstation/ctl_chef_delete_policy %}}
 
 #### Syntax
 
-{{% ctl_chef_delete_policy_syntax %}}
+{{% chef-workstation/ctl_chef_delete_policy_syntax %}}
 
 #### Options
 
-{{% ctl_chef_delete_policy_options %}}
+{{% chef-workstation/ctl_chef_delete_policy_options %}}
 
 #### Examples
 
@@ -1061,15 +1093,15 @@ None.
 
 ### chef delete-policy-group
 
-{{% ctl_chef_delete_policy_group %}}
+{{% chef-workstation/ctl_chef_delete_policy_group %}}
 
 #### Syntax
 
-{{% ctl_chef_delete_policy_group_syntax %}}
+{{% chef-workstation/ctl_chef_delete_policy_group_syntax %}}
 
 #### Options
 
-{{% ctl_chef_delete_policy_group_options %}}
+{{% chef-workstation/ctl_chef_delete_policy_group_options %}}
 
 #### Examples
 
@@ -1077,57 +1109,57 @@ None.
 
 ### chef diff
 
-{{% ctl_chef_diff %}}
+{{% chef-workstation/ctl_chef_diff %}}
 
 #### Syntax
 
-{{% ctl_chef_diff_syntax %}}
+{{% chef-workstation/ctl_chef_diff_syntax %}}
 
 #### Options
 
-{{% ctl_chef_diff_options %}}
+{{% chef-workstation/ctl_chef_diff_options %}}
 
 #### Examples
 
 **Compare current lock to latest commit on latest branch**
 
-{{% ctl_chef_diff_current_lock_latest_branch %}}
+{{% chef-workstation/ctl_chef_diff_current_lock_latest_branch %}}
 
 **Compare current lock with latest commit on master branch**
 
-{{% ctl_chef_diff_current_lock_master_branch %}}
+{{% chef-workstation/ctl_chef_diff_current_lock_master_branch %}}
 
 **Compare current lock to specified revision**
 
-{{% ctl_chef_diff_current_lock_specified_revision %}}
+{{% chef-workstation/ctl_chef_diff_current_lock_specified_revision %}}
 
 **Compare lock on master branch to lock on revision**
 
-{{% ctl_chef_diff_master_lock_revision_lock %}}
+{{% chef-workstation/ctl_chef_diff_master_lock_revision_lock %}}
 
 **Compare lock for version with latest commit on master branch**
 
-{{% ctl_chef_diff_version_lock_master_branch %}}
+{{% chef-workstation/ctl_chef_diff_version_lock_master_branch %}}
 
 **Compare current lock with latest lock for policy group**
 
-{{% ctl_chef_diff_current_lock_policy_group %}}
+{{% chef-workstation/ctl_chef_diff_current_lock_policy_group %}}
 
 **Compare locks for two policy groups**
 
-{{% ctl_chef_diff_two_policy_groups %}}
+{{% chef-workstation/ctl_chef_diff_two_policy_groups %}}
 
 ### chef export
 
-{{% ctl_chef_export %}}
+{{% chef-workstation/ctl_chef_export %}}
 
 #### Syntax
 
-{{% ctl_chef_export_syntax %}}
+{{% chef-workstation/ctl_chef_export_syntax %}}
 
 #### Options
 
-{{% ctl_chef_export_options %}}
+{{% chef-workstation/ctl_chef_export_options %}}
 
 #### Examples
 
@@ -1135,15 +1167,15 @@ None.
 
 ### chef generate policyfile
 
-{{% ctl_chef_generate_policyfile %}}
+{{% chef-workstation/ctl_chef_generate_policyfile %}}
 
 #### Syntax
 
-{{% ctl_chef_generate_policyfile_syntax %}}
+{{% chef-workstation/ctl_chef_generate_policyfile_syntax %}}
 
 #### Options
 
-{{% ctl_chef_generate_policyfile_options %}}
+{{% chef-workstation/ctl_chef_generate_policyfile_options %}}
 
 #### Examples
 
@@ -1151,15 +1183,15 @@ None.
 
 ### chef install
 
-{{% ctl_chef_install %}}
+{{% chef-workstation/ctl_chef_install %}}
 
 #### Syntax
 
-{{% ctl_chef_install_syntax %}}
+{{% chef-workstation/ctl_chef_install_syntax %}}
 
 #### Options
 
-{{% ctl_chef_install_options %}}
+{{% chef-workstation/ctl_chef_install_options %}}
 
 #### Policyfile.lock.json
 
@@ -1173,15 +1205,15 @@ None.
 
 ### chef push
 
-{{% ctl_chef_push %}}
+{{% chef-workstation/ctl_chef_push %}}
 
 #### Syntax
 
-{{% ctl_chef_push_syntax %}}
+{{% chef-workstation/ctl_chef_push_syntax %}}
 
 #### Options
 
-{{% ctl_chef_push_options %}}
+{{% chef-workstation/ctl_chef_push_options %}}
 
 #### Examples
 
@@ -1189,15 +1221,15 @@ None.
 
 ### chef push-archive
 
-{{% ctl_chef_push_archive %}}
+{{% chef-workstation/ctl_chef_push_archive %}}
 
 #### Syntax
 
-{{% ctl_chef_push_archive_syntax %}}
+{{% chef-workstation/ctl_chef_push_archive_syntax %}}
 
 #### Options
 
-{{% ctl_chef_push_archive_options %}}
+{{% chef-workstation/ctl_chef_push_archive_options %}}
 
 #### Examples
 
@@ -1205,15 +1237,15 @@ None.
 
 ### chef show-policy
 
-{{% ctl_chef_show_policy %}}
+{{% chef-workstation/ctl_chef_show_policy %}}
 
 #### Syntax
 
-{{% ctl_chef_show_policy_syntax %}}
+{{% chef-workstation/ctl_chef_show_policy_syntax %}}
 
 #### Options
 
-{{% ctl_chef_show_policy_options %}}
+{{% chef-workstation/ctl_chef_show_policy_options %}}
 
 #### Examples
 
@@ -1221,15 +1253,15 @@ None.
 
 ### chef undelete
 
-{{% ctl_chef_undelete %}}
+{{% chef-workstation/ctl_chef_undelete %}}
 
 #### Syntax
 
-{{% ctl_chef_undelete_syntax %}}
+{{% chef-workstation/ctl_chef_undelete_syntax %}}
 
 #### Options
 
-{{% ctl_chef_undelete_options %}}
+{{% chef-workstation/ctl_chef_undelete_options %}}
 
 #### Examples
 
@@ -1237,15 +1269,15 @@ None.
 
 ### chef update
 
-{{% ctl_chef_update %}}
+{{% chef-workstation/ctl_chef_update %}}
 
 #### Syntax
 
-{{% ctl_chef_update_syntax %}}
+{{% chef-workstation/ctl_chef_update_syntax %}}
 
 #### Options
 
-{{% ctl_chef_update_options %}}
+{{% chef-workstation/ctl_chef_update_options %}}
 
 #### Examples
 

--- a/docs-chef-io/content/workstation/ctl_kitchen.md
+++ b/docs-chef-io/content/workstation/ctl_kitchen.md
@@ -15,7 +15,7 @@ aliases = ["/ctl_kitchen.html", "/ctl_kitchen/"]
 +++
 <!-- markdownlint-disable-file MD024 MD036 MD046-->
 
-{{% ctl_kitchen_summary %}}
+{{% chef-workstation/ctl_kitchen_summary %}}
 
 {{< note >}}
 
@@ -139,7 +139,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -289,7 +289,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-    {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+    {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -415,7 +415,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -460,7 +460,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -615,7 +615,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -662,7 +662,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -719,7 +719,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -802,7 +802,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -850,7 +850,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -902,7 +902,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-  {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+  {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 
@@ -1027,7 +1027,7 @@ This subcommand has the following options:
 
 : Run Test Kitchen against one or more platforms listed in the kitchen.yml file. Use `all` to run Test Kitchen against all platforms. Use a Ruby regular expression to glob two or more platforms into a single run.
 
-    {{< readFile_shortcode file="ctl_kitchen_common_option_platforms.md" >}}
+    {{< readfile file="layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md" >}}
 
 ### Examples
 

--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -15,7 +15,7 @@ aliases = ["/install_workstation.html", "/install_dk.html", "/workstation_window
 +++
 <!-- markdownlint-disable-file MD033 -->
 
-{{% chef_workstation %}}
+{{% chef-workstation/chef_workstation %}}
 
 ## Supported Platforms
 

--- a/docs-chef-io/content/workstation/kitchen.md
+++ b/docs-chef-io/content/workstation/kitchen.md
@@ -14,7 +14,16 @@ aliases = ["/kitchen.html", "/kitchen/"]
     weight = 10
 +++
 
-{{% test_kitchen %}}
+Use [Test Kitchen](https://kitchen.ci/) to automatically test cookbooks
+across any combination of platforms and test suites:
+
+- Test suites are defined in a kitchen.yml file. See the
+    [configuration](/workstation/config_yml_kitchen/) documentation for options
+    and syntax information.
+- Supports cookbook testing across many cloud providers and
+    virtualization technologies.
+- Uses a comprehensive set of operating system base images from Chef's
+    [Bento](https://github.com/chef/bento) project.
 
 The key concepts in Test Kitchen are:
 
@@ -26,11 +35,11 @@ The key concepts in Test Kitchen are:
 
 ## Bento
 
-{{% bento %}}
+{{% chef-workstation/bento %}}
 
 ## Drivers
 
-{{% test_kitchen_drivers %}}
+{{% chef-workstation/test_kitchen_drivers %}}
 
 ## Validation with InSpec
 
@@ -43,7 +52,7 @@ converged cookbook for easy local validation of your infrastructure.
 
 ## kitchen (executable)
 
-{{% ctl_kitchen_summary %}}
+{{% chef-workstation/ctl_kitchen_summary %}}
 
 {{< note >}}
 
@@ -54,7 +63,7 @@ For more information about the `kitchen` command line tool, see
 
 ## kitchen.yml
 
-{{% test_kitchen_yml %}}
+{{% chef-workstation/test_kitchen_yml %}}
 
 {{< note >}}
 
@@ -65,11 +74,11 @@ For more information about the kitchen.yml file, see
 
 ### Syntax
 
-{{% test_kitchen_yml_syntax %}}
+{{% chef-workstation/test_kitchen_yml_syntax %}}
 
 ### Work with Proxies
 
-{{< readFile_shortcode file="test_kitchen_yml_syntax_proxy.md" >}}
+{{% chef-workstation/test_kitchen_yml_syntax_proxy %}}
 
 ## For more information ...
 

--- a/docs-chef-io/content/workstation/knife.md
+++ b/docs-chef-io/content/workstation/knife.md
@@ -101,103 +101,103 @@ organization.
 <tbody>
 <tr class="odd">
 <td><a href="/knife_bootstrap/">knife_bootstrap</a></td>
-<td>{{% knife_bootstrap_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_bootstrap_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_client/">knife_client</a></td>
-<td>{{% knife_client_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_client_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_configure/">knife configure</a></td>
-<td>{{% knife_configure_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_configure_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_cookbook/">knife cookbook</a></td>
-<td>{{% knife_cookbook_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_cookbook_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_data_bag/">knife data bag</a></td>
-<td>{{% knife_data_bag_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_data_bag_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_delete/">knife delete</a></td>
-<td>{{% knife_delete_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_delete_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_deps/">knife deps</a></td>
-<td>{{% knife_deps_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_deps_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_diff/">knife diff</a></td>
-<td>{{% knife_diff_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_diff_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_download/">knife download</a></td>
-<td>{{% knife_download_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_download_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_edit/">knife edit</a></td>
-<td>{{% knife_edit_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_edit_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_environment/">knife environment</a></td>
-<td>{{% knife_environment_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_environment_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_exec/">knife exec</a></td>
-<td>{{% knife_exec_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_exec_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_list/">knife list</a></td>
-<td>{{% knife_list_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_list_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_node/">knife node</a></td>
-<td>{{% knife_node_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_node_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_raw/">knife raw</a></td>
-<td>{{% knife_raw_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_raw_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_recipe_list/">knife recipe list</a></td>
-<td>{{% knife_recipe_list_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_recipe_list_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_role/">knife role</a></td>
-<td>{{% knife_role_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_role_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_search/">knife search</a></td>
-<td>{{% knife_search_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_search_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_serve/">knife serve</a></td>
-<td>{{% knife_serve_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_serve_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_show/">knife show</a></td>
-<td>{{% knife_show_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_show_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_ssh/">knife ssh</a></td>
-<td>{{% knife_ssh_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_ssh_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_ssl_check/">knife ssl check</a></td>
-<td>{{% knife_ssl_check_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_ssl_check_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_ssl_fetch/">knife ssl fetch</a></td>
-<td>{{% knife_ssl_fetch_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_ssl_fetch_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_status/">knife status</a></td>
-<td>{{% knife_status_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_status_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_tag/">knife tag</a></td>
-<td>{{% knife_tag_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_tag_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_supermarket/">knife supermarket</a></td>
@@ -205,15 +205,15 @@ organization.
 </tr>
 <tr class="odd">
 <td><a href="/knife_upload/">knife upload</a></td>
-<td>{{% knife_upload_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_upload_summary.md" >}}</td>
 </tr>
 <tr class="even">
 <td><a href="/knife_user/">knife user</a></td>
-<td>{{% knife_user_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_user_summary.md" >}}</td>
 </tr>
 <tr class="odd">
 <td><a href="/knife_xargs/">knife xargs</a></td>
-<td>{{% knife_xargs_summary %}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_xargs_summary.md" >}}</td>
 </tr>
 </tbody>
 </table>

--- a/docs-chef-io/content/workstation/knife_azurerm.md
+++ b/docs-chef-io/content/workstation/knife_azurerm.md
@@ -16,7 +16,7 @@ aliases = ["/knife_azurerm.html", "/knife_azurerm/"]
 
 ## Knife Azure Overview
 
-{{% knife_azure %}}
+{{% chef-workstation/knife_azure %}}
 
 {{< note >}}
 

--- a/docs-chef-io/content/workstation/knife_bootstrap.md
+++ b/docs-chef-io/content/workstation/knife_bootstrap.md
@@ -16,7 +16,7 @@ aliases = ["/knife_bootstrap.html", "/knife_bootstrap/"]
 
 {{% chef_client_bootstrap_node %}}
 
-{{% knife_bootstrap_summary %}}
+{{% chef-workstation/knife_bootstrap_summary %}}
 
 **Considerations:**
 
@@ -36,7 +36,7 @@ knife bootstrap FQDN_or_IP_ADDRESS (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -285,13 +285,54 @@ knife bootstrap FQDN_or_IP_ADDRESS (options)
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
 ### Validatorless Bootstrap
 
-{{% knife_bootstrap_no_validator %}}
+The ORGANIZATION-validator.pem is typically added to the .chef directory
+on the workstation. When a node is bootstrapped from that workstation,
+the ORGANIZATION-validator.pem is used to authenticate the newly-created
+node to the Chef Infra Server during the initial Chef Infra Client run.
+It is possible to bootstrap a node using the USER.pem file instead of
+the ORGANIZATION-validator.pem file. This is known as a "validatorless
+bootstrap".
+
+To create a node using the USER.pem file, simply delete the
+ORGANIZATION-validator.pem file on the workstation. For example:
+
+```bash
+rm -f /home/lamont/.chef/myorg-validator.pem
+```
+
+and then make the following changes in the config.rb file:
+
+- Remove the `validation_client_name` setting
+- Edit the `validation_key` setting to be something that is not a path
+    to an existent ORGANIZATION-validator.pem file. For example:
+    `/nonexist`.
+
+As long as a USER.pem is also present on the workstation from which the
+validatorless bootstrap operation will be initiated, the bootstrap
+operation will run and will use the USER.pem file instead of the
+ORGANIZATION-validator.pem file.
+
+When running a validatorless `knife bootstrap` operation, the output is
+similar to:
+
+```bash
+desktop% knife bootstrap 10.1.1.1 -N foo01.acme.org \
+  -E dev -r 'role[base]' -j '{ "foo": "bar" }' \
+  --ssh-user vagrant --sudo
+Node foo01.acme.org exists, overwrite it? (Y/N)
+Client foo01.acme.org exists, overwrite it? (Y/N)
+Creating new client for foo01.acme.org
+Creating new node for foo01.acme.org
+Connecting to 10.1.1.1
+10.1.1.1 Starting first Chef Infra Client run...
+[....etc...]
+```
 
 {{< note >}}
 
@@ -305,7 +346,7 @@ The `--node-name` option is required for a validatorless bootstrap.
 
 **Bootstrap a node using FIPS**
 
-{{% knife_bootstrap_node_fips %}}
+{{% chef-workstation/knife_bootstrap_node_fips %}}
 
 ## Custom Templates
 

--- a/docs-chef-io/content/workstation/knife_client.md
+++ b/docs-chef-io/content/workstation/knife_client.md
@@ -14,11 +14,11 @@ aliases = ["/knife_client.html", "/knife_client/"]
 +++
 <!-- markdownlint-disable-file MD024 MD033 MD036 MD046-->
 
-{{% knife_client_summary %}}
+{{% chef-workstation/knife_client_summary %}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -94,7 +94,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -401,7 +401,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_configure.md
+++ b/docs-chef-io/content/workstation/knife_configure.md
@@ -14,7 +14,7 @@ aliases = ["/knife_configure.html", "/knife_configure/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_configure_summary %}}
+{{% chef-workstation/knife_configure_summary %}}
 
 ## Syntax
 
@@ -34,7 +34,7 @@ knife configure client DIRECTORY
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -71,7 +71,7 @@ config.rb file:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_cookbook.md
+++ b/docs-chef-io/content/workstation/knife_cookbook.md
@@ -16,11 +16,11 @@ aliases = ["/knife_cookbook.html", "/knife_cookbook/"]
 
 {{% cookbooks_summary %}}
 
-{{% knife_cookbook_summary %}}
+{{% chef-workstation/knife_cookbook_summary %}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -48,7 +48,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -96,7 +96,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -149,7 +149,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -193,7 +193,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -236,7 +236,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -326,7 +326,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -442,7 +442,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -523,7 +523,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_cookbook_site.md
+++ b/docs-chef-io/content/workstation/knife_cookbook_site.md
@@ -31,13 +31,13 @@ supermarket](/workstation/knife_supermarket/) command.
 
 {{< warning >}}
 
-{{% notes_knife_cookbook_site_use_devkit_berkshelf %}}
+{{% chef-workstation/notes_knife_cookbook_site_use_devkit_berkshelf %}}
 
 {{< /warning >}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -93,7 +93,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -175,7 +175,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -370,7 +370,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_data_bag.md
+++ b/docs-chef-io/content/workstation/knife_data_bag.md
@@ -18,11 +18,11 @@ aliases = ["/knife_data_bag.html", "/knife_data_bag/"]
 
 {{% data_bag_encryption %}}
 
-{{% knife_data_bag_summary %}}
+{{% chef-workstation/knife_data_bag_summary %}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -56,7 +56,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -121,7 +121,7 @@ Type `Y` to confirm a deletion.
 
 ## edit
 
-{{% knife_data_bag_edit %}}
+{{% chef-workstation/knife_data_bag_edit %}}
 
 ### Syntax
 
@@ -156,7 +156,7 @@ For encrypted data bag items, use *either* `--secret` or
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -195,7 +195,7 @@ save them.
 
 **Edit a data bag item**
 
-{{% knife_data_bag_edit_item %}}
+{{% chef-workstation/knife_data_bag_edit_item %}}
 
 ## from file
 
@@ -244,7 +244,7 @@ For encrypted data bag items, use *either* `--secret` or
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -272,7 +272,7 @@ knife data bag from file devops_data --secret-file "path to decryption file"
 **Create an encrypted data bag for use with Chef Infra Client local
 mode**
 
-{{% knife_data_bag_from_file_create_encrypted_local_mode %}}
+{{% chef-workstation/knife_data_bag_from_file_create_encrypted_local_mode %}}
 
 ## list
 
@@ -342,7 +342,7 @@ For encrypted data bag items, use *either* `--secret` or
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_delete.md
+++ b/docs-chef-io/content/workstation/knife_delete.md
@@ -13,7 +13,7 @@ aliases = ["/knife_delete.html", "/knife_delete/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-{{% knife_delete_summary %}}
+{{% chef-workstation/knife_delete_summary %}}
 
 ## Syntax
 
@@ -27,7 +27,7 @@ knife delete [PATTERN...] (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -59,7 +59,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_deps.md
+++ b/docs-chef-io/content/workstation/knife_deps.md
@@ -14,7 +14,7 @@ aliases = ["/knife_deps.html", "/knife_deps/"]
 +++
 <!-- markdownlint-disable-file MD024 MD036 -->
 
-{{% knife_deps_summary %}}
+{{% chef-workstation/knife_deps_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife deps (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -60,7 +60,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_diff.md
+++ b/docs-chef-io/content/workstation/knife_diff.md
@@ -14,7 +14,7 @@ aliases = ["/knife_diff.html", "/knife_diff/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_diff_summary %}}
+{{% chef-workstation/knife_diff_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife diff [PATTERN...] (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -68,7 +68,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_download.md
+++ b/docs-chef-io/content/workstation/knife_download.md
@@ -14,7 +14,7 @@ aliases = ["/knife_download.html", "/knife_download/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_download_summary %}}
+{{% chef-workstation/knife_download_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife download [PATTERN...] (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -72,7 +72,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_edit.md
+++ b/docs-chef-io/content/workstation/knife_edit.md
@@ -13,7 +13,7 @@ aliases = ["/knife_edit.html", "/knife_edit/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-{{% knife_edit_summary %}}
+{{% chef-workstation/knife_edit_summary %}}
 
 ## Syntax
 
@@ -27,7 +27,7 @@ knife edit (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -51,7 +51,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -61,4 +61,4 @@ The following examples show how to use this knife subcommand:
 
 ### Remove a user from /groups/admins.json
 
-{{% knife_edit_admin_users %}}
+{{% chef-workstation/knife_edit_admin_users %}}

--- a/docs-chef-io/content/workstation/knife_environment.md
+++ b/docs-chef-io/content/workstation/knife_environment.md
@@ -16,11 +16,11 @@ aliases = ["/knife_environment.html", "/knife_environment/"]
 
 {{% environment %}}
 
-{{% knife_environment_summary %}}
+{{% chef-workstation/knife_environment_summary %}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -153,7 +153,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -255,7 +255,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_exec.md
+++ b/docs-chef-io/content/workstation/knife_exec.md
@@ -14,7 +14,7 @@ aliases = ["/knife_exec.html", "/knife_exec/"]
 +++
 <!-- markdownlint-disable-file MD033 MD036 -->
 
-{{% knife_exec_summary %}}
+{{% chef-workstation/knife_exec_summary %}}
 
 ## Authenticated API Requests
 
@@ -116,7 +116,7 @@ knife exec SCRIPT (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -132,7 +132,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_list.md
+++ b/docs-chef-io/content/workstation/knife_list.md
@@ -14,7 +14,7 @@ aliases = ["/knife_list.html", "/knife_list/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_list_summary %}}
+{{% chef-workstation/knife_list_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife list [PATTERN...] (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -72,7 +72,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_node.md
+++ b/docs-chef-io/content/workstation/knife_node.md
@@ -16,11 +16,11 @@ aliases = ["/knife_node.html", "/knife_node/"]
 
 {{% node %}}
 
-{{% knife_node_summary %}}
+{{% chef-workstation/knife_node_summary %}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -277,7 +277,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -326,33 +326,33 @@ knife node policy set test-node 'test-group' 'test-name'
 
 {{% node_run_list %}}
 
-{{% knife_node_run_list_add %}}
+{{% chef-workstation/knife_node_run_list_add %}}
 
 {{% node_run_list_format %}}
 
 ### Syntax
 
-{{% knife_node_run_list_add_syntax %}}
+{{% chef-workstation/knife_node_run_list_add_syntax %}}
 
 {{< warning >}}
 
-{{% knife_common_windows_quotes %}}
+{{% chef-workstation/knife_common_windows_quotes %}}
 
 {{< /warning >}}
 
 {{< note >}}
 
-{{% knife_common_windows_quotes_module %}}
+{{% chef-workstation/knife_common_windows_quotes_module %}}
 
 {{< /note >}}
 
 ### Options
 
-{{% knife_node_run_list_add_options %}}
+{{% chef-workstation/knife_node_run_list_add_options %}}
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -362,31 +362,31 @@ The following examples show how to use this knife subcommand:
 
 **Add a role**
 
-{{% knife_node_run_list_add_role %}}
+{{% chef-workstation/knife_node_run_list_add_role %}}
 
 **Add roles and recipes**
 
-{{% knife_node_run_list_add_roles_and_recipes %}}
+{{% chef-workstation/knife_node_run_list_add_roles_and_recipes %}}
 
 **Add a recipe with a FQDN**
 
-{{% knife_node_run_list_add_recipe_with_fqdn %}}
+{{% chef-workstation/knife_node_run_list_add_recipe_with_fqdn %}}
 
 **Add a recipe with a cookbook**
 
-{{% knife_node_run_list_add_recipe_with_cookbook %}}
+{{% chef-workstation/knife_node_run_list_add_recipe_with_cookbook %}}
 
 **Add the default recipe**
 
-{{% knife_node_run_list_add_default_recipe %}}
+{{% chef-workstation/knife_node_run_list_add_default_recipe %}}
 
 ## run_list remove
 
-{{% knife_node_run_list_remove %}}
+{{% chef-workstation/knife_node_run_list_remove %}}
 
 ### Syntax
 
-{{% knife_node_run_list_remove_syntax %}}
+{{% chef-workstation/knife_node_run_list_remove_syntax %}}
 
 ### Options
 
@@ -394,7 +394,7 @@ This command does not have any specific options.
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -404,29 +404,29 @@ The following examples show how to use this knife subcommand:
 
 **Remove a role**
 
-{{% knife_node_run_list_remove_role %}}
+{{% chef-workstation/knife_node_run_list_remove_role %}}
 
 **Remove a run-list**
 
-{{% knife_node_run_list_remove_run_list %}}
+{{% chef-workstation/knife_node_run_list_remove_run_list %}}
 
 ## run_list set
 
-{{% knife_node_run_list_set %}}
+{{% chef-workstation/knife_node_run_list_set %}}
 
 ### Syntax
 
-{{% knife_node_run_list_set_syntax %}}
+{{% chef-workstation/knife_node_run_list_set_syntax %}}
 
 {{< warning >}}
 
-{{% knife_common_windows_quotes %}}
+{{% chef-workstation/knife_common_windows_quotes %}}
 
 {{< /warning >}}
 
 {{< note >}}
 
-{{% knife_common_windows_quotes_module %}}
+{{% chef-workstation/knife_common_windows_quotes_module %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_raw.md
+++ b/docs-chef-io/content/workstation/knife_raw.md
@@ -14,7 +14,7 @@ aliases = ["/knife_raw.html", "/knife_raw/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_raw_summary %}}
+{{% chef-workstation/knife_raw_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife raw REQUEST_PATH (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -52,7 +52,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_recipe_list.md
+++ b/docs-chef-io/content/workstation/knife_recipe_list.md
@@ -14,7 +14,7 @@ aliases = ["/knife_recipe_list.html", "/knife_recipe_list/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_recipe_list_summary %}}
+{{% chef-workstation/knife_recipe_list_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife recipe list REGEX
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_role.md
+++ b/docs-chef-io/content/workstation/knife_role.md
@@ -16,7 +16,7 @@ aliases = ["/knife_role.html", "/knife_role/"]
 
 {{% role %}}
 
-{{% knife_role_summary %}}
+{{% chef-workstation/knife_role_summary %}}
 
 {{< note >}}
 
@@ -28,7 +28,7 @@ argument.
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -87,7 +87,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -220,7 +220,7 @@ This command does not have any specific options.
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -292,7 +292,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_search.md
+++ b/docs-chef-io/content/workstation/knife_search.md
@@ -16,7 +16,7 @@ aliases = ["/knife_search.html", "/knife_search/"]
 
 {{% search %}}
 
-{{% knife_search_summary %}}
+{{% chef-workstation/knife_search_summary %}}
 
 ## Syntax
 
@@ -160,7 +160,7 @@ To search for the available fields for a particular object, use the
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -216,40 +216,40 @@ The following examples show how to use this knife subcommand:
 
 **Search by platform ID**
 
-{{% knife_search_by_platform_ids %}}
+{{% chef-workstation/knife_search_by_platform_ids %}}
 
 **Search by instance type**
 
-{{% knife_search_by_platform_instance_type %}}
+{{% chef-workstation/knife_search_by_platform_instance_type %}}
 
 **Search by recipe**
 
-{{% knife_search_by_recipe %}}
+{{% chef-workstation/knife_search_by_recipe %}}
 
 **Search by cookbook, then recipe**
 
-{{% knife_search_by_cookbook %}}
+{{% chef-workstation/knife_search_by_cookbook %}}
 
 **Search by node**
 
-{{% knife_search_by_node %}}
+{{% chef-workstation/knife_search_by_node %}}
 
 **Search by node and environment**
 
-{{% knife_search_by_node_and_environment %}}
+{{% chef-workstation/knife_search_by_node_and_environment %}}
 
 **Search for nested attributes**
 
-{{% knife_search_by_nested_attribute %}}
+{{% chef-workstation/knife_search_by_nested_attribute %}}
 
 **Search for multiple attributes**
 
-{{% knife_search_by_query_for_many_attributes %}}
+{{% chef-workstation/knife_search_by_query_for_many_attributes %}}
 
 **Search for nested attributes using a search query**
 
-{{% knife_search_by_query_for_nested_attribute %}}
+{{% chef-workstation/knife_search_by_query_for_nested_attribute %}}
 
 **Use a test query**
 
-{{% knife_search_test_query_for_ssh %}}
+{{% chef-workstation/knife_search_test_query_for_ssh %}}

--- a/docs-chef-io/content/workstation/knife_serve.md
+++ b/docs-chef-io/content/workstation/knife_serve.md
@@ -13,7 +13,7 @@ aliases = ["/knife_serve.html", "/knife_serve/"]
     parent = "chef_workstation/chef_workstation_tools/knife"
 +++
 
-{{% knife_serve_summary %}}
+{{% chef-workstation/knife_serve_summary %}}
 
 ## Syntax
 
@@ -27,7 +27,7 @@ knife serve (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_show.md
+++ b/docs-chef-io/content/workstation/knife_show.md
@@ -14,7 +14,7 @@ aliases = ["/knife_show.html", "/knife_show/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_show_summary %}}
+{{% chef-workstation/knife_show_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife show [PATTERN...] (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_ssh.md
+++ b/docs-chef-io/content/workstation/knife_ssh.md
@@ -14,7 +14,7 @@ aliases = ["/knife_ssh.html", "/knife_ssh/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_ssh_summary %}}
+{{% chef-workstation/knife_ssh_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife ssh SEARCH_QUERY SSH_COMMAND (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -116,7 +116,7 @@ knife search node "tags:*ubuntu* OR roles:*ubuntu* OR fqdn:*ubuntu* (etc.)"
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_ssl_check.md
+++ b/docs-chef-io/content/workstation/knife_ssl_check.md
@@ -14,7 +14,7 @@ aliases = ["/knife_ssl_check.html", "/knife_ssl_check/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_ssl_check_summary %}}
+{{% chef-workstation/knife_ssl_check_summary %}}
 
 ## Syntax
 
@@ -38,11 +38,11 @@ The following examples show how to use this knife subcommand:
 
 **SSL certificate has valid X.509 properties**
 
-{{% knife_ssl_check_verify_server_config %}}
+{{% chef-workstation/knife_ssl_check_verify_server_config %}}
 
 **SSL certificate has invalid X.509 properties**
 
-{{% knife_ssl_check_bad_ssl_certificate %}}
+{{% chef-workstation/knife_ssl_check_bad_ssl_certificate %}}
 
 **Verify the SSL configuration for Chef Infra Client**
 

--- a/docs-chef-io/content/workstation/knife_ssl_fetch.md
+++ b/docs-chef-io/content/workstation/knife_ssl_fetch.md
@@ -14,7 +14,7 @@ aliases = ["/knife_ssl_fetch.html", "/knife_ssl_fetch/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_ssl_fetch_summary %}}
+{{% chef-workstation/knife_ssl_fetch_summary %}}
 
 ## Syntax
 
@@ -63,4 +63,4 @@ knife ssl fetch https://www.example.com
 
 **Verify Checksums**
 
-{{% knife_ssl_fetch_verify_certificate %}}
+{{% chef-workstation/knife_ssl_fetch_verify_certificate %}}

--- a/docs-chef-io/content/workstation/knife_status.md
+++ b/docs-chef-io/content/workstation/knife_status.md
@@ -14,7 +14,7 @@ aliases = ["/knife_status.html", "/knife_status/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_status_summary %}}
+{{% chef-workstation/knife_status_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife status (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -57,7 +57,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -67,7 +67,7 @@ The following examples show how to use this knife subcommand:
 
 **View status, include run-lists**
 
-{{% knife_status_include_run_lists %}}
+{{% chef-workstation/knife_status_include_run_lists %}}
 
 **View status using a time range**
 
@@ -87,7 +87,7 @@ to return something like:
 
 **View status using a query**
 
-{{% knife_status_returned_by_query %}}
+{{% chef-workstation/knife_status_returned_by_query %}}
 
 **View status for all nodes**
 

--- a/docs-chef-io/content/workstation/knife_supermarket.md
+++ b/docs-chef-io/content/workstation/knife_supermarket.md
@@ -23,13 +23,13 @@ arguments do not require a user account: `download`, `search`,
 
 {{< note >}}
 
-{{% notes_knife_cookbook_site_use_devkit_berkshelf %}}
+{{% chef-workstation/notes_knife_cookbook_site_use_devkit_berkshelf %}}
 
 {{< /note >}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_tag.md
+++ b/docs-chef-io/content/workstation/knife_tag.md
@@ -16,11 +16,11 @@ aliases = ["/knife_tag.html", "/knife_tag/"]
 
 {{% chef_tags %}}
 
-{{% knife_tag_summary %}}
+{{% chef-workstation/knife_tag_summary %}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_upload.md
+++ b/docs-chef-io/content/workstation/knife_upload.md
@@ -14,7 +14,7 @@ aliases = ["/knife_upload.html", "/knife_upload/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_upload_summary %}}
+{{% chef-workstation/knife_upload_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife upload [PATTERN...] (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -72,7 +72,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_user.md
+++ b/docs-chef-io/content/workstation/knife_user.md
@@ -14,11 +14,11 @@ aliases = ["/knife_user.html", "/knife_user/"]
 +++
 <!-- markdownlint-disable-file MD024 MD036 -->
 
-{{% knife_user_summary %}}
+{{% chef-workstation/knife_user_summary %}}
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -82,7 +82,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 
@@ -453,7 +453,7 @@ This argument has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/knife_windows.md
+++ b/docs-chef-io/content/workstation/knife_windows.md
@@ -14,7 +14,7 @@ aliases = ["/knife_windows.html", "/knife_windows/"]
 +++
 <!-- markdownlint-disable-file MD024 MD036 -->
 
-{{% knife_windows_summary %}}
+{{% chef-workstation/knife_windows_summary %}}
 
 {{< note >}}
 
@@ -191,7 +191,7 @@ This argument has the following options:
 
 Use the `winrm` argument to create a connection to one or more remote machines. As each connection is created, a password must be provided. This argument uses the same syntax as the `search` subcommand.
 
-{{% knife_windows_winrm_ports %}}
+{{% chef-workstation/knife_windows_winrm_ports %}}
 
 ### Syntax
 

--- a/docs-chef-io/content/workstation/knife_winrm.md
+++ b/docs-chef-io/content/workstation/knife_winrm.md
@@ -94,7 +94,7 @@ knife winrm 'node1.domain.com' 'dir' -m -x domain\\administrator -P 'super_secre
 
 Use the `winrm` argument to create a connection to one or more remote machines. As each connection is created, a password must be provided. This argument uses the same syntax as the `search` subcommand.
 
-{{% knife_windows_winrm_ports %}}
+{{% chef-workstation/knife_windows_winrm_ports %}}
 
 ### Syntax
 

--- a/docs-chef-io/content/workstation/knife_xargs.md
+++ b/docs-chef-io/content/workstation/knife_xargs.md
@@ -14,7 +14,7 @@ aliases = ["/knife_xargs.html", "/knife_xargs/"]
 +++
 <!-- markdownlint-disable-file MD036 -->
 
-{{% knife_xargs_summary %}}
+{{% chef-workstation/knife_xargs_summary %}}
 
 ## Syntax
 
@@ -28,7 +28,7 @@ knife xargs [PATTERN...] (options)
 
 {{< note >}}
 
-{{% knife_common_see_common_options_link %}}
+{{% chef-workstation/knife_common_see_common_options_link %}}
 
 {{< /note >}}
 
@@ -92,7 +92,7 @@ This subcommand has the following options:
 
 {{< note >}}
 
-{{% knife_common_see_all_config_options %}}
+{{% chef-workstation/knife_common_see_all_config_options %}}
 
 {{< /note >}}
 

--- a/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md
+++ b/docs-chef-io/content/workstation/plugin_kitchen_vagrant.md
@@ -14,8 +14,8 @@ aliases = ["/plugin_kitchen_vagrant.html", "/plugin_kitchen_vagrant/"]
     weight = 40
 +++
 
-{{% test_kitchen_driver_vagrant %}}
+{{% chef-workstation/test_kitchen_driver_vagrant %}}
 
-{{% test_kitchen_driver_vagrant_settings %}}
+{{% chef-workstation/test_kitchen_driver_vagrant_settings %}}
 
-{{% test_kitchen_driver_vagrant_config %}}
+{{% chef-workstation/test_kitchen_driver_vagrant_config %}}

--- a/docs-chef-io/content/workstation/plugin_knife.md
+++ b/docs-chef-io/content/workstation/plugin_knife.md
@@ -37,7 +37,7 @@ The following knife plug-ins are maintained by Chef:
 <tbody>
 <tr>
 <td><a href="https://github.com/chef/knife-azure">knife-azure</a></td>
-<td>{{< readFile_shortcode file="knife_azure.md" >}}</td>
+<td>{{< readfile file="layouts/shortcodes/chef-workstation/knife_azure.md" >}}</td>
 </tr>
 <tr>
 <td><a href="https://github.com/chef/knife-ec2">knife-ec2</a></td>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/bento.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/bento.md
@@ -1,0 +1,5 @@
+[Bento](https://github.com/chef/bento) is a Chef Software project that
+produces base testing VirtualBox, Parallels, and VMware boxes for
+multiple operating systems for use with Test Kitchen. By default, Test
+Kitchen uses the base images provided by Bento although custom images
+may also be built using HashiCorp Packer.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/chef_workstation.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/chef_workstation.md
@@ -1,0 +1,10 @@
+Start your infrastructure automation with [Chef Workstation](/workstation/). Chef Workstation gives you everything you need to get started with Chef - ad hoc remote execution, remote scanning, configuration tasks, cookbook creation tools as well as robust dependency and testing software - all in one easy-to-install package.
+
+Chef Workstation includes:
+
+- Chef Infra Client
+- Chef InSpec
+- Chef Habitat
+- chef and knife command line tools
+- Testing tools such as Test Kitchen and Cookstyle
+- Everything else needed to author cookbooks and upload them to the Chef Infra Server

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_cookbooks.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_cookbooks.md
@@ -1,0 +1,17 @@
+Use the `chef clean-policy-cookbooks` subcommand to delete cookbooks
+that are not used by Policyfile files. Cookbooks are considered unused
+when they are not referenced by any policy revisions on the Chef Infra
+Server.
+
+<div class="admonition-note">
+
+<p class="admonition-note-title">Note</p>
+
+<div class="admonition-note-text">
+
+Cookbooks that are referenced by orphaned policy revisions are not
+removed. Use `chef clean-policy-revisions` to remove orphaned policies.
+
+</div>
+
+</div>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_cookbooks_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_cookbooks_options.md
@@ -1,0 +1,17 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_cookbooks_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_cookbooks_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef clean-policy-cookbooks (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_revisions.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_revisions.md
@@ -1,0 +1,6 @@
+Use the `chef clean-policy-revisions` subcommand to delete orphaned
+policy revisions to Policyfile files from the Chef Infra Server. An
+orphaned policy revision is not associated to any policy group and
+therefore is not in active use by any node. Use
+`chef show-policy --orphans` to view a list of orphaned policy
+revisions.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_revisions_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_revisions_options.md
@@ -1,0 +1,17 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_revisions_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_clean_policy_revisions_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef clean-policy-revisions (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_bootstrap_initial_run_list.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_bootstrap_initial_run_list.md
@@ -1,0 +1,37 @@
+A node's initial run-list is specified using a JSON file on the host
+system. When running Chef Infra Client as an executable, use the `-j`
+option to tell Chef Infra Client which JSON file to use. For example:
+
+```bash
+chef-client -j /etc/chef/file.json --environment _default
+```
+
+where `file.json` is similar to:
+
+```javascript
+{
+  "resolver": {
+    "nameservers": [ "10.0.0.1" ],
+    "search":"int.example.com"
+  },
+  "run_list": [ "recipe[resolver]" ]
+}
+```
+
+and where `_default` is the name of the environment that is assigned to
+the node.
+
+<div class="admonition-warning">
+
+<p class="admonition-warning-title">Warning</p>
+
+<div class="admonition-warning-text">
+
+This approach may be used to update
+[normal](/attributes.html#attribute-types) attributes, but should never
+be used to update any other attribute type, as all attributes updated
+using this option are treated as `normal` attributes.
+
+</div>
+
+</div>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_elevated_privileges.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_elevated_privileges.md
@@ -1,0 +1,5 @@
+The Chef Infra Client may need to be run with elevated privileges in
+order to get a recipe to converge correctly. On UNIX and UNIX-like
+operating systems this can be done by running the command as root. On
+Windows this can be done by running the command prompt as an
+administrator.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_elevated_privileges_windows.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_elevated_privileges_windows.md
@@ -1,0 +1,22 @@
+On Windows, running without elevated privileges (when they are
+necessary) is an issue that fails silently. It will appear that Chef
+Infra Client completed its run successfully, but the changes will not
+have been made. When this occurs, do one of the following to run Chef
+Infra Client as the administrator:
+
+- Log in to the administrator account. (This is not the same as an
+    account in the administrator's security group.)
+
+- Run Chef Infra Client process from the administrator account while
+    being logged into another account. Run the following command:
+
+    ```bash
+    runas /user:Administrator "cmd /C chef-client"
+    ```
+
+    This will prompt for the administrator account password.
+
+- Open a command prompt by right-clicking on the command prompt
+    application, and then selecting **Run as administrator**. After the
+    command window opens, Chef Infra Client can be run as the
+    administrator

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_options_format.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_client_options_format.md
@@ -1,0 +1,16 @@
+The output format: `doc` (default) or `min`.
+
+- Use `doc` to print the progress of a Chef Infra Client run using
+    full strings that display a summary of updates as they occur.
+- Use `min` to print the progress of a Chef Infra Client run using
+    single characters.
+
+A summary of updates is printed at the end of a Chef Infra Client run. A
+dot (`.`) is printed for events that do not have meaningful status
+information, such as loading a file or synchronizing a cookbook. For
+resources, a dot (`.`) is printed when the resource is up to date, an
+`S` is printed when the resource is skipped by `not_if` or `only_if`,
+and a `U` is printed when the resource is updated.
+
+Other formatting options are available when those formatters are
+configured in the client.rb file using the `add_formatter` option.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy.md
@@ -1,0 +1,4 @@
+Use the `chef delete-policy` subcommand to delete all revisions of the
+named policy that exist on the Chef Infra Server. (The state of the
+policy revision is backed up locally and may be restored using the
+`chef undelete` subcommand.)

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_group.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_group.md
@@ -1,0 +1,5 @@
+Use the `chef delete-policy-group` subcommand to delete the named policy
+group from the Chef Infra Server. Any policy revision associated with
+that policy group is not deleted. (The state of the policy group is
+backed up locally and may be restored using the `chef undelete`
+subcommand.)

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_group_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_group_options.md
@@ -1,0 +1,17 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_group_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_group_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef delete-policy-group POLICY_GROUP (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_options.md
@@ -1,0 +1,17 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_delete_policy_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef delete-policy POLICY_NAME (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff.md
@@ -1,0 +1,2 @@
+Use the `chef diff` subcommand to display an itemized comparison of two
+revisions of a `Policyfile.lock.json` file.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_latest_branch.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_latest_branch.md
@@ -1,0 +1,3 @@
+```bash
+chef diff --git HEAD
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_master_branch.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_master_branch.md
@@ -1,0 +1,3 @@
+```bash
+chef diff --git master
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_policy_group.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_policy_group.md
@@ -1,0 +1,3 @@
+```bash
+chef diff staging
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_specified_revision.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_current_lock_specified_revision.md
@@ -1,0 +1,3 @@
+```bash
+chef diff --git v1.0.0
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_master_lock_revision_lock.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_master_lock_revision_lock.md
@@ -1,0 +1,3 @@
+```bash
+chef diff --git master...dev
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_options.md
@@ -1,0 +1,35 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-g GIT_REF`, `--git GIT_REF`
+
+:   Compare the specified git reference against the current revision of
+    a `Policyfile.lock.json` file or against another git reference.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`--head`
+
+:   A shortcut for `chef diff --git HEAD`. When a git-specific flag is
+    not provided, the on-disk `Policyfile.lock.json` file is compared to
+    one on the Chef Infra Server or (if a `Policyfile.lock.json` file is
+    not present on-disk) two `Policyfile.lock.json` files in the
+    specified policy group on the Chef Infra Server are compared.
+
+`--[no-]pager`
+
+:   Use `--pager` to enable paged output for a `Policyfile.lock.json`
+    file. Default value: `--pager`.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef diff POLICY_FILE --head | --git POLICY_GROUP | POLICY_GROUP...POLICY_GROUP (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_two_policy_groups.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_two_policy_groups.md
@@ -1,0 +1,3 @@
+```bash
+chef diff production...staging
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_version_lock_master_branch.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_diff_version_lock_master_branch.md
@@ -1,0 +1,3 @@
+```bash
+chef diff --git v1.0.0...master
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_export.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_export.md
@@ -1,0 +1,5 @@
+Use the `chef export` subcommand to create a chef-zero-compatible
+chef-repo that contains the cookbooks described by a
+`Policyfile.lock.json` file. After a chef-zero-compatible chef-repo is
+copied to a node, the policy can be applied locally on that machine by
+running `chef-client -z` (local mode).

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_export_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_export_options.md
@@ -1,0 +1,23 @@
+This subcommand has the following options:
+
+`-a`, `--archive`
+
+:   Export an archive as a tarball, instead as a directory. Default
+    value: `false`.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-f`, `--force`
+
+:   Remove the contents of the destination directory if that directory
+    is not empty. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_export_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_export_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef export POLICY_FILE DIRECTORY (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_policyfile.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_policyfile.md
@@ -1,0 +1,2 @@
+Use the `chef generate policyfile` subcommand to generate a file to be
+used with Policyfile.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_policyfile_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_policyfile_options.md
@@ -1,0 +1,9 @@
+This subcommand has the following options:
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_policyfile_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_policyfile_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef generate policyfile POLICY_NAME (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_profile.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_profile.md
@@ -1,0 +1,1 @@
+Use the `chef generate profile` subcommand to generate a [profile](/inspec/profiles/) for the Chef Infra Client's Compliance Phase execution.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_profile_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_profile_options.md
@@ -1,0 +1,9 @@
+This subcommand has the following options:
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Workstation version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_profile_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_profile_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef generate profile [path/to/cookbook] NAME
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_repo.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_repo.md
@@ -1,0 +1,3 @@
+Use the `chef generate repo` subcommand to create a chef-repo. By
+default, the repo is a cookbook repo with options available to support
+generating a cookbook that supports Policyfile.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_repo_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_repo_options.md
@@ -1,0 +1,23 @@
+This subcommand has the following options:
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-p`, `--policy-only`
+
+:   Create a repository that does not store cookbook files, only
+    Policyfile files.
+
+`-P`, `--policy`
+
+:   Use Policyfile instead of Berkshelf.
+
+`-r`, `--roles`
+
+:   Create directories for `/roles` and `/environments` instead of
+    creating directories for Policyfile.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_repo_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_generate_repo_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef generate repo REPO_NAME (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_install.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_install.md
@@ -1,0 +1,7 @@
+Use the `chef install` subcommand to evaluate a policy file and find a
+compatible set of cookbooks, build a run-list, cache it locally, and
+then emit a `Policyfile.lock.json` file that describes the locked policy
+set. The `Policyfile.lock.json` file may be used to install the locked
+policy set to other machines and may be pushed to a policy group on the
+Chef Infra Server to apply that policy to a group of nodes that are
+under management by Chef.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_install_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_install_options.md
@@ -1,0 +1,13 @@
+This subcommand has the following options:
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_install_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_install_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef install POLICY_FILE (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push.md
@@ -1,0 +1,5 @@
+Use the `chef push` subcommand to upload an existing
+`Policyfile.lock.json` file to the Chef Infra Server, along with all of
+the cookbooks that are contained in the file. The `Policyfile.lock.json`
+file will be applied to the specified policy group, which is a set of
+nodes that share the same run-list and cookbooks.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_archive.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_archive.md
@@ -1,0 +1,5 @@
+The `chef push-archive` subcommand is used to publish a policy archive
+file to the Chef Infra Server. (A policy archive is created using the
+`chef export` subcommand.) The policy archive is assigned to the
+specified policy group, which is a set of nodes that share the same
+run-list and cookbooks.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_archive_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_archive_options.md
@@ -1,0 +1,17 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_archive_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_archive_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef push-archive POLICY_GROUP ARCHIVE_FILE (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_options.md
@@ -1,0 +1,17 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_push_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef push POLICY_GROUP POLICY_FILE (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_show_policy.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_show_policy.md
@@ -1,0 +1,5 @@
+Use the `chef show-policy` subcommand to display revisions for every
+`Policyfile.rb` file that is on the Chef Infra Server. By default, only
+active policy revisions are shown. When both a policy and policy group
+are specified, the contents of the active `Policyfile.lock.json` file
+for the policy group is returned.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_show_policy_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_show_policy_options.md
@@ -1,0 +1,27 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-o`, `--orphans`
+
+:   Show policy revisions that are not currently assigned to any policy
+    group.
+
+`--[no-]pager`
+
+:   Use `--pager` to enable paged output for a `Policyfile.lock.json`
+    file. Default value: `--pager`.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_show_policy_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_show_policy_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef show-policy POLICY_NAME POLICY_GROUP (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_undelete.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_undelete.md
@@ -1,0 +1,9 @@
+Use the `chef undelete` subcommand to recover a deleted policy or policy
+group. This command:
+
+- Does not detect conflicts. If a deleted item has been recreated,
+    running this command will overwrite it
+- Does not include cookbooks that may be referenced by policy files;
+    cookbooks that are cleaned after running this command may not be
+    fully restorable to their previous state
+- Does not store access control data

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_undelete_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_undelete_options.md
@@ -1,0 +1,29 @@
+This subcommand has the following options:
+
+`-c CONFIG_FILE`, `--config CONFIG_FILE`
+
+:   The path to the knife configuration file.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-i ID`, `--id ID`
+
+:   Undo the delete operation specified by `ID`.
+
+`-l`, `--last`
+
+:   Undo the most recent delete operation.
+
+`--list`
+
+:   Default. Return a list of available operations.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_undelete_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_undelete_syntax.md
@@ -1,0 +1,7 @@
+This subcommand has the following syntax:
+
+```bash
+chef undelete (options)
+```
+
+When run with no arguments, returns a list of available operations.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_update.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_update.md
@@ -1,0 +1,6 @@
+Use the `chef update` subcommand to read the `Policyfile.rb` file, and
+then apply any changes. This will resolve dependencies and will create a
+`Policyfile.lock.json` file. The locked policy will reflect any changes
+to the run-list and will pull in any cookbook updates that are
+compatible with any version constraints defined in the `Policyfile.rb`
+file.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_update_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_update_options.md
@@ -1,0 +1,17 @@
+This subcommand has the following options:
+
+`-a`, `--attributes`
+
+:   Update attributes. Default value: `false`.
+
+`-D`, `--debug`
+
+:   Enable stack traces and other debug output. Default value: `false`.
+
+`-h`, `--help`
+
+:   Show help for the command.
+
+`-v`, `--version`
+
+:   The Chef Infra Client version.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_update_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_chef_update_syntax.md
@@ -1,0 +1,5 @@
+This subcommand has the following syntax:
+
+```bash
+chef update POLICY_FILE (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_kitchen_common_option_platforms.md
@@ -1,0 +1,15 @@
+For example, if a kitchen.yml file contains the following:
+
+```javascript
+- name: centos-7
+- name: centos-8
+- name: fedora-latest
+- name: ubuntu-1604
+- name: ubuntu-1804
+```
+
+then a regular expression like `(04|7)` would run Test Kitchen against
+`centos-7`, `ubuntu-1604`, and `ubuntu-1804`. A regular expression like
+`(ubuntu)` would run Test Kitchen against `ubuntu-1604` and
+`ubuntu-1804`. A regular expression like `(fedora)` would run Test
+Kitchen against only `fedora-latest`. Default: `all`.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_kitchen_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_kitchen_summary.md
@@ -1,0 +1,21 @@
+kitchen is the command-line tool for Test Kitchen, an integration
+testing tool maintained by Chef Software. Test Kitchen runs tests
+against any combination of platforms using any combination of test
+suites. Each test, however, is done against a specific instance, which
+is comprised of a single platform and a single set of testing criteria.
+This allows each test to be run in isolation, ensuring that different
+behaviors within the same codebase can be tested thoroughly before those
+changes are committed to production.
+
+<div class="admonition-note">
+
+<p class="admonition-note-title">Note</p>
+
+<div class="admonition-note-text">
+
+Any Test Kitchen subcommand that does not specify an instance will be
+applied to all instances.
+
+</div>
+
+</div>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_supermarket_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/ctl_supermarket_summary.md
@@ -1,0 +1,5 @@
+The Chef Supermarket installations that are done using the Chef
+installer include a command-line utility named supermarket-ctl. This
+command-line tool is used to start and stop individual services,
+reconfigure the Chef Supermarket server, run smoke tests, and tail the
+Chef Supermarket log files.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_azure.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_azure.md
@@ -1,0 +1,4 @@
+Microsoft Azure is a cloud hosting platform from Microsoft that provides
+virtual machines for Linux and Windows Server, cloud and database
+services, and more. Use the `knife azure` subcommand to manage
+API-driven cloud servers hosted by Microsoft Azure.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_bootstrap_node_fips.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_bootstrap_node_fips.md
@@ -1,0 +1,11 @@
+```bash
+knife bootstrap 192.0.2.0 -P vanilla -x root -r 'recipe[apt],recipe[xfs],recipe[vim]' --fips
+```
+
+which shows something similar to:
+
+```none
+OpenSSL FIPS 140 mode enabled
+...
+192.0.2.0 Chef Infra Client finished, 12/12 resources updated in 78.942455583 seconds
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_bootstrap_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_bootstrap_summary.md
@@ -1,0 +1,3 @@
+Use the `knife bootstrap` subcommand to run a bootstrap operation that
+installs Chef Infra Client on the target system. The bootstrap operation
+must specify the IP address or FQDN of the target system.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_client_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_client_summary.md
@@ -1,0 +1,4 @@
+Use the `knife client` subcommand to manage an API client list and their
+associated RSA public key-pairs. This allows authentication requests to
+be made to the Chef Infra Server by any entity that uses the Chef Infra
+Server API, such as Chef Infra Client and knife.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_see_all_config_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_see_all_config_options.md
@@ -1,0 +1,3 @@
+See [config.rb](/workstation/config_rb_optional_settings/) for more information
+about how to add certain knife options as settings in the config.rb
+file.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_see_common_options_link.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_see_common_options_link.md
@@ -1,0 +1,2 @@
+Review the list of [common options](/workstation/knife_options/) available to
+this (and all) knife subcommands and plugins.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_windows_quotes.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_windows_quotes.md
@@ -1,0 +1,18 @@
+When running knife in Windows, a string may be interpreted as
+a wildcard pattern when quotes are not present in the command. The
+number of quotes to use depends on the shell from which the command is
+being run.
+
+When running knife from the command prompt, a string should be
+surrounded by single quotes (`' '`). For example:
+
+```bash
+knife node run_list set test-node 'recipe[iptables]'
+```
+
+When running knife from Windows PowerShell, a string should be
+surrounded by triple single quotes (`''' '''`). For example:
+
+```bash
+knife node run_list set test-node '''recipe[iptables]'''
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_windows_quotes_module.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_common_windows_quotes_module.md
@@ -1,0 +1,53 @@
+The Chef Infra Client 12.4 release adds an optional feature to the Microsoft
+Installer Package (MSI) for Chef. This feature enables the ability to
+pass quoted strings from the Windows PowerShell command line without the
+need for triple single quotes (`''' '''`). This feature installs a
+Windows PowerShell module (typically in `C:\opscode\chef\modules`) that
+is also appended to the `PSModulePath` environment variable. This
+feature is not enabled by default. To activate this feature, run the
+following command from within Windows PowerShell:
+
+```bash
+Import-Module chef
+```
+
+or add `Import-Module chef` to the profile for Windows PowerShell
+located at:
+
+```bash
+~\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+```
+
+This module exports cmdlets that have the same name as the command-line
+tools---chef-client, knife---that are built into Chef.
+
+For example:
+
+```bash
+knife exec -E 'puts ARGV' """&s0meth1ng"""
+```
+
+is now:
+
+```bash
+knife exec -E 'puts ARGV' '&s0meth1ng'
+```
+
+and:
+
+```bash
+knife node run_list set test-node '''role[ssssssomething]'''
+```
+
+is now:
+
+```bash
+knife node run_list set test-node 'role[ssssssomething]'
+```
+
+To remove this feature, run the following command from within Windows
+PowerShell:
+
+```bash
+Remove-Module chef
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_configure_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_configure_summary.md
@@ -1,0 +1,1 @@
+Use the `knife configure` subcommand to create the [client.rb](/config_rb_client/) and credential files so that they can be distributed to workstations and nodes.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_cookbook_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_cookbook_summary.md
@@ -1,0 +1,2 @@
+Use the `knife cookbook` subcommand to interact with cookbooks that are
+located on the Chef Infra Server or the local chef-repo.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_edit.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_edit.md
@@ -1,0 +1,4 @@
+Use the `edit` argument to edit the data contained in a data bag. If
+encryption is being used, the data bag will be decrypted, the data will
+be made available in the \$EDITOR, and then encrypted again before
+saving it to the Chef Infra Server.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_edit_item.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_edit_item.md
@@ -1,0 +1,27 @@
+To edit an item named "charlie" that is contained in a data bag named
+"admins", enter:
+
+```bash
+knife data bag edit admins charlie
+```
+
+to open the \$EDITOR. Once opened, you can update the data before saving
+it to the Chef Infra Server. For example, by changing:
+
+```javascript
+{
+   "id": "charlie"
+}
+```
+
+to:
+
+```javascript
+{
+   "id": "charlie",
+   "uid": 1005,
+   "gid": "ops",
+   "shell": "/bin/zsh",
+   "comment": "Crazy Charlie"
+}
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_from_file_create_encrypted_local_mode.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_from_file_create_encrypted_local_mode.md
@@ -1,0 +1,11 @@
+To generate an encrypted data bag item in a JSON file for use when Chef
+Infra Client is run in local mode (using the `--local-mode` option),
+enter:
+
+```bash
+knife data bag from file my_data_bag /path/to/data_bag_item.json -z --secret-file /path/to/encrypted_data_bag_secret
+```
+
+this will create an encrypted JSON file in:
+
+    data_bags/my_data_bag/data_bag_item.json

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_data_bag_summary.md
@@ -1,0 +1,2 @@
+Use the `knife data bag` subcommand to manage arbitrary stores of
+globally available JSON data.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_delete_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_delete_summary.md
@@ -1,0 +1,5 @@
+Use the `knife delete` subcommand to delete an object from a Chef Infra
+Server. This subcommand works similar to `knife cookbook delete`,
+`knife data bag delete`, `knife environment delete`,
+`knife node delete`, and `knife role delete`, but with a single verb
+(and a single action).

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_deps_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_deps_summary.md
@@ -1,0 +1,2 @@
+Use the `knife deps` subcommand to identify dependencies for a node,
+role, or cookbook.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_diff_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_diff_summary.md
@@ -1,0 +1,8 @@
+Use the `knife diff` subcommand to compare the differences between files
+and directories on the Chef Infra Server and in the chef-repo. For
+example, to compare files on the Chef Infra Server before uploading or
+downloading files using the `knife download` and `knife upload`
+subcommands, or to ensure that certain files in multiple production
+environments are the same. This subcommand is similar to the `git diff`
+command that can be used to diff what is in the chef-repo with what is
+synced to a git repository.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_download_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_download_summary.md
@@ -1,0 +1,9 @@
+Use the `knife download` subcommand to download roles, cookbooks,
+environments, nodes, and data bags from the Chef Infra Server to the
+current working directory. It can be used to back up data on the Chef
+Infra Server, inspect the state of one or more files, or to extract
+out-of-process changes users may have made to files on the Chef Infra
+Server, such as if a user made a change that bypassed version source
+control. This subcommand is often used in conjunction with `knife diff`,
+which can be used to see exactly what changes will be downloaded, and
+then `knife upload`, which does the opposite of `knife download`.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_edit_admin_users.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_edit_admin_users.md
@@ -1,0 +1,9 @@
+A user who belongs to the `admins` group must be removed from the group
+before they may be removed from an organization. To remove a user from
+the `admins` group, run the following:
+
+```bash
+EDITOR=vi knife edit /groups/admins.json
+```
+
+make the required changes, and then save the file.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_edit_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_edit_summary.md
@@ -1,0 +1,4 @@
+Use the `knife edit` subcommand to edit objects on the Chef Infra
+Server. This subcommand works similar to `knife cookbook edit`,
+`knife data bag edit`, `knife environment edit`, `knife node edit`, and
+`knife role edit`, but with a single verb (and a single action).

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_environment_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_environment_summary.md
@@ -1,0 +1,2 @@
+Use the `knife environment` subcommand to manage environments within a
+single organization on the Chef Infra Server.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_exec_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_exec_summary.md
@@ -1,0 +1,5 @@
+Use the `knife exec` subcommand to execute Ruby scripts in the context
+of a fully configured Chef Infra Client. Use this subcommand to run
+scripts that will only access Chef Infra Server one time (or otherwise
+infrequently) or any time that an operation does not warrant full
+usage of the knife subcommand library.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_list_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_list_summary.md
@@ -1,0 +1,4 @@
+Use the `knife list` subcommand to view a list of objects on the Chef
+Infra Server. This subcommand works similar to `knife cookbook list`,
+`knife data bag list`, `knife environment list`, `knife node list`, and
+`knife role list`, but with a single verb (and a single action).

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add.md
@@ -1,0 +1,2 @@
+Use the `run_list add` argument to add run-list items (roles or recipes)
+to a node.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_default_recipe.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_default_recipe.md
@@ -1,0 +1,5 @@
+To add the default recipe of a cookbook to a run-list, enter:
+
+```bash
+knife node run_list add NODE_NAME 'COOKBOOK'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_options.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_options.md
@@ -1,0 +1,9 @@
+This argument has the following options:
+
+`-a ITEM`, `--after ITEM`
+
+:   Add a run-list item after the specified run-list item.
+
+`-b ITEM`, `--before ITEM`
+
+:   Add a run-list item before the specified run-list item.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_recipe_with_cookbook.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_recipe_with_cookbook.md
@@ -1,0 +1,5 @@
+To add a recipe to a run-list using the cookbook format, enter:
+
+```bash
+knife node run_list add NODE_NAME 'COOKBOOK::RECIPE_NAME'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_recipe_with_fqdn.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_recipe_with_fqdn.md
@@ -1,0 +1,5 @@
+To add a recipe to a run-list using the fully qualified format, enter:
+
+```bash
+knife node run_list add NODE_NAME 'recipe[COOKBOOK::RECIPE_NAME]'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_role.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_role.md
@@ -1,0 +1,5 @@
+To add a role to a run-list, enter:
+
+```bash
+knife node run_list add NODE_NAME 'role[ROLE_NAME]'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_roles_and_recipes.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_roles_and_recipes.md
@@ -1,0 +1,5 @@
+To add roles and recipes to a run-list, enter:
+
+```bash
+knife node run_list add NODE_NAME 'recipe[COOKBOOK::RECIPE_NAME],recipe[COOKBOOK::RECIPE_NAME],role[ROLE_NAME]'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_add_syntax.md
@@ -1,0 +1,5 @@
+This argument has the following syntax:
+
+```bash
+knife node run_list add NODE_NAME RUN_LIST_ITEM (options)
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove.md
@@ -1,0 +1,7 @@
+Use the `run_list remove` argument to remove run-list items (roles or
+recipes) from a node. A recipe must be in one of the following formats:
+fully qualified, cookbook, or default. Both roles and recipes must be in
+quotes, for example: `'role[ROLE_NAME]'` or
+`'recipe[COOKBOOK::RECIPE_NAME]'`. Use a comma to separate roles and
+recipes when removing more than one, like this:
+`'recipe[COOKBOOK::RECIPE_NAME],COOKBOOK::RECIPE_NAME,role[ROLE_NAME]'`.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove_role.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove_role.md
@@ -1,0 +1,5 @@
+To remove a role from a run-list, enter:
+
+```bash
+knife node run_list remove NODE_NAME 'role[ROLE_NAME]'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove_run_list.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove_run_list.md
@@ -1,0 +1,6 @@
+To remove a recipe from a run-list using the fully qualified format,
+enter:
+
+```bash
+knife node run_list remove NODE_NAME 'recipe[COOKBOOK::RECIPE_NAME]'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_remove_syntax.md
@@ -1,0 +1,5 @@
+This argument has the following syntax:
+
+```bash
+knife node run_list remove NODE_NAME RUN_LIST_ITEM
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_set.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_set.md
@@ -1,0 +1,6 @@
+Use the `run_list set` argument to set the run-list for a node. A recipe
+must be in one of the following formats: fully qualified, cookbook, or
+default. Both roles and recipes must be in quotes, for example:
+`"role[ROLE_NAME]"` or `"recipe[COOKBOOK::RECIPE_NAME]"`. Use a comma to
+separate roles and recipes when setting more than one, like this:
+`"recipe[COOKBOOK::RECIPE_NAME],COOKBOOK::RECIPE_NAME,role[ROLE_NAME]"`.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_set_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_run_list_set_syntax.md
@@ -1,0 +1,5 @@
+This argument has the following syntax:
+
+```bash
+knife node run_list set NODE_NAME RUN_LIST_ITEM
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_node_summary.md
@@ -1,0 +1,2 @@
+Use the `knife node` subcommand to manage the nodes that exist on a Chef
+Infra Server.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_raw_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_raw_summary.md
@@ -1,0 +1,2 @@
+Use the `knife raw` subcommand to send a REST request to an endpoint in
+the Chef Infra Server API.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_recipe_list_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_recipe_list_summary.md
@@ -1,0 +1,5 @@
+Use the `knife recipe list` subcommand to view all of the recipes that
+are on a Chef Infra Server. A regular expression can be used to limit
+the results to recipes that match a specific pattern. The regular
+expression must be within quotes and not be surrounded by forward
+slashes (/).

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_role_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_role_summary.md
@@ -1,0 +1,2 @@
+Use the `knife role` subcommand to manage the roles that are associated
+with one or more nodes on a Chef Infra Server.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_cookbook.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_cookbook.md
@@ -1,0 +1,7 @@
+To search for cookbooks on a node, use the `recipes` attribute followed
+by the `cookbook::recipe` pattern, escaping both of the `:` characters.
+For example:
+
+```bash
+knife search node 'recipes:cookbook_name\:\:recipe_name'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_nested_attribute.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_nested_attribute.md
@@ -1,0 +1,5 @@
+To find a nested attribute, use a pattern similar to the following:
+
+```bash
+knife search node <query_to_run> -a <main_attribute>.<nested_attribute>
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_node.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_node.md
@@ -1,0 +1,5 @@
+To search for all nodes running Ubuntu, enter:
+
+```bash
+knife search node 'platform:ubuntu'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_node_and_environment.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_node_and_environment.md
@@ -1,0 +1,6 @@
+To search for all nodes running CentOS in the production environment,
+enter:
+
+```bash
+knife search node 'chef_environment:production AND platform:centos'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_platform_ids.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_platform_ids.md
@@ -1,0 +1,20 @@
+To search for the IDs of all nodes running on the Amazon EC2 platform,
+enter:
+
+```bash
+knife search node 'ec2:*' -i
+```
+
+to return something like:
+
+```bash
+4 items found
+
+ip-0A7CA19F.ec2.internal
+
+ip-0A58CF8E.ec2.internal
+
+ip-0A58E134.ec2.internal
+
+ip-0A7CFFD5.ec2.internal
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_platform_instance_type.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_platform_instance_type.md
@@ -1,0 +1,24 @@
+To search for the instance type (flavor) of all nodes running on the
+Amazon EC2 platform, enter:
+
+```bash
+knife search node 'ec2:*' -a ec2.instance_type
+```
+
+to return something like:
+
+```bash
+4 items found
+
+ec2.instance_type:  m1.large
+id:                 ip-0A7CA19F.ec2.internal
+
+ec2.instance_type:  m1.large
+id:                 ip-0A58CF8E.ec2.internal
+
+ec2.instance_type:  m1.large
+id:                 ip-0A58E134.ec2.internal
+
+ec2.instance_type:  m1.large
+id:                 ip-0A7CFFD5.ec2.internal
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_query_for_many_attributes.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_query_for_many_attributes.md
@@ -1,0 +1,7 @@
+To build a search query to use more than one attribute, use an
+underscore (`_`) to separate each attribute. For example, the following
+query will search for all nodes running a specific version of Ruby:
+
+```bash
+knife search node "languages_ruby_version:2.7.0"
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_query_for_nested_attribute.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_query_for_nested_attribute.md
@@ -1,0 +1,5 @@
+To build a search query that can find a nested attribute:
+
+```bash
+knife search node name: <node_name> -a kernel.machine
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_recipe.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_by_recipe.md
@@ -1,0 +1,12 @@
+To search for recipes that are used by a node, use the `recipes`
+attribute to search for the recipe names, enter something like:
+
+```bash
+knife search node 'recipes:recipe_name'
+```
+
+or:
+
+```bash
+knife search node '*:*' -a recipes | grep 'recipe_name'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_summary.md
@@ -1,0 +1,2 @@
+Use the `knife search` subcommand to run a search query for information
+that is indexed on a Chef Infra Server.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_test_query_for_ssh.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_search_test_query_for_ssh.md
@@ -1,0 +1,8 @@
+To test a search query that will be used in a `knife ssh` subcommand:
+
+```bash
+knife search node "role:web NOT name:web03"
+```
+
+where the query in the previous example will search all servers that
+have the `web` role, but not on the server named `web03`.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_serve_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_serve_summary.md
@@ -1,0 +1,8 @@
+Use the `knife serve` subcommand to run a persistent chef-zero against
+the local chef-repo. (chef-zero is a lightweight Chef Infra Server that
+runs in-memory on the local machine.) This is the same as running the
+Chef Infra Client executable with the `--local-mode` option. The
+`chef_repo_path` is located automatically and the Chef Infra Server will
+bind to the first available port between `8889` and `9999`.
+`knife serve` will print the URL for the local Chef Infra Server, so
+that it may be added to the config.rb file.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_show_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_show_summary.md
@@ -1,0 +1,5 @@
+Use the `knife show` subcommand to view the details of one (or more)
+objects on the Chef Infra Server. This subcommand works similar to
+`knife cookbook show`, `knife data bag show`, `knife environment show`,
+`knife node show`, and `knife role show`, but with a single verb (and a
+single action).

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssh_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssh_summary.md
@@ -1,0 +1,3 @@
+Use the `knife ssh` subcommand to invoke SSH commands (in parallel) on a
+subset of nodes within an organization, based on the results of a
+[search query](/chef_search/) made to the Chef Infra Server.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_check_bad_ssl_certificate.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_check_bad_ssl_certificate.md
@@ -1,0 +1,42 @@
+If the SSL certificate cannot be verified, the response to
+
+```bash
+knife ssl check
+```
+
+is similar to:
+
+```bash
+Connecting to host chef-server.example.com:443
+ERROR: The SSL certificate of chef-server.example.com could not be verified
+Certificate issuer data:
+  /C=US/ST=WA/L=S/O=Corp/OU=Ops/CN=chef-server.example.com/emailAddress=you@example.com
+
+Configuration Info:
+
+OpenSSL Configuration:
+* Version: OpenSSL 1.0.2u  20 Dec 2019
+* Certificate file: /opt/chef-workstation/embedded/ssl/cert.pem
+* Certificate directory: /opt/chef-workstation/embedded/ssl/certs
+Chef SSL Configuration:
+* ssl_ca_path: nil
+* ssl_ca_file: nil
+* trusted_certs_dir: "/Users/grantmc/Downloads/chef-repo/.chef/trusted_certs"
+
+TO FIX THIS ERROR:
+
+If the server you are connecting to uses a self-signed certificate,
+you must configure chef to trust that certificate.
+
+By default, the certificate is stored in the following location on the
+host where your Chef Infra Server runs:
+
+  /var/opt/opscode/nginx/ca/SERVER_HOSTNAME.crt
+
+Copy that file to your trusted_certs_dir (currently:
+
+  /Users/grantmc/Downloads/chef-repo/.chef/trusted_certs)
+
+using SSH/SCP or some other secure method, then re-run this command to
+confirm that the certificate is now trusted.
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_check_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_check_summary.md
@@ -1,0 +1,28 @@
+Use the `knife ssl check` subcommand to verify the SSL configuration for
+the Chef Infra Server or a location specified by a URL or URI. Invalid
+certificates will not be used by OpenSSL.
+
+When this command is run, the certificate files (`*.crt` and/or `*.pem`)
+that are located in the `/.chef/trusted_certs` directory are checked to
+see if they have valid X.509 certificate properties. A warning is
+returned when certificates do not have valid X.509 certificate
+properties or if the `/.chef/trusted_certs` directory does not contain
+any certificates.
+
+<div class="admonition-warning">
+
+<p class="admonition-warning-title">Warning</p>
+
+<div class="admonition-warning-text">
+
+When verification of a remote server's SSL certificate is disabled, Chef
+Infra Client will issue a warning similar to "SSL validation of HTTPS
+requests is disabled. HTTPS connections are still encrypted, but Chef
+Infra Client is not able to detect forged replies or man-in-the-middle
+attacks." To configure SSL for Chef Infra Client, set `ssl_verify_mode`
+to `:verify_peer` (recommended) **or** `verify_api_cert` to `true` in
+the client.rb file.
+
+</div>
+
+</div>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_check_verify_server_config.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_check_verify_server_config.md
@@ -1,0 +1,12 @@
+If the SSL certificate can be verified, the response to
+
+```bash
+knife ssl check
+```
+
+is similar to:
+
+```bash
+Connecting to host chef-server.example.com:443
+Successfully verified certificates from 'chef-server.example.com'
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_fetch_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_fetch_summary.md
@@ -1,0 +1,25 @@
+Use the `knife ssl fetch` subcommand to copy SSL certificates from an
+HTTPS server to the `trusted_certs_dir` directory that is used by knife
+and Chef Infra Client to store trusted SSL certificates. When these
+certificates match the hostname of the remote server, running
+`knife ssl fetch` is the only step required to verify a remote server
+that is accessed by either knife or Chef Infra Client.
+
+<div class="admonition-warning">
+
+<p class="admonition-warning-title">Warning</p>
+
+<div class="admonition-warning-text">
+
+It is the user's responsibility to verify the authenticity of every SSL
+certificate before downloading it to the `/.chef/trusted_certs`
+directory. knife will use any certificate in that directory as if it is
+a 100% trusted and authentic SSL certificate. knife will not be able to
+determine if any certificate in this directory has been tampered with,
+is forged, malicious, or otherwise harmful. Therefore it is essential
+that users take the proper steps before downloading certificates into
+this directory.
+
+</div>
+
+</div>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_fetch_verify_certificate.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_ssl_fetch_verify_certificate.md
@@ -1,0 +1,30 @@
+The SSL certificate that is downloaded to the `/.chef/trusted_certs`
+directory should be verified to ensure that it is, in fact, the same
+certificate as the one located on the Chef Infra Server. This can be
+done by comparing the SHA-256 checksums.
+
+1.  View the checksum on the Chef Infra Server:
+
+    ```bash
+    ssh ubuntu@chef-server.example.com sudo sha256sum /var/opt/opscode/nginx/ca/chef-server.example.com.crt
+    ```
+
+    The response is similar to:
+
+    ```bash
+    <ABC123checksum>  /var/opt/opscode/nginx/ca/chef-server.example.com.crt
+    ```
+
+2.  View the checksum on the workstation:
+
+    ```bash
+    gsha256sum .chef/trusted_certs/chef-server.example.com.crt
+    ```
+
+    The response is similar to:
+
+    ```bash
+    <ABC123checksum>  .chef/trusted_certs/chef-server.example.com.crt
+    ```
+
+3.  Verify that the checksum values are identical.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_status_include_run_lists.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_status_include_run_lists.md
@@ -1,0 +1,16 @@
+To include run-lists in the status, enter:
+
+```bash
+knife status --run-list
+```
+
+to return something like:
+
+```bash
+20 hours ago, dev-vm.chisamore.com, ubuntu 10.04, dev-vm.chisamore.com, 10.66.44.126, role[lb].
+3 hours ago, i-225f954f, ubuntu 10.04, ec2-67-202-63-102.compute-1.amazonaws.com, 67.202.63.102, role[web].
+3 hours ago, i-a45298c9, ubuntu 10.04, ec2-174-129-127-206.compute-1.amazonaws.com, 174.129.127.206, role[web].
+3 hours ago, i-5272a43f, ubuntu 10.04, ec2-184-73-9-250.compute-1.amazonaws.com, 184.73.9.250, role[web].
+3 hours ago, i-226ca64f, ubuntu 10.04, ec2-75-101-240-230.compute-1.amazonaws.com, 75.101.240.230, role[web].
+3 hours ago, i-f65c969b, ubuntu 10.04, ec2-184-73-60-141.compute-1.amazonaws.com, 184.73.60.141, role[web].
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_status_returned_by_query.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_status_returned_by_query.md
@@ -1,0 +1,16 @@
+To show the status of a subset of nodes that are returned by a specific
+query, enter:
+
+```bash
+knife status "role:web" --run-list
+```
+
+to return something like:
+
+```bash
+3 hours ago, i-225f954f, ubuntu 10.04, ec2-67-202-63-102.compute-1.amazonaws.com, 67.202.63.102, role[web].
+3 hours ago, i-a45298c9, ubuntu 10.04, ec2-174-129-127-206.compute-1.amazonaws.com, 174.129.127.206, role[web].
+3 hours ago, i-5272a43f, ubuntu 10.04, ec2-184-73-9-250.compute-1.amazonaws.com, 184.73.9.250, role[web].
+3 hours ago, i-226ca64f, ubuntu 10.04, ec2-75-101-240-230.compute-1.amazonaws.com, 75.101.240.230, role[web].
+3 hours ago, i-f65c969b, ubuntu 10.04, ec2-184-73-60-141.compute-1.amazonaws.com, 184.73.60.141, role[web].
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_status_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_status_summary.md
@@ -1,0 +1,3 @@
+Use the `knife status` subcommand to display a brief summary of the
+nodes on a Chef Infra Server, including the time of the most recent
+successful Chef Infra Client run.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_tag_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_tag_summary.md
@@ -1,0 +1,2 @@
+Use the `knife tag` subcommand to apply tags to nodes on a Chef Infra
+Server.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_upload_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_upload_summary.md
@@ -1,0 +1,13 @@
+Use the `knife upload` subcommand to upload data to the Chef Infra
+Server from the current working directory in the chef-repo. The
+following types of data may be uploaded with this subcommand:
+
+- Cookbooks
+- Data bags
+- Roles stored as JSON data
+- Environments stored as JSON data
+
+(Roles and environments stored as Ruby data will not be uploaded.) This
+subcommand is often used in conjunction with `knife diff`, which can be
+used to see exactly what changes will be uploaded, and then
+`knife download`, which does the opposite of `knife upload`.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_user_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_user_summary.md
@@ -1,0 +1,2 @@
+Use the `knife user` subcommand to manage the list of users and their
+associated RSA public key-pairs.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_windows_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_windows_summary.md
@@ -1,0 +1,5 @@
+The `knife windows` subcommand is used to interact with Windows systems
+managed by Chef Infra. Nodes are configured using WinRM, which allows
+external applications to call native objects like batch scripts, Windows
+PowerShell scripts, or scripting library variables. The `knife windows`
+subcommand supports NTLM and Kerberos methods of authentication.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_windows_winrm_ports.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_windows_winrm_ports.md
@@ -1,0 +1,2 @@
+WinRM requires that a target node be accessible using the ports configured
+to support access using HTTP or HTTPS.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/knife_xargs_summary.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/knife_xargs_summary.md
@@ -1,0 +1,3 @@
+Use the `knife xargs` subcommand to take patterns from standard input,
+download as JSON, run a command against the downloaded JSON, and then
+upload any changes.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/notes_knife_cookbook_site_use_devkit_berkshelf.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/notes_knife_cookbook_site_use_devkit_berkshelf.md
@@ -1,0 +1,3 @@
+Please consider managing community cookbooks using the version of
+Berkshelf that ships with Chef Workstation. For more information about
+Chef Workstation, see [About Chef Workstation](/workstation/).

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_driver_vagrant.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_driver_vagrant.md
@@ -1,0 +1,4 @@
+The `kitchen-vagrant` driver for Kitchen generates a single Vagrantfile
+for each instance of Kitchen in a sandboxed directory. The
+`kitchen-vagrant` driver supports VirtualBox and VMware Fusion, requires
+Vagrant 1.1.0 (or higher), and is the default driver for Test Kitchen.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_driver_vagrant_config.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_driver_vagrant_config.md
@@ -1,0 +1,24 @@
+The `kitchen-vagrant` driver can predict the box name for Vagrant and
+the download URL that have been published by Chef. For example:
+
+```ruby
+platforms:
+- name: ubuntu-18.04
+- name: ubuntu-20.04
+- name: centos-7
+- name: centos-8
+- name: debian-10
+```
+
+which will generate a configuration file similar to:
+
+```ruby
+platforms:
+- name: ubuntu-18.04
+  driver:
+    box: bento/ubuntu-18.04
+- name: ubuntu-20.04
+  driver:
+    box: bento/ubuntu-20.04
+# ...
+```

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_driver_vagrant_settings.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_driver_vagrant_settings.md
@@ -1,0 +1,81 @@
+The following attributes are used to configure `kitchen-vagrant` for
+Chef:
+
+<table>
+<colgroup>
+<col style="width: 12%" />
+<col style="width: 87%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Attribute</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>box</code></td>
+<td>Required. Use to specify the box on which Vagrant will run. Default value: computed from the platform name of the instance.</td>
+</tr>
+<tr>
+<td><code>box_check_update</code></td>
+<td>Use to check for box updates. Default value: <code>false</code>.</td>
+</tr>
+<tr>
+<td><code>box_url</code></td>
+<td>Use to specify the URL at which the configured box is located. Default value: computed from the platform name of the instance, but only when the Vagrant provider is VirtualBox- or VMware-based.</td>
+</tr>
+<tr>
+<td><code>communicator</code></td>
+<td>Use to override the <code>config.vm.communicator</code> setting in Vagrant. For example, when a base box is a Windows operating system that does not have SSH installed and enabled, Vagrant will not be able to boot without a custom Vagrant file. Default value: <code>nil</code> (assumes SSH is available).</td>
+</tr>
+<tr>
+<td><code>customize</code></td>
+<td>A hash of key-value pairs that define customizations that should be made to the Vagrant virtual machine. For example: <code>customize: memory: 1024 cpuexecutioncap: 50</code>.</td>
+</tr>
+<tr>
+<td><code>guest</code></td>
+<td>Use to specify the <code>config.vm.guest</code> setting in the default Vagrantfile.</td>
+</tr>
+<tr>
+<td><code>gui</code></td>
+<td>Use to enable the graphical user interface for the defined platform. This is passed to the <code>config.vm.provider</code> setting in Vagrant, but only when the Vagrant provider is VirtualBox- or VMware-based.</td>
+</tr>
+<tr>
+<td><code>network</code></td>
+<td>Use to specify an array of network customizations to be applied to the virtual machine. Default value: <code>[]</code>. For example: <code>network: - ["forwarded_port", {guest: 80, host: 8080}] - ["private_network", {ip: "192.168.33.33"}]</code>.</td>
+</tr>
+<tr>
+<td><code>pre_create_command</code></td>
+<td>Use to run a command immediately before <code>vagrant up --no-provisioner</code>.</td>
+</tr>
+<tr>
+<td><code>provider</code></td>
+<td>Use to specify the Vagrant provider. This value must match a provider name in Vagrant.</td>
+</tr>
+<tr>
+<td><code>provision</code></td>
+<td>Use to provision Vagrant when the instance is created. This is useful if the operating system needs customization during provisioning. Default value: <code>false</code>.</td>
+</tr>
+<tr>
+<td><code>ssh_key</code></td>
+<td>Use to specify the private key file used for SSH authentication.</td>
+</tr>
+<tr>
+<td><code>synced_folders</code></td>
+<td>Use to specify a collection of synchronized folders on each Vagrant instance. Source paths are relative to the Kitchen root path. Default value: <code>[]</code>. For example: <code>synced_folders: - ["data/%{instance_name}", "/opt/instance_data"] - ["/host_path", "/vm_path", "create: true, type: :nfs"]</code>.</td>
+</tr>
+<tr>
+<td><code>vagrantfile_erb</code></td>
+<td>Use to specify an alternate Vagrant Embedded Ruby (ERB) template to be used by this driver.</td>
+</tr>
+<tr>
+<td><code>vagrantfiles</code></td>
+<td>An array of paths to one (or more) Vagrant files to be merged with the default Vagrant file. The paths may be absolute or relative to the kitchen.yml file.</td>
+</tr>
+<tr>
+<td><code>vm_hostname</code></td>
+<td>Use to specify the internal hostname for the instance. This is not required when connecting to a Vagrant virtual machine. Set this to <code>false</code> to prevent this value from being rendered in the default Vagrantfile. Default value: computed from the platform name of the instance.</td>
+</tr>
+</tbody>
+</table>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_drivers.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_drivers.md
@@ -1,0 +1,83 @@
+Test Kitchen uses a driver plugin architecture to enable Test Kitchen to
+test instances on cloud providers such as Amazon EC2, Google Compute
+Engine, and Microsoft Azure. You can also test on multiple local
+hypervisors, such as VMware, Hyper-V, or VirtualBox.
+
+<div class="admonition-note">
+
+<p class="admonition-note-title">Note</p>
+
+<div class="admonition-note-text">
+
+Chef Workstation includes many common Test Kitchen drivers.
+
+</div>
+
+</div>
+
+Most drivers have driver-specific configuration settings that must be
+added to the kitchen.yml file before Test Kitchen will be able to use
+that platform during cookbook testing. For information about these
+driver-specific settings, please refer to the driver-specific
+documentation.
+
+Some popular drivers:
+
+<table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 75%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Driver Plugin</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-azurerm">kitchen-azurerm</a></td>
+<td>A driver for Microsoft Azure.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-cloudstack">kitchen-cloudstack</a></td>
+<td>A driver for CloudStack.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-digitalocean">kitchen-digitalocean</a></td>
+<td>A driver for DigitalOcean. This driver ships in Chef Workstation.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-dokken">kitchen-dokken</a></td>
+<td>A driver for Docker. This driver ships in Chef Workstation.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-dsc">kitchen-dsc</a></td>
+<td>A driver for Windows PowerShell Desired State Configuration (DSC).</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-ec2">kitchen-ec2</a></td>
+<td>A driver for Amazon EC2. This driver ships in Chef Workstation.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-google">kitchen-google</a></td>
+<td>A driver for Google Compute Engine. This driver ships in Chef Workstation</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-hyperv">kitchen-hyperv</a></td>
+<td>A driver for Microsoft Hyper-V Server. This driver ships in Chef Workstation.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-openstack">kitchen-openstack</a></td>
+<td>A driver for OpenStack. This driver ships in Chef Workstation.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-rackspace">kitchen-rackspace</a></td>
+<td>A driver for Rackspace.</td>
+</tr>
+<tr>
+<td><a href="https://github.com/test-kitchen/kitchen-vagrant">kitchen-vagrant</a></td>
+<td>A driver for HashiCorp Vagrant. This driver ships in Chef Workstation.</td>
+</tr>
+</tbody>
+</table>

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_yml.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_yml.md
@@ -1,0 +1,2 @@
+Use a kitchen.yml file to define what is required to run Test Kitchen,
+including drivers, provisioners, platforms, and test suites.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_yml_syntax.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_yml_syntax.md
@@ -1,0 +1,116 @@
+The basic structure of a kitchen.yml file is as follows:
+
+```yaml
+driver:
+  name: driver_name
+
+provisioner:
+  name: provisioner_name
+
+verifier:
+  name: verifier_name
+
+transport:
+  name: transport_name
+
+platforms:
+  - name: platform-version
+    driver:
+      name: driver_name
+  - name: platform-version
+
+suites:
+  - name: suite_name
+    run_list:
+      - recipe[cookbook_name::recipe_name]
+    attributes: { foo: "bar" }
+    excludes:
+      - platform-version
+  - name: suite_name
+    driver:
+      name: driver_name
+    run_list:
+      - recipe[cookbook_name::recipe_name]
+    attributes: { foo: "bar" }
+    includes:
+      - platform-version
+```
+
+where:
+
+- `driver_name` is the name of a driver that will be used to create
+    platform instances used during cookbook testing. This is the default
+    driver used for all platforms and suites **unless** a platform or
+    suite specifies a `driver` to override the default driver for that
+    platform or suite; a driver specified for a suite will override a
+    driver set for a platform
+
+- `provisioner_name` specifies how Chef Infra Client will be simulated
+    during testing. `chef_zero` and `chef_solo` are the most common
+    provisioners used for testing cookbooks
+
+- `verifier_name` specifies which application to use when running
+    tests, such as `inspec`
+
+- `transport_name` specifies which transport to use when executing
+    commands remotely on the test instance. `winrm` is the default
+    transport on Windows. The `ssh` transport is the default on all
+    other operating systems.
+
+- `platform-version` is the name of a platform on which Test Kitchen
+    will perform cookbook testing, for example, `ubuntu-20.04` or
+    `centos-7`; depending on the platform, additional driver
+    details---for example, instance names and URLs used with cloud
+    platforms like OpenStack or Amazon EC2---may be required
+
+- `platforms` may define Chef Infra Server attributes that are common
+    to the collection of test suites
+
+- `suites` is a collection of test suites, with each `suite_name`
+    grouping defining an aspect of a cookbook to be tested. Each
+    `suite_name` must specify a run-list, for example:
+
+    ```ruby
+    run_list:
+      - recipe[cookbook_name::default]
+      - recipe[cookbook_name::recipe_name]
+    ```
+
+- Each `suite_name` grouping may specify `attributes` as a Hash:
+    `{ foo: "bar" }`
+
+- A `suite_name` grouping may use `excludes` and `includes` to
+    exclude/include one (or more) platforms. For example:
+
+    ```ruby
+    excludes:
+       - platform-version
+       - platform-version       # for additional platforms
+    ```
+
+For example, a simple kitchen.yml file:
+
+```yaml
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-20.04
+  - name: centos-8
+  - name: debian-10
+
+suites:
+  - name: default
+    run_list:
+      - recipe[apache::httpd]
+    excludes:
+      - debian-10
+```
+
+This file uses HashiCorp Vagrant as the driver, which requires no additional
+configuration because it is the default driver used by Test Kitchen,
+chef-zero as the provisioner, and a single (default) test suite that
+runs on Ubuntu 20.04, and CentOS 7.

--- a/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_yml_syntax_proxy.md
+++ b/docs-chef-io/layouts/shortcodes/chef-workstation/test_kitchen_yml_syntax_proxy.md
@@ -1,0 +1,43 @@
+The environment variables `http_proxy`, `https_proxy`, and `ftp_proxy`
+are honored by Test Kitchen for proxies. The client.rb file is read to
+look for proxy configuration settings. If `http_proxy`, `https_proxy`,
+and `ftp_proxy` are specified in the client.rb file, Chef Infra Client
+will configure the `ENV` variable based on these (and related) settings.
+For example:
+
+```ruby
+http_proxy 'http://proxy.example.org:8080'
+http_proxy_user 'myself'
+http_proxy_pass 'Password1'
+```
+
+will be set to:
+
+```ruby
+ENV['http_proxy'] = 'http://myself:Password1@proxy.example.org:8080'
+```
+
+Test Kitchen also supports `http_proxy` and `https_proxy` in the
+`kitchen.yml` file. You can set them manually or have them read from
+your local environment variables:
+
+```yaml
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  # Set proxy settings manually, or
+  http_proxy: 'http://user:password@server:port'
+  https_proxy: 'http://user:password@server:port'
+
+  # Read from local environment variables
+  http_proxy: <%= ENV['http_proxy'] %>
+  https_proxy: <%= ENV['https_proxy'] %>
+```
+
+This will not set the proxy environment variables for applications other
+than Chef. The Vagrant plugin,
+[vagrant-proxyconf](http://tmatilai.github.io/vagrant-proxyconf/), can
+be used to set the proxy environment variables for applications inside
+the VM.


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Move shortcode files from chef-web-docs to chef-workstation.
Delete shortcodes that are only used once and place shortcode text in page.



## Related Issue
https://chefio.atlassian.net/browse/CHEFDOCS-189
https://chefio.atlassian.net/browse/CHEFDOCS-179

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
