### PR TITLE
Copilot Track - Crawl: 2 Build/Test Confidence and Deterministic Test

### DIFF
--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -1,41 +1,46 @@
 # Build & Test Reference
 
-> Placeholder – update as you verify commands during the AI track exercises.
+This file documents commands verified during Crawl Exercise 1 and is intended to be copy/paste repeatable from the repository root.
 
 ## Prerequisites
 
-<!-- Go version, Ruby version, Habitat, Docker, etc. -->
-
-## Building
-
 ```sh
-# Go components (example)
-cd components/main-chef-wrapper && go build ./...
-cd components/chef-automate-collect && go build ./...
+# macOS: install Go if missing
+command -v go >/dev/null || brew install go
+
+# confirm toolchain
+go version
 ```
 
-## Running Tests
+## Build Commands
 
 ```sh
-# Go unit tests
-go test ./...
-
-# Ruby / Rake
-bundle exec rake
+# from repo root
+cd components/chef-automate-collect
+go build ./...
 ```
 
-## Linting / Static Analysis
+## Deterministic Unit Test (Chosen Module)
+
+Target module: `components/chef-automate-collect/commands/environment_variables.go`
 
 ```sh
-# Go
-go vet ./...
-
-# Spell check
-cspell "**/*.{go,rb,md}"
+# from repo root
+cd components/chef-automate-collect
+go test ./commands -run TestEnvironmentVariableConstantsStable -count=1 -v
 ```
 
-## CI / Release
+Expected result: `PASS` with exit code `0`.
 
-- Habitat plan: `habitat/plan.sh`
-- Omnibus packaging: `omnibus/`
-- See [RELEASE_PROCESS.md](../RELEASE_PROCESS.md) for the release workflow.
+## Optional Wider Test Sweep
+
+```sh
+# from repo root
+cd components/chef-automate-collect
+go test ./... -count=1
+```
+
+## Notes
+
+- The deterministic test validates env var constants and checks for accidental duplicate values.
+- This gives a low-risk guardrail for the selected reusable module before changing config behavior elsewhere.

--- a/components/chef-automate-collect/commands/environment_variables_test.go
+++ b/components/chef-automate-collect/commands/environment_variables_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import "testing"
+
+func TestEnvironmentVariableConstantsStable(t *testing.T) {
+	tests := map[string]string{
+		"AutomateURLEnvVar":             AutomateURLEnvVar,
+		"AutomateTokenEnvVar":           AutomateTokenEnvVar,
+		"AutomateInsecureTLSEnvVar":     AutomateInsecureTLSEnvVar,
+		"RepoConfigDirPathEnvVar":       RepoConfigDirPathEnvVar,
+		"UserConfigDirPathEnvVar":       UserConfigDirPathEnvVar,
+		"SystemConfigDirPathEnvVar":     SystemConfigDirPathEnvVar,
+		"NoRepoConfigEnvVar":            NoRepoConfigEnvVar,
+		"NoUserConfigEnvVar":            NoUserConfigEnvVar,
+		"NoSystemConfigEnvVar":          NoSystemConfigEnvVar,
+		"DisableReportNewRolloutEnvVar": DisableReportNewRolloutEnvVar,
+		"GitRemoteNameEnvVar":           GitRemoteNameEnvVar,
+	}
+
+	expected := map[string]string{
+		"AutomateURLEnvVar":             "CHEF_AC_AUTOMATE_URL",
+		"AutomateTokenEnvVar":           "CHEF_AC_AUTOMATE_TOKEN",
+		"AutomateInsecureTLSEnvVar":     "CHEF_AC_AUTOMATE_INSECURE_TLS",
+		"RepoConfigDirPathEnvVar":       "CHEF_AC_REPO_CONFIG_DIR",
+		"UserConfigDirPathEnvVar":       "CHEF_AC_USER_CONFIG_DIR",
+		"SystemConfigDirPathEnvVar":     "CHEF_AC_SYSTEM_CONFIG_DIR",
+		"NoRepoConfigEnvVar":            "CHEF_AC_NO_REPO_CONFIG",
+		"NoUserConfigEnvVar":            "CHEF_AC_NO_USER_CONFIG",
+		"NoSystemConfigEnvVar":          "CHEF_AC_NO_SYSTEM_CONFIG",
+		"DisableReportNewRolloutEnvVar": "CHEF_AC_DISABLE_COLLECTOR",
+		"GitRemoteNameEnvVar":           "CHEF_AC_GIT_REMOTE_NAME",
+	}
+
+	for name, got := range tests {
+		if got != expected[name] {
+			t.Fatalf("%s: got %q, want %q", name, got, expected[name])
+		}
+	}
+
+	seen := map[string]string{}
+	for name, got := range tests {
+		if prev, exists := seen[got]; exists {
+			t.Fatalf("duplicate env var value %q used by %s and %s", got, prev, name)
+		}
+		seen[got] = name
+	}
+}


### PR DESCRIPTION
Summary
- Updated build/test reference with repeatable local commands for Exercise 2.
- Added one deterministic unit test for the chosen low-risk module constants contract.
- Files/paths touched: ai-track-docs/build-test.md, components/chef-automate-collect/commands/environment_variables_test.go.

Test & Risk
- Build command (from repo root):
  - cd components/chef-automate-collect && go build ./...
  - Result: exit code 0
- Deterministic unit test command (from repo root):
  - cd components/chef-automate-collect && go test ./commands -run TestEnvironmentVariableConstantsStable -count=1 -v
  - Output:
    - === RUN   TestEnvironmentVariableConstantsStable
    - --- PASS: TestEnvironmentVariableConstantsStable (0.00s)
    - PASS
    - ok github.com/chef/chef-workstation/components/chef-automate-collect/commands 0.508s
- Risk: low (docs + constants validation test only).
- Rollback: git revert 7eef71bb

Track
- Level: crawl
- Exercise: 2-build-test-confidence
- Evidence: ai-track-docs/build-test.md, components/chef-automate-collect/commands/environment_variables_test.go
