### PR TITLE
cached dependencies don't cause issue in workstation build

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -20,9 +20,7 @@ pipelines:
   - verify:
       description: Pull Request validation tests
   - docker/build
-  - omnibus/release:
-      env:
-        - IGNORE_CACHE: true # caching causes constant build failures
+  - omnibus/release
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Due to build issues observed in few other products, the omnibus flag to ignore cache was set to TRUE. this slows down build  time. reverted the change so default value is used.

Successful ad hoc [build](https://buildkite.com/chef/chef-chef-workstation-main-omnibus-adhoc/builds/953) with setting restored to default.

## Related PR
https://github.com/chef/chef-workstation/pull/2460

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
