### PR TITLE
update Mac builder matrix to resolve notarization step failure

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -27,7 +27,6 @@ builder-to-testers-map:
     - mac_os_x-12-x86_64
   mac_os_x-12-arm64:
     - mac_os_x-12-arm64
-  mac_os_x-13-arm64:
     - mac_os_x-13-arm64
     - mac_os_x-14-arm64
   ubuntu-18.04-x86_64:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This PR updates the builder matrix to ensure that:

- The build is always performed on macOS 12 (arm64) for compatibility with the notarization process.

- Tests continue to run on macOS 12, 13, and 14 (arm64) to ensure broad compatibility.



## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
