### PR TITLE
Copilot Track - Crawl: 8 Security and Secrets Hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,18 @@ tags
 Gemfile.lock
 */vendor/*
 
+# local secrets and credentials
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+.netrc
+secrets.yml
+secrets.local.yml
+
 # vi
 *.swp
 

--- a/ai-track-docs/security-secrets.md
+++ b/ai-track-docs/security-secrets.md
@@ -1,0 +1,48 @@
+# Security and Secrets Hygiene
+
+## Scope
+
+This note covers local secret-handling hygiene for the current crawl-track slice, especially `chef-automate-collect` configuration and developer-created secret files.
+
+## Current Improvement
+
+The `chef-automate-collect` config loader no longer emits the raw `CHEF_AC_AUTOMATE_TOKEN` value in verbose logs.
+
+- Before: verbose logging printed the token value directly.
+- After: verbose logging prints `[REDACTED]` for non-empty token values.
+
+This reduces the chance of leaking credentials into terminal logs, CI logs, or copied troubleshooting output.
+
+## Ignore Rules Added
+
+The repository `.gitignore` now ignores common local secret artifacts:
+
+- `.env`
+- `.env.*` except `.env.example`
+- `*.pem`
+- `*.key`
+- `*.p12`
+- `*.pfx`
+- `.netrc`
+- `secrets.yml`
+- `secrets.local.yml`
+
+These are intended for developer-local credentials and should not be committed.
+
+## Practical Rules
+
+- Do not log raw tokens, passwords, or private keys, even in verbose/debug output.
+- Prefer environment variables or ignored local files for local credentials.
+- Treat `.automate_collector_private.toml` as secret-bearing configuration.
+- If a value is sensitive, log presence or redacted state, not the content.
+- When adding new secret inputs, update both ignore rules and nearby docs if local files are involved.
+
+## Validation
+
+Run from the repository root:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run 'TestRedactSecretForLog|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
+go build ./...
+```

--- a/components/chef-automate-collect/commands/automate_config.go
+++ b/components/chef-automate-collect/commands/automate_config.go
@@ -71,6 +71,14 @@ type PrivateAutomateConfig struct {
 	InsecureTLS bool   `toml:"insecure_tls"`
 }
 
+func redactSecretForLog(secret string) string {
+	if secret == "" {
+		return ""
+	}
+
+	return "[REDACTED]"
+}
+
 func NewConfigLoader() *ConfigLoader {
 	c := &ConfigLoader{}
 	c.findRepoConfig()
@@ -481,7 +489,7 @@ func (a *AutomateConfig) ApplyValuesFromEnv() {
 		a.URL = url
 	}
 	if token, envVarSet := os.LookupEnv(AutomateTokenEnvVar); envVarSet {
-		cliIO.verbose("found environment %s=%q setting Automate Token", AutomateURLEnvVar, token)
+		cliIO.verbose("found environment %s=%q setting Automate Token", AutomateTokenEnvVar, redactSecretForLog(token))
 		a.authToken = token
 	}
 	if val, envVarSet := os.LookupEnv(AutomateInsecureTLSEnvVar); envVarSet {

--- a/components/chef-automate-collect/commands/automate_config_test.go
+++ b/components/chef-automate-collect/commands/automate_config_test.go
@@ -1,0 +1,23 @@
+package commands
+
+import "testing"
+
+func TestRedactSecretForLogRedactsNonEmptySecrets(t *testing.T) {
+	secret := "super-secret-token"
+	got := redactSecretForLog(secret)
+
+	if got == secret {
+		t.Fatalf("got raw secret %q, expected redacted value", got)
+	}
+	if got != "[REDACTED]" {
+		t.Fatalf("got %q, want %q", got, "[REDACTED]")
+	}
+}
+
+func TestRedactSecretForLogKeepsEmptyValueEmpty(t *testing.T) {
+	got := redactSecretForLog("")
+
+	if got != "" {
+		t.Fatalf("got %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
Summary
- Improved local secret hygiene by ignoring common secret files and adding a short security note for this repo slice.
- Remediated an obvious risk in `chef-automate-collect`: verbose logging no longer emits the raw `CHEF_AC_AUTOMATE_TOKEN` value.
- Files/paths touched: .gitignore, ai-track-docs/security-secrets.md, components/chef-automate-collect/commands/automate_config.go, components/chef-automate-collect/commands/automate_config_test.go.

Test & Risk
- Focused validation command (from repo root):
  - cd components/chef-automate-collect && go test ./commands -run 'TestRedactSecretForLog|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
  - Output:
    - === RUN   TestRedactSecretForLogRedactsNonEmptySecrets
    - --- PASS: TestRedactSecretForLogRedactsNonEmptySecrets (0.00s)
    - === RUN   TestRedactSecretForLogKeepsEmptyValueEmpty
    - --- PASS: TestRedactSecretForLogKeepsEmptyValueEmpty (0.00s)
    - PASS
    - ok github.com/chef/chef-workstation/components/chef-automate-collect/commands 0.245s
- Build command (from repo root):
  - cd components/chef-automate-collect && go build ./...
  - Result: success (no build errors)
- Risk: low (secret logging is reduced; ignore rules and docs are additive).
- Rollback: git revert c17afb2f

Track
- Level: crawl
- Exercise: 8-security-secrets-hygiene
- Evidence: ai-track-docs/security-secrets.md, components/chef-automate-collect/commands/automate_config.go, .gitignore
