### PR TITLE
Fixed the - Chef Workstation Errors When Running from D Drive - "exec... file does not exist"

### DIFF
--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -83,7 +83,8 @@ func createRubyEnvUnix() {
 }
 
 func createRubyEnvWindows() {
-	InstallerDir := `D:\opscode\chef-workstation`
+	InstallerDir := platform_lib.WorkstationInfo().InstallDirectory
+	fmt.Println("-------InstallerDir---------", InstallerDir)
 	home, err := os.UserHomeDir()
 	installationPath := path.Join(home, `.chef\ruby-env.json`)
 	result, err := exists(installationPath)

--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -84,7 +84,6 @@ func createRubyEnvUnix() {
 
 func createRubyEnvWindows() {
 	InstallerDir := platform_lib.WorkstationInfo().InstallDirectory
-	fmt.Println("-------InstallerDir---------", InstallerDir)
 	home, err := os.UserHomeDir()
 	installationPath := path.Join(home, `.chef\ruby-env.json`)
 	result, err := exists(installationPath)

--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -83,7 +83,7 @@ func createRubyEnvUnix() {
 }
 
 func createRubyEnvWindows() {
-	InstallerDir := `C:\opscode\chef-workstation`
+	InstallerDir := `D:\opscode\chef-workstation`
 	home, err := os.UserHomeDir()
 	installationPath := path.Join(home, `.chef\ruby-env.json`)
 	result, err := exists(installationPath)


### PR DESCRIPTION

## Description
Updated the hardcoded path of  InstallerDir from `C:\opscode\chef-workstation` to fetch the actual InstallDirectory of the chef-workstation installation path across all platforms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
