### PR TITLE
CHEF-20210 : Verified builds on both x86_64 and arm64 macOS 

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -23,11 +23,9 @@ builder-to-testers-map:
     - el-8-x86_64
   el-9-x86_64:
     - el-9-x86_64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64

--- a/omnibus/config/projects/chef-workstation.rb
+++ b/omnibus/config/projects/chef-workstation.rb
@@ -52,6 +52,10 @@ dependency "preparation"
 # TODO: unless check should be removed once hab package is available in linux aarch64
 dependency "habitat" unless RUBY_PLATFORM =~ /aarch64-linux/
 dependency "openssl"
+if mac_os_x?
+  dependency "autoconf"
+  dependency "gecode"
+end
 
 if windows?
   dependency "git-windows"


### PR DESCRIPTION

* Add Macos 12 arm and X86-64 support
The Chef Workstation build for macOS 12   fails due to a critical error in the dep-selector-libgecode gem during compilation. Hence autoconf (2.69) and gecode (3.7.3)   added for mac platform.

Gecode 3.7.3’s build system is incompatible with autoconf ≥2.72.

Error: 

configure: error: cannot find required auxiliary files: config.guess config.sub
  | make: *** [Makefile:1457: config.status] Error 1
  | extconf.rb:124:in `block in run': Failed to build gecode library.
  | (GecodeBuild::BuildError)
  | from extconf.rb:123:in `chdir'
  | from extconf.rb:123:in `run'
  | from extconf.rb:130:in `<main>'
  |  
  | extconf failed, exit code 1

- Introduced conditional dependencies: autoconf and gecode for macOS
Log: https://buildkite.com/chef/chef-chef-workstation-main-omnibus-adhoc/builds/1964
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
