### PR TITLE
Added Rails service stop when uninstalling on Windows

### DIFF
--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -76,16 +76,16 @@
       Execute="deferred"
       Return="ignore" />
 
-    <SetProperty
-      Id="ClearApiServerCommandLine"
-      Sequence="execute"
-      Before="RemoveFiles"
+    <CustomAction Id="ClearApiServerCmd"
+      Property="ClearApiServerCommandLine"
+      Execute="immediate"
       Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"' />
     <CustomAction Id="ClearApiServerCommandLine"
       BinaryKey="WixCA"
       DllEntry="WixQuietExec"
       Execute="deferred"
-      Return="ignore" />
+      Return="ignore"
+      Impersonate="no" />
 
     <!-- Detect if ChefDK is installed - this upgrade GUID is specified in
          chef-dk/omnibus/projects/chef-dk.rb. We don't look for a specific version -
@@ -105,6 +105,7 @@
     <InstallExecuteSequence>
       <Custom Action="TaskKill" After="InstallInitialize">1</Custom>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+      <Custom Action="ClearApiServerCmd" Before="CostInitialize">REMOVE~="ALL"</Custom>
       <Custom Action="ClearApiServerCommandLine" Before="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="SetupApiServerCommandLine" After="FastUnzip">NOT Installed OR REINSTALL</Custom>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -105,7 +105,7 @@
     <InstallExecuteSequence>
       <Custom Action="TaskKill" After="InstallInitialize">1</Custom>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
-      <Custom Action="ClearApiServerCmd" Before="CostInitialize">REMOVE~="ALL"</Custom>
+      <Custom Action="ClearApiServerCmd" After="CostFinalize">REMOVE~="ALL"</Custom>
       <Custom Action="ClearApiServerCommandLine" Before="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="SetupApiServerCommandLine" After="FastUnzip">NOT Installed OR REINSTALL</Custom>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -52,6 +52,13 @@
         DllEntry="WixShellExec"
         Impersonate="yes" />
 
+    <Property Id="WixQuietExecCmdLine" Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"'/>
+    <CustomAction Id="RailsSvc.TaskKill"
+      BinaryKey="WixCA"
+      DllEntry="WixQuietExec"
+      Execute="immediate"
+      Return="ignore"/>
+
     <CustomAction Id="TaskKill"
       BinaryKey="WixCA"
       DllEntry="WixQuietExec"
@@ -72,19 +79,8 @@
       Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\server.ps1"' />
     <CustomAction Id="SetupApiServerCommandLine"
       BinaryKey="WixCA"
-      DllEntry="WixQuietExecCmdLine"
+      DllEntry="WixQuietExec"
       Execute="deferred"
-      Return="ignore" />
-
-    <SetProperty
-      Id="ClearApiServerCommandLine"
-      Sequence="execute"
-      After="InstallInitialize"
-      Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"' />
-    <CustomAction Id="ClearApiServerCommandLine"
-      BinaryKey="WixCA"
-      DllEntry="WixQuietExecCmdLine"
-      Execute="immediate"
       Return="ignore" />
 
     <!-- Detect if ChefDK is installed - this upgrade GUID is specified in
@@ -105,7 +101,7 @@
     <InstallExecuteSequence>
       <Custom Action="TaskKill" After="InstallInitialize">1</Custom>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
-      <Custom Action="ClearApiServerCommandLine" After="InstallInitialize">REMOVE~="ALL"</Custom>
+      <Custom Action="RailsSvc.TaskKill" Before="InstallValidate">REMOVE~="ALL"</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="SetupApiServerCommandLine" After="FastUnzip">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -52,13 +52,6 @@
         DllEntry="WixShellExec"
         Impersonate="yes" />
 
-    <Property Id="WixQuietExecCmdLine" Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"'/>
-    <CustomAction Id="RailsSvc.TaskKill"
-      BinaryKey="WixCA"
-      DllEntry="WixQuietExec"
-      Execute="immediate"
-      Return="ignore"/>
-
     <CustomAction Id="TaskKill"
       BinaryKey="WixCA"
       DllEntry="WixQuietExec"
@@ -79,8 +72,19 @@
       Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\server.ps1"' />
     <CustomAction Id="SetupApiServerCommandLine"
       BinaryKey="WixCA"
-      DllEntry="WixQuietExec"
+      DllEntry="WixQuietExecCmdLine"
       Execute="deferred"
+      Return="ignore" />
+
+    <SetProperty
+      Id="ClearApiServerCommandLine"
+      Sequence="execute"
+      After="InstallInitialize"
+      Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"' />
+    <CustomAction Id="ClearApiServerCommandLine"
+      BinaryKey="WixCA"
+      DllEntry="WixQuietExecCmdLine"
+      Execute="immediate"
       Return="ignore" />
 
     <!-- Detect if ChefDK is installed - this upgrade GUID is specified in
@@ -101,7 +105,7 @@
     <InstallExecuteSequence>
       <Custom Action="TaskKill" After="InstallInitialize">1</Custom>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
-      <Custom Action="RailsSvc.TaskKill" Before="InstallValidate">REMOVE~="ALL"</Custom>
+      <Custom Action="ClearApiServerCommandLine" After="InstallInitialize">REMOVE~="ALL"</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="SetupApiServerCommandLine" After="FastUnzip">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -76,6 +76,17 @@
       Execute="deferred"
       Return="ignore" />
 
+    <SetProperty
+      Id="ClearApiServerCommandLine"
+      Sequence="execute"
+      Before="RemoveFiles"
+      Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"' />
+    <CustomAction Id="ClearApiServerCommandLine"
+      BinaryKey="WixCA"
+      DllEntry="WixQuietExec"
+      Execute="deferred"
+      Return="ignore" />
+
     <!-- Detect if ChefDK is installed - this upgrade GUID is specified in
          chef-dk/omnibus/projects/chef-dk.rb. We don't look for a specific version -
          we are incompatible with *any* DK version
@@ -94,6 +105,7 @@
     <InstallExecuteSequence>
       <Custom Action="TaskKill" After="InstallInitialize">1</Custom>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+      <Custom Action="ClearApiServerCommandLine" Before="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="SetupApiServerCommandLine" After="FastUnzip">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -72,19 +72,19 @@
       Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\server.ps1"' />
     <CustomAction Id="SetupApiServerCommandLine"
       BinaryKey="WixCA"
-      DllEntry="WixQuietExecCmdLine"
+      DllEntry="WixQuietExec"
       Execute="deferred"
       Return="ignore" />
 
     <SetProperty
       Id="ClearApiServerCommandLine"
       Sequence="execute"
-      After="InstallInitialize"
+      Before="RemoveFiles"
       Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"' />
     <CustomAction Id="ClearApiServerCommandLine"
       BinaryKey="WixCA"
-      DllEntry="WixQuietExecCmdLine"
-      Execute="immediate"
+      DllEntry="WixQuietExec"
+      Execute="deferred"
       Return="ignore" />
 
     <!-- Detect if ChefDK is installed - this upgrade GUID is specified in
@@ -105,7 +105,7 @@
     <InstallExecuteSequence>
       <Custom Action="TaskKill" After="InstallInitialize">1</Custom>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
-      <Custom Action="ClearApiServerCommandLine" After="InstallInitialize">REMOVE~="ALL"</Custom>
+      <Custom Action="ClearApiServerCommandLine" Before="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="SetupApiServerCommandLine" After="FastUnzip">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>

--- a/omnibus/resources/chef-workstation/msi/source.wxs.erb
+++ b/omnibus/resources/chef-workstation/msi/source.wxs.erb
@@ -72,19 +72,19 @@
       Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\server.ps1"' />
     <CustomAction Id="SetupApiServerCommandLine"
       BinaryKey="WixCA"
-      DllEntry="WixQuietExec"
+      DllEntry="WixQuietExecCmdLine"
       Execute="deferred"
       Return="ignore" />
 
     <SetProperty
       Id="ClearApiServerCommandLine"
       Sequence="execute"
-      Before="RemoveFiles"
+      After="InstallInitialize"
       Value='"[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -InputFormat None -NoProfile -windowstyle hidden -File "[PROJECTLOCATION]embedded\service\workstation-gui\stopserver.ps1"' />
     <CustomAction Id="ClearApiServerCommandLine"
       BinaryKey="WixCA"
-      DllEntry="WixQuietExec"
-      Execute="deferred"
+      DllEntry="WixQuietExecCmdLine"
+      Execute="immediate"
       Return="ignore" />
 
     <!-- Detect if ChefDK is installed - this upgrade GUID is specified in
@@ -105,7 +105,7 @@
     <InstallExecuteSequence>
       <Custom Action="TaskKill" After="InstallInitialize">1</Custom>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
-      <Custom Action="ClearApiServerCommandLine" Before="RemoveFiles">REMOVE~="ALL"</Custom>
+      <Custom Action="ClearApiServerCommandLine" After="InstallInitialize">REMOVE~="ALL"</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="SetupApiServerCommandLine" After="FastUnzip">NOT Installed OR REINSTALL</Custom>
     </InstallExecuteSequence>

--- a/src/workstation-gui/stopserver.ps1
+++ b/src/workstation-gui/stopserver.ps1
@@ -1,0 +1,14 @@
+# Killing the process that utilises port 7050 during an update can be used to restart the service.
+Write-Output "Trying to kill the existing service"
+$serverProcess = netstat -ano | findstr "PID :7050"
+$activePortPattern = ":7050\s.+LISTENING\s+\d+$"
+$pidNumberPattern = "\d+$"
+
+IF ($serverProcess | Select-String -Pattern $activePortPattern -Quiet) {
+  $matches = $serverProcess | Select-String -Pattern $activePortPattern
+  $firstMatch = $matches.Matches.Get(0).Value
+
+  $pidNumber = [regex]::match($firstMatch, $pidNumberPattern).Value
+  taskkill /pid $pidNumber /f
+  Write-Output "Terminated the service after locating it running on PID:$pidNumber."
+}

--- a/src/workstation-gui/stopserver.ps1
+++ b/src/workstation-gui/stopserver.ps1
@@ -9,6 +9,6 @@ IF ($serverProcess | Select-String -Pattern $activePortPattern -Quiet) {
   $firstMatch = $matches.Matches.Get(0).Value
 
   $pidNumber = [regex]::match($firstMatch, $pidNumberPattern).Value
-  taskkill /pid $pidNumber /f
+  Stop-Process -Id $pidNumber -Force
   Write-Output "Terminated the service after locating it running on PID:$pidNumber."
 }

--- a/src/workstation-gui/stopserver.ps1
+++ b/src/workstation-gui/stopserver.ps1
@@ -9,6 +9,6 @@ IF ($serverProcess | Select-String -Pattern $activePortPattern -Quiet) {
   $firstMatch = $matches.Matches.Get(0).Value
 
   $pidNumber = [regex]::match($firstMatch, $pidNumberPattern).Value
-  Stop-Process -Id $pidNumber -Force
+  taskkill /pid $pidNumber /f
   Write-Output "Terminated the service after locating it running on PID:$pidNumber."
 }


### PR DESCRIPTION
## Description
Added custom action that invokes a script similar to `server.ps1` to kill the Rails server process only on uninstall. Earlier, the uninstall would not be a clean one as files in use by ruby process would not get deleted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
