### PR TITLE
Update chef-cli version

### DIFF
--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
       tty-spinner
     chef-bin (18.2.7)
       chef (= 18.2.7)
-    chef-cli (5.6.8)
+    chef-cli (5.6.11)
       addressable (>= 2.3.5, < 2.9)
       chef (>= 16.0)
       cookbook-omnifetch (~> 0.5)


### PR DESCRIPTION
## Description
The updated chef-cli gem has fix to the template creation warning.

## Related Issue
https://github.com/chef/chef-cli/issues/219

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
