### PR TITLE
reverting this change due to chef oss limitations with secrets

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -18,7 +18,6 @@ changelog:
 
 pipelines:
   - verify:
-      public: true
       description: Pull Request validation tests
   - docker/build
   - omnibus/release:


### PR DESCRIPTION
reverting: https://github.com/chef/chef-workstation/pull/3311 

build error:

```
/usr/local/bundle/gems/vault-0.16.0/lib/vault/client.rb:303:in `rescue in request': The Vault server at `https://vault.ps.chef.co' is not currently (Vault::HTTPConnectionError)
```

will need a workaround if we need this public. 