### PR TITLE
Test PR for verifying trufflehog

### DIFF
--- a/.github/trufflehog-canary.env
+++ b/.github/trufflehog-canary.env
@@ -1,0 +1,6 @@
+# Intentionally fake canary credentials for verifying TruffleHog enforcement in PR CI.
+# Expected behavior: the TruffleHog job should flag these as unverified secrets in
+# the pull request diff. These values are shaped like real tokens, but are not live
+# credentials and are only used to exercise secret scanning in CI.
+GITHUB_TOKEN=ghp_7Yh3mK9pQ2vL8nR4xT6cW1bN5dF0jH2sP4qR
+GITHUB_APP_TOKEN=ghs_4Pm8tQ2nV7xL1cR5wK9bD3fH6jN0sY4pT8mW


### PR DESCRIPTION
<h2>Summary</h2>
<p>This is a test PR to verify that the TruffleHog secret scanning is correctly configured and working in the chef-workstation CI pipeline.</p>

<h2>Changes Made</h2>
<ul>
<li>Added <code>.github/trufflehog-canary.env</code> with intentionally fake canary credentials shaped like real GitHub tokens.</li>
</ul>

<h2>Expected Behavior</h2>
<p>The TruffleHog CI job should flag the fake credentials as <code>Found unverified Github result 🐷🔑</code>, confirming secret scanning is active.</p>

<blockquote><strong>⚠️ Do not merge this PR.</strong> It is only for testing TruffleHog configuration. See <a href='https://github.com/inspec/inspec/pull/7809'>inspec/inspec#7809</a> for reference.</blockquote>