### PR TITLE
Removed the github token setting on expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,7 +26,6 @@ pipelines:
   - omnibus/release:
       env:
         - IGNORE_ARTIFACTORY_RUBY_PROXY: true # Artifactory is throwing 500's when downloading some gems like ffi.
-        - BUNDLE_GITHUB__COM: "x-access-token:$GITHUB_TOKEN"
         - EXPIRE_CACHE: true
         - IGNORE_CACHE: true
   - omnibus/adhoc:
@@ -36,14 +35,12 @@ pipelines:
         - IGNORE_ARTIFACTORY_RUBY_PROXY: true
         - EXPIRE_CACHE: true
         - IGNORE_CACHE: true
-        - BUNDLE_GITHUB__COM: "x-access-token:$GITHUB_TOKEN"
   - omnibus/adhoc-canary:
       canary: true
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_ARTIFACTORY_RUBY_PROXY: true
-        - BUNDLE_GITHUB__COM: "x-access-token:$GITHUB_TOKEN"
   - third-party-packages:
       description: post-release publishing of Workstation packages to third party distribution platforms
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The Release pipeline is failing now with a missing GitHub token error. We don't have to explicitly set the token in the expeditor config; this is handled by the omnibus plugin. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
