### PR TITLE
Updated condition for windows specific gems

### DIFF
--- a/components/gems/Gemfile
+++ b/components/gems/Gemfile
@@ -128,7 +128,7 @@ end
 gem "chefstyle", group: :test
 
 # Ensure support for push-client on Windows
-platforms :mswin, :mswin64, :mingw, :x64_mingw do
+if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
   gem "rdp-ruby-wmi"
   gem "windows-pr"
   gem "win32-api"


### PR DESCRIPTION
## Description

Added the RUBY_PLATFORM method to identify different windows platforms and installed these windows specific gems.
This will install the win32-security gem which was missing in installer in the latest chef-workstation version

## Related Issue
https://chefio.atlassian.net/browse/CHEF-4143

