### PR TITLE
CHEF-25762 - standardize - remove_sla_from_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Chef Workstation
 
 
-**Umbrella Project**: [Chef Workstation](https://github.com/chef/chef-oss-practices/blob/main/projects/chef-workstation.md)
-
 Chef Workstation installs everything you need to get started using Chef products on Windows, Mac and Linux. It includes:
 
 * Chef Workstation App

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 
 **Umbrella Project**: [Chef Workstation](https://github.com/chef/chef-oss-practices/blob/main/projects/chef-workstation.md)
 
-* **[Project State](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md):** Active
-* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md):** 14 days
-* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md):** 14 days
-
 Chef Workstation installs everything you need to get started using Chef products on Windows, Mac and Linux. It includes:
 
 * Chef Workstation App


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).