### PR TITLE
Copilot Track - Crawl: 5 Minimal Validation and Negative Test

### DIFF
--- a/components/chef-automate-collect/commands/metadata_collectors.go
+++ b/components/chef-automate-collect/commands/metadata_collectors.go
@@ -89,6 +89,23 @@ func newSCMMetadata(policyLockPath string) SCMMetadata {
 	}
 }
 
+func gitRemoteNameFromEnv(lookupEnv func(string) (string, bool)) string {
+	gitRemoteName := "origin"
+
+	if value, envVarSet := lookupEnv(GitRemoteNameEnvVar); envVarSet {
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedValue == "" {
+			cliIO.verbose("Found environment %s=%q, ignoring empty value and using default git remote %q", GitRemoteNameEnvVar, value, gitRemoteName)
+			return gitRemoteName
+		}
+
+		cliIO.verbose("Found environment %s=%q, using this value to detect git URL", GitRemoteNameEnvVar, trimmedValue)
+		return trimmedValue
+	}
+
+	return gitRemoteName
+}
+
 func (s *SCMMetadata) ReadGitMetadata() error {
 	gitDir := fpath.Dir(s.policyLockPath)
 
@@ -157,12 +174,7 @@ func (s *SCMMetadata) ReadGitMetadata() error {
 	s.SCMAuthorName = strings.Trim(commiterNameOut, "\n")
 	s.SCMAuthorEmail = strings.Trim(commiterEmailOut, "\n")
 
-	gitRemoteName := "origin"
-
-	if value, envVarSet := os.LookupEnv(GitRemoteNameEnvVar); envVarSet {
-		cliIO.verbose("Found environment %s=%q, using this value to detect git URL", GitRemoteNameEnvVar, value)
-		gitRemoteName = value
-	}
+	gitRemoteName := gitRemoteNameFromEnv(os.LookupEnv)
 	// get the URL of the remote
 	//   git ls-remote --get-url $origin
 	originURLOut, err := c.Output("git", g("ls-remote", "--get-url", gitRemoteName))

--- a/components/chef-automate-collect/commands/metadata_collectors_test.go
+++ b/components/chef-automate-collect/commands/metadata_collectors_test.go
@@ -1,0 +1,33 @@
+package commands
+
+import "testing"
+
+func TestGitRemoteNameFromEnvDefaultsToOriginWhenUnset(t *testing.T) {
+	got := gitRemoteNameFromEnv(func(string) (string, bool) {
+		return "", false
+	})
+
+	if got != "origin" {
+		t.Fatalf("got %q, want %q", got, "origin")
+	}
+}
+
+func TestGitRemoteNameFromEnvIgnoresEmptyValue(t *testing.T) {
+	got := gitRemoteNameFromEnv(func(string) (string, bool) {
+		return "   ", true
+	})
+
+	if got != "origin" {
+		t.Fatalf("got %q, want %q", got, "origin")
+	}
+}
+
+func TestGitRemoteNameFromEnvUsesTrimmedValue(t *testing.T) {
+	got := gitRemoteNameFromEnv(func(string) (string, bool) {
+		return " upstream ", true
+	})
+
+	if got != "upstream" {
+		t.Fatalf("got %q, want %q", got, "upstream")
+	}
+}


### PR DESCRIPTION
Summary
- Added minimal validation at the `CHEF_AC_GIT_REMOTE_NAME` boundary so empty or whitespace-only values no longer override the safe default remote name.
- Added focused unit tests, including a negative test proving invalid input falls back to `origin`.
- Files/paths touched: components/chef-automate-collect/commands/metadata_collectors.go, components/chef-automate-collect/commands/metadata_collectors_test.go.

Test & Risk
- Focused test command (from repo root):
  - cd components/chef-automate-collect && go test ./commands -run 'TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
  - Output:
    - === RUN   TestEnvironmentVariableConstantsStable
    - --- PASS: TestEnvironmentVariableConstantsStable (0.00s)
    - === RUN   TestGitRemoteNameFromEnvDefaultsToOriginWhenUnset
    - --- PASS: TestGitRemoteNameFromEnvDefaultsToOriginWhenUnset (0.00s)
    - === RUN   TestGitRemoteNameFromEnvIgnoresEmptyValue
    - --- PASS: TestGitRemoteNameFromEnvIgnoresEmptyValue (0.00s)
    - === RUN   TestGitRemoteNameFromEnvUsesTrimmedValue
    - --- PASS: TestGitRemoteNameFromEnvUsesTrimmedValue (0.00s)
    - PASS
    - ok github.com/chef/chef-workstation/components/chef-automate-collect/commands 0.589s
- Build command (from repo root):
  - cd components/chef-automate-collect && go build ./...
  - Result: success (no build errors)
- Risk: low (invalid env input now falls back to existing default behavior instead of overriding it).
- Rollback: git revert 260f9db5

Track
- Level: crawl
- Exercise: 5-minimal-validation-negative-test
- Evidence: components/chef-automate-collect/commands/metadata_collectors.go, components/chef-automate-collect/commands/metadata_collectors_test.go
