### PR TITLE
Update rb-fsevent SHA in sync with updated version in Gemfile

### DIFF
--- a/omnibus/config/software/rb-fsevent-gem.rb
+++ b/omnibus/config/software/rb-fsevent-gem.rb
@@ -20,8 +20,8 @@
 
 name "rb-fsevent-gem"
 
-# IMPORTANT: this must be in sync with the components/gems/Gemfile.lock version, currently 0.11.1
-default_version "e46390c4a12d26288e44c42539594e90a7c6fc46"
+# IMPORTANT: this must be in sync with the components/gems/Gemfile.lock version, currently 0.11.2
+default_version "623f64a7edfd2505e64aa2125f01a54ffd6166ba"
 
 source git: "https://github.com/thibaudgg/rb-fsevent.git"
 


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Need to manually update `rb-fsevent` commit hash to match version specified in Gemfile, to avoid notarize error. The `rb-fsevent` version got bumped in https://github.com/chef/chef-workstation/pull/2919

## Related Issue
Related to https://github.com/chef/chef-workstation/pull/2637

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
