### PR TITLE
Copilot Track - Crawl: 6 Performance Baseline for Git Remote Helper

### DIFF
--- a/ai-track-docs/perf-baseline.md
+++ b/ai-track-docs/perf-baseline.md
@@ -1,0 +1,40 @@
+# Performance Baseline
+
+## Module
+
+`components/chef-automate-collect/commands/metadata_collectors.go`
+
+## Function
+
+`gitRemoteNameFromEnv`
+
+## Command
+
+Run from the repository root:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run 'TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -bench BenchmarkGitRemoteNameFromEnv -benchmem -count=5
+```
+
+## Environment
+
+- `goos: darwin`
+- `goarch: arm64`
+- `cpu: Apple M4 Pro`
+
+## Baseline Results
+
+Five benchmark runs were recorded for each sub-case.
+
+| Case | Observed range | Allocations |
+|------|----------------|-------------|
+| `unset` | `1.692 ns/op` to `1.732 ns/op` | `0 B/op`, `0 allocs/op` |
+| `whitespace` | `13.31 ns/op` to `13.75 ns/op` | `16 B/op`, `1 allocs/op` |
+| `trimmed_value` | `13.30 ns/op` to `13.62 ns/op` | `16 B/op`, `1 allocs/op` |
+
+## Variance Notes
+
+- The `unset` path is effectively allocation-free and stayed within roughly 2.4% across five runs.
+- The whitespace and trimmed-value paths stayed within roughly 3.3% and 2.4% respectively across five runs.
+- This is a measurement baseline only; no optimization target is implied by these numbers.

--- a/components/chef-automate-collect/commands/metadata_collectors_test.go
+++ b/components/chef-automate-collect/commands/metadata_collectors_test.go
@@ -31,3 +31,37 @@ func TestGitRemoteNameFromEnvUsesTrimmedValue(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, "upstream")
 	}
 }
+
+func BenchmarkGitRemoteNameFromEnv(b *testing.B) {
+	benchmarks := []struct {
+		name   string
+		lookup func(string) (string, bool)
+	}{
+		{
+			name: "unset",
+			lookup: func(string) (string, bool) {
+				return "", false
+			},
+		},
+		{
+			name: "whitespace",
+			lookup: func(string) (string, bool) {
+				return "   ", true
+			},
+		},
+		{
+			name: "trimmed_value",
+			lookup: func(string) (string, bool) {
+				return " upstream ", true
+			},
+		},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			for b.Loop() {
+				_ = gitRemoteNameFromEnv(benchmark.lookup)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary
- Added a micro-benchmark for `gitRemoteNameFromEnv` to establish a repeatable baseline before any optimization work.
- Recorded baseline timing results and variance notes in `ai-track-docs/perf-baseline.md`.
- Files/paths touched: components/chef-automate-collect/commands/metadata_collectors_test.go, ai-track-docs/perf-baseline.md.

Test & Risk
- Benchmark command (from repo root):
  - cd components/chef-automate-collect && go test ./commands -run 'TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -bench BenchmarkGitRemoteNameFromEnv -benchmem -count=5
- Baseline results:
  - `unset`: `1.692 ns/op` to `1.732 ns/op`, `0 B/op`, `0 allocs/op`
  - `whitespace`: `13.31 ns/op` to `13.75 ns/op`, `16 B/op`, `1 allocs/op`
  - `trimmed_value`: `13.30 ns/op` to `13.62 ns/op`, `16 B/op`, `1 allocs/op`
- Variance notes:
  - `unset` stayed within roughly 2.4% across five runs.
  - `whitespace` stayed within roughly 3.3% across five runs.
  - `trimmed_value` stayed within roughly 2.4% across five runs.
- Risk: low (benchmark + documentation only; no runtime behavior changes).
- Rollback: git revert 94cd2911

Track
- Level: crawl
- Exercise: 6-performance-baseline
- Evidence: ai-track-docs/perf-baseline.md, components/chef-automate-collect/commands/metadata_collectors_test.go
