### PR TITLE
Fix Windows build for git-sourced gems

### DIFF
--- a/components/gems/post-bundle-install.rb
+++ b/components/gems/post-bundle-install.rb
@@ -8,11 +8,20 @@ puts "fixing bundle installed gems in #{gem_home}"
 # you can simply gem build + gem install the resulting gem, so nothing fancy.  This does not use
 # rake install since we need --conservative --minimal-deps in order to not install duplicate gems.
 #
-Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
+bundler_gems_path = File.join(gem_home, "bundler", "gems", "*")
+puts "Looking for git gems in: #{bundler_gems_path}"
+
+Dir[bundler_gems_path].each do |gempath|
+  puts "Found gem path: #{gempath}"
   matches = File.basename(gempath).match(/.*-[A-Fa-f0-9]{12}/)
   next unless matches
 
-  gem_name = File.basename(Dir["#{gempath}/*.gemspec"].first, ".gemspec")
+  gemspec_files = Dir[File.join(gempath, "*.gemspec")]
+  puts "Found gemspec files: #{gemspec_files.inspect}"
+
+  next if gemspec_files.empty?
+
+  gem_name = File.basename(gemspec_files.first, ".gemspec")
   # FIXME: should strip any valid ruby platform off of the gem_name if it matches
 
   next unless gem_name
@@ -20,11 +29,27 @@ Dir["#{gem_home}/bundler/gems/*"].each do |gempath|
   puts "re-installing #{gem_name}..."
 
   Dir.chdir(gempath) do
-    system("gem build #{gem_name}.gemspec") or raise "gem build failed"
-    system("gem install #{gem_name}*.gem --conservative --minimal-deps --no-document") or raise "gem install failed"
+    # Use full path to gem command for Windows compatibility
+    gem_cmd = File.join(RbConfig::CONFIG["bindir"], "gem")
+
+    build_cmd = "\"#{gem_cmd}\" build #{gem_name}.gemspec"
+    puts "Running: #{build_cmd}"
+    system(build_cmd) or raise "gem build failed for #{gem_name}"
+
+    install_cmd = "\"#{gem_cmd}\" install #{gem_name}*.gem --conservative --minimal-deps --no-document"
+    puts "Running: #{install_cmd}"
+    system(install_cmd) or raise "gem install failed for #{gem_name}"
   end
 
-  puts "#{gem_name} re-installed successfully"
+  # Verify the gem was installed using the correct gem command (not PATH's gem)
+  gem_cmd = File.join(RbConfig::CONFIG["bindir"], "gem")
+  puts "Verifying #{gem_name} installation..."
+  installed_gems = `"#{gem_cmd}" list #{gem_name}`.chomp
+  if installed_gems.include?(gem_name)
+    puts "#{gem_name} installed successfully: #{installed_gems}"
+  else
+    raise "#{gem_name} installation verification failed!"
+  end
 end
 
 # Handle default gem conflicts with bundled gems

--- a/components/gems/post-bundle-install.rb
+++ b/components/gems/post-bundle-install.rb
@@ -34,11 +34,11 @@ Dir[bundler_gems_path].each do |gempath|
 
     build_cmd = "\"#{gem_cmd}\" build #{gem_name}.gemspec"
     puts "Running: #{build_cmd}"
-    raise RuntimeError, "gem build failed for #{gem_name}" unless system(build_cmd)
+    raise "gem build failed for #{gem_name}" unless system(build_cmd)
 
     install_cmd = "\"#{gem_cmd}\" install #{gem_name}*.gem --conservative --minimal-deps --no-document"
     puts "Running: #{install_cmd}"
-    raise RuntimeError, "gem install failed for #{gem_name}" unless system(install_cmd)
+    raise "gem install failed for #{gem_name}" unless system(install_cmd)
   end
 
   # Verify the gem was installed using the correct gem command (not PATH's gem)
@@ -49,7 +49,7 @@ Dir[bundler_gems_path].each do |gempath|
   if installed_gems.include?(gem_name)
     puts "#{gem_name} installed successfully: #{installed_gems}"
   else
-    raise RuntimeError, "#{gem_name} installation verification failed!"
+    raise "#{gem_name} installation verification failed!"
   end
 end
 

--- a/components/gems/post-bundle-install.rb
+++ b/components/gems/post-bundle-install.rb
@@ -34,21 +34,22 @@ Dir[bundler_gems_path].each do |gempath|
 
     build_cmd = "\"#{gem_cmd}\" build #{gem_name}.gemspec"
     puts "Running: #{build_cmd}"
-    system(build_cmd) or raise "gem build failed for #{gem_name}"
+    raise RuntimeError, "gem build failed for #{gem_name}" unless system(build_cmd)
 
     install_cmd = "\"#{gem_cmd}\" install #{gem_name}*.gem --conservative --minimal-deps --no-document"
     puts "Running: #{install_cmd}"
-    system(install_cmd) or raise "gem install failed for #{gem_name}"
+    raise RuntimeError, "gem install failed for #{gem_name}" unless system(install_cmd)
   end
 
   # Verify the gem was installed using the correct gem command (not PATH's gem)
   gem_cmd = File.join(RbConfig::CONFIG["bindir"], "gem")
   puts "Verifying #{gem_name} installation..."
-  installed_gems = `"#{gem_cmd}" list #{gem_name}`.chomp
+  # Use --exact to match only the specific gem name (avoids 'chef' matching 'chef-utils')
+  installed_gems = `"#{gem_cmd}" list --exact #{gem_name}`.chomp
   if installed_gems.include?(gem_name)
     puts "#{gem_name} installed successfully: #{installed_gems}"
   else
-    raise "#{gem_name} installation verification failed!"
+    raise RuntimeError, "#{gem_name} installation verification failed!"
   end
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Fixes Windows omnibus build failure when using git-sourced gems. This enables kitchen-dokken to be pulled from GitHub on all platforms including Windows.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
