### PR TITLE
Revert documentation note #2954

### DIFF
--- a/docs-chef-io/content/workstation/chef-workstation-app.md
+++ b/docs-chef-io/content/workstation/chef-workstation-app.md
@@ -14,7 +14,6 @@ gh_repo = "chef-workstation"
 
 The Chef Workstation App (CWA) is an early release desktop application that provides additional services for Chef Workstation:
 
-* Run cookbook actions in local repositories
 * Update checking and notifications
 * Chef Workstation version information
 
@@ -38,30 +37,6 @@ Start Chef Workstation App by running the command `chef-workstation-app`.
 ### Mac
 
 Start `Chef Workstation App` from your Applications folder.
-
-## Chef Workstation App Dashboard
-
-The Chef Workstation App dashboard lets you manage Cookbooks and Chef repositories. Open the Chef Workstation App dashboard by selecting **Manage Cookbooks** from the Chef Workstation App menu in the menu bar (macOS) or taskbar (Windows).
-
-### Chef Repositories
-
-Select **Chef Repositories** to view Chef repositories and cookbooks on your local workstation.
-
-To add a new Chef repository and its cookbooks, select **Add New** and then navigate to a Chef repository in your workstation's file system.
-
-The linked Chef repositories are persistent, so you only need to add them once in the dashboard. The repository name displayed in the dashboard is the same as the Chef repository folder name.
-
-### Cookbooks
-
-Use the **Cookbooks** panel to upload cookbooks to a configured Chef Infra Server.
-
-To upload a cookbook, select **Upload** next to the corresponding cookbook.
-
-{{< note >}}
-
-There is a known limitation where the profile settings in `~/.chef/credentials` are not parsed correctly, causing a request signing error to show up when you upload a cookbook. To overcome this issue, copy your knife `config.rb` to `~/.chef`.
-
-{{< /note >}}
 
 ## Disabling Automatic Update Checks
 


### PR DESCRIPTION
This reverts commit c3856390ccb36bef0e04a6ffaf6733d420aec1e3.

## Description
We removed the experimental feature in the most recent build 23.3.1030. Updating doc to remove note on same.

## Related Issue
https://github.com/chef/chef-workstation-app/pull/745

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
