### PR TITLE
Updated the ruby image to overcome the thread error

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -14,7 +14,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.1
+        image: ruby:3.1-bullseye
 # This tests that our verify.rb script (and dependencies) can successfully test components included in CW
 - label: component-test-tests-ruby-3.1
   command:
@@ -22,7 +22,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.1
+        image: ruby:3.1-bullseye
 - label: ":linux: :darwin: :windows: top-level chef cmd"
   commands:
     - cd components/main-chef-wrapper


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Updating the ruby image to ruby:3.1-bullseye to overcome the thread error on verify pipelines. 

Ref: https://github.com/docker-library/golang/issues/467#issuecomment-1601845758
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
