### PR TITLE
Bump kitchen-dokken to 2.20.6

### DIFF
--- a/components/gems/Gemfile.lock
+++ b/components/gems/Gemfile.lock
@@ -696,7 +696,7 @@ GEM
     kitchen-digitalocean (0.16.0)
       droplet_kit (>= 3.7, < 4.0)
       test-kitchen (>= 1.17, < 4)
-    kitchen-dokken (2.20.4)
+    kitchen-dokken (2.20.6)
       docker-api (>= 1.33, < 3)
       lockfile (~> 2.1)
       test-kitchen (>= 1.15, < 4)


### PR DESCRIPTION
Because of Centos 7 EOL all workflows are broken: https://github.com/test-kitchen/kitchen-dokken/compare/v2.20.5...v2.20.6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
