### PR TITLE
Removed Ubuntu 16 and added support for Ubuntu 22.04

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -24,10 +24,10 @@ builder-to-testers-map:
   mac_os_x-11-arm64:
     - mac_os_x-11-arm64
     - mac_os_x-12-arm64
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
+    - ubuntu-22.04-x86_64
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/docs-chef-io/content/workstation/install_workstation.md
+++ b/docs-chef-io/content/workstation/install_workstation.md
@@ -51,7 +51,7 @@ Supported Host Operating Systems:
 </tr>
 <tr class="even">
 <td>Ubuntu</td>
-<td>16.04, 18.04, 20.04</td>
+<td>18.04, 20.04, 22.04</td>
 </tr>
 <tr class="odd">
 <td>Debian</td>


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Ubuntu package is presently built on an Ubuntu 16.04 system. This package is usable on Ubuntu 18.04 & 20.04 as well. This pr will remove Ubuntu 16 from the supported platforms and add Ubuntu 22.04. The package has been now built with ubuntu 18.04. 

Adhoc build URL: https://buildkite.com/chef/chef-chef-workstation-main-omnibus-adhoc/builds/1239#018498b7-6660-4567-a7af-8e84a1bed67f
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
