### PR TITLE
INFWS-175 Tweaks in post-install script

### DIFF
--- a/omnibus/package-scripts/chef-workstation/postinst
+++ b/omnibus/package-scripts/chef-workstation/postinst
@@ -107,7 +107,7 @@ if is_darwin; then
   ditto -x -k -V chef-workstation-app-mac.zip ./
   sudo rm -rf "/Applications/Chef Workstation App.app"
   sudo mv "Chef Workstation App.app" /Applications/
-  mv "/Applications/Chef Workstation App.app/Contents/Resources/assets/scripts/$app_launcher" $INSTALLER_DIR/bin || error_exit "Cannot move $app_launcher to $INSTALLER_DIR/bin"
+  cp "/Applications/Chef Workstation App.app/Contents/Resources/assets/scripts/$app_launcher" $INSTALLER_DIR/bin/. || error_exit "Cannot copy $app_launcher to $INSTALLER_DIR/bin"
   rm -rf "$INSTALLER_DIR/components"
   popd
 

--- a/src/workstation-gui/poststeps.sh
+++ b/src/workstation-gui/poststeps.sh
@@ -5,13 +5,23 @@ chmod -R 777 /opt/chef-workstation/embedded/service/workstation-gui/tmp
 
 chmod -R 777 /opt/chef-workstation/embedded/service/workstation-gui/log
 
+echo "Generating seed secrets"
 bash /opt/chef-workstation/embedded/service/workstation-gui/secrets.sh
+echo $?
+echo "Exit-code of secrets.sh script run"
 
 if [ ! -d "~/Library/LaunchAgents" ]; then
+  echo $HOME
+  echo "Creating LaunchAgents folder"
   mkdir -p "~/Library/LaunchAgents"
+  echo $?
+  echo "Exit-code of LaunchAgents folder creation"
 fi
 
+echo "Copying plist to LaunchAgents"
 cp /opt/chef-workstation/embedded/service/workstation-gui/config/io.chef.chef-workstation.plist ~/Library/LaunchAgents/
+echo $?
+echo "Exit-code of plist copy"
 
 # Unload first, this will help reload the service on further upgrades
 sudo -u $USER launchctl unload ~/Library/LaunchAgents/io.chef.chef-workstation.plist

--- a/src/workstation-gui/poststeps.sh
+++ b/src/workstation-gui/poststeps.sh
@@ -10,20 +10,20 @@ bash /opt/chef-workstation/embedded/service/workstation-gui/secrets.sh
 echo $?
 echo "Exit-code of secrets.sh script run"
 
-if [ ! -d "~/Library/LaunchAgents" ]; then
+if [ ! -d "$HOME/Library/LaunchAgents" ]; then
   echo $HOME
   echo "Creating LaunchAgents folder"
-  mkdir -p "~/Library/LaunchAgents"
+  mkdir -p "$HOME/Library/LaunchAgents"
   echo $?
   echo "Exit-code of LaunchAgents folder creation"
 fi
 
 echo "Copying plist to LaunchAgents"
-cp /opt/chef-workstation/embedded/service/workstation-gui/config/io.chef.chef-workstation.plist ~/Library/LaunchAgents/
+cp /opt/chef-workstation/embedded/service/workstation-gui/config/io.chef.chef-workstation.plist $HOME/Library/LaunchAgents/.
 echo $?
 echo "Exit-code of plist copy"
 
 # Unload first, this will help reload the service on further upgrades
-sudo -u $USER launchctl unload ~/Library/LaunchAgents/io.chef.chef-workstation.plist
+sudo -u $USER launchctl unload $HOME/Library/LaunchAgents/io.chef.chef-workstation.plist
 
-sudo -u $USER launchctl load ~/Library/LaunchAgents/io.chef.chef-workstation.plist
+sudo -u $USER launchctl load $HOME/Library/LaunchAgents/io.chef.chef-workstation.plist

--- a/src/workstation-gui/poststeps.sh
+++ b/src/workstation-gui/poststeps.sh
@@ -6,24 +6,18 @@ chmod -R 777 /opt/chef-workstation/embedded/service/workstation-gui/tmp
 chmod -R 777 /opt/chef-workstation/embedded/service/workstation-gui/log
 
 echo "Generating seed secrets"
-bash /opt/chef-workstation/embedded/service/workstation-gui/secrets.sh
-echo $?
-echo "Exit-code of secrets.sh script run"
+bash /opt/chef-workstation/embedded/service/workstation-gui/secrets.sh || echo "Execution of secrets.sh failed"
 
 if [ ! -d "$HOME/Library/LaunchAgents" ]; then
-  echo $HOME
   echo "Creating LaunchAgents folder"
-  mkdir -p "$HOME/Library/LaunchAgents"
-  echo $?
-  echo "Exit-code of LaunchAgents folder creation"
+  mkdir -p "$HOME/Library/LaunchAgents" || echo "LaunchAgents folder creation failed"
 fi
 
 echo "Copying plist to LaunchAgents"
-cp /opt/chef-workstation/embedded/service/workstation-gui/config/io.chef.chef-workstation.plist $HOME/Library/LaunchAgents/.
-echo $?
-echo "Exit-code of plist copy"
+cp /opt/chef-workstation/embedded/service/workstation-gui/config/io.chef.chef-workstation.plist $HOME/Library/LaunchAgents/. || echo "plist copy to LaunchAgents failed"
 
 # Unload first, this will help reload the service on further upgrades
 sudo -u $USER launchctl unload $HOME/Library/LaunchAgents/io.chef.chef-workstation.plist
 
+echo "Loading agent to start puma service"
 sudo -u $USER launchctl load $HOME/Library/LaunchAgents/io.chef.chef-workstation.plist

--- a/src/workstation-gui/poststeps.sh
+++ b/src/workstation-gui/poststeps.sh
@@ -7,6 +7,10 @@ chmod -R 777 /opt/chef-workstation/embedded/service/workstation-gui/log
 
 bash /opt/chef-workstation/embedded/service/workstation-gui/secrets.sh
 
+if [ ! -d "~/Library/LaunchAgents" ]; then
+  mkdir -p "~/Library/LaunchAgents"
+fi
+
 cp /opt/chef-workstation/embedded/service/workstation-gui/config/io.chef.chef-workstation.plist ~/Library/LaunchAgents/
 
 # Unload first, this will help reload the service on further upgrades


### PR DESCRIPTION
## Description
Few cases covered in macOS install-
1. Create `~/Library/LaunchAgents` folder if not already present.
1. Use `$HOME` instead of `~` in filepaths.
1. Keep Chef Workstation App intact post-install so codesign check succeeds in Ventura.

## Related Issue
https://github.com/chef/chef-workstation/issues/3019
https://github.com/chef/chef-workstation/issues/3021

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
