### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # Run the entire container with the default locale to be en_US.UTF-8
 RUN apt-get update && \
-    apt-get install -y locales && \
+    apt-get install -y locales=2.35-* && \ 
     locale-gen en_US.UTF-8 && \
     update-locale LANG=en_US.UTF-8 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -19,7 +19,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y gcc git graphviz make rsync ssh vim-tiny wget && \
+    apt-get install -y gcc=4:11.2.* git=1:2.34.* graphviz=2.42.* make=4.3-* rsync=3.2.* ssh=1:8.9p1-* vim-tiny=2:8.2.* wget=1.21.* && \ 
     ln -s /usr/bin/vi /usr/bin/vim && \
     wget --content-disposition "http://packages.chef.io/files/${CHANNEL}/chef-workstation/${VERSION}/ubuntu/18.04/chef-workstation_${VERSION}-1_amd64.deb" -O /tmp/chef-workstation.deb && \
     dpkg -i /tmp/chef-workstation.deb && \


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved using the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
