### PR TITLE
Copilot Track - Crawl: 9 Structured Logging

### DIFF
--- a/ai-track-docs/logging.md
+++ b/ai-track-docs/logging.md
@@ -1,0 +1,58 @@
+# Logging Notes
+
+## Scope
+
+This note covers the current structured logging added in `components/chef-automate-collect/commands`.
+
+## Structured Log Format
+
+The current structured log line format is emitted to `stderr` when verbose mode is enabled.
+
+Required fields:
+
+- `op`: operation name
+- `status`: current outcome (`success` or `error`)
+- `elapsed_ms`: elapsed time in milliseconds
+
+Current structured logging path:
+
+- `ConfigLoader.Load()` in `components/chef-automate-collect/commands/automate_config.go`
+
+Example log lines:
+
+```text
+op=config_load status=success elapsed_ms=4 config_paths=2
+op=config_load status=error elapsed_ms=1 path=/tmp/bad.toml error=decode_toml
+```
+
+## How To View Logs
+
+Run from the repository root.
+
+Show computed config and verbose logs:
+
+```sh
+cd components/chef-automate-collect
+go run . show-config -v
+```
+
+Test config and verbose logs:
+
+```sh
+cd components/chef-automate-collect
+go run . test-config -v
+```
+
+Because verbose output goes to `stderr`, you can separate it from normal output if needed:
+
+```sh
+cd components/chef-automate-collect
+go run . show-config -v 2>verbose.log
+```
+
+## Guidance
+
+- Reuse the same required fields for future structured logs.
+- Add extra fields only when they help identify the failing resource or boundary.
+- Do not include secrets in structured fields.
+- Prefer logging at boundary operations such as config loading, HTTP calls, and external command execution.

--- a/components/chef-automate-collect/commands/automate_config.go
+++ b/components/chef-automate-collect/commands/automate_config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	fpath "path/filepath"
 
@@ -108,16 +109,24 @@ func (l *ConfigLoader) ViableConfigPaths() []string {
 }
 
 func (l *ConfigLoader) Load() error {
+	start := time.Now()
 	l.LoadedConfig = &Config{Automate: &AutomateConfig{}}
+	configPaths := l.ViableConfigPaths()
 
-	for _, p := range l.ViableConfigPaths() {
+	for _, p := range configPaths {
 		configFromFile := &PrivateConfig{}
 		fileContent, err := ioutil.ReadFile(p)
 		if err != nil {
+			cliIO.structuredVerbose("config_load", "error", time.Since(start),
+				StructuredField{Key: "path", Value: p},
+				StructuredField{Key: "error", Value: "read_config"})
 			return errors.Wrapf(err, "failed to read config file %q", p)
 		}
 		err = toml.Unmarshal(fileContent, configFromFile)
 		if err != nil {
+			cliIO.structuredVerbose("config_load", "error", time.Since(start),
+				StructuredField{Key: "path", Value: p},
+				StructuredField{Key: "error", Value: "decode_toml"})
 			return errors.Wrapf(err, "cannot decode TOML content in %q", p)
 		}
 		cliIO.verbose("applying configuration from %q", p)
@@ -125,6 +134,8 @@ func (l *ConfigLoader) Load() error {
 	}
 
 	l.LoadedConfig.ApplyValuesFromEnv()
+	cliIO.structuredVerbose("config_load", "success", time.Since(start),
+		StructuredField{Key: "config_paths", Value: fmt.Sprintf("%d", len(configPaths))})
 
 	return nil
 }

--- a/components/chef-automate-collect/commands/cli_io.go
+++ b/components/chef-automate-collect/commands/cli_io.go
@@ -4,9 +4,15 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 var cliIO = &CLIIO{}
+
+type StructuredField struct {
+	Key   string
+	Value string
+}
 
 type CLIIO struct {
 	EnableVerbose bool
@@ -24,6 +30,26 @@ func (c *CLIIO) verbose(format string, args ...interface{}) {
 	if c.EnableVerbose {
 		c.msg(newlineify(format), args...)
 	}
+}
+
+func (c *CLIIO) structuredVerbose(op string, status string, elapsed time.Duration, fields ...StructuredField) {
+	if c.EnableVerbose {
+		c.msg(structuredLogLine(op, status, elapsed, fields...))
+	}
+}
+
+func structuredLogLine(op string, status string, elapsed time.Duration, fields ...StructuredField) string {
+	parts := []string{
+		fmt.Sprintf("op=%s", op),
+		fmt.Sprintf("status=%s", status),
+		fmt.Sprintf("elapsed_ms=%d", elapsed.Milliseconds()),
+	}
+
+	for _, field := range fields {
+		parts = append(parts, fmt.Sprintf("%s=%s", field.Key, field.Value))
+	}
+
+	return strings.Join(parts, " ")
 }
 
 func newlineify(s string) string {

--- a/components/chef-automate-collect/commands/cli_io_test.go
+++ b/components/chef-automate-collect/commands/cli_io_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStructuredLogLineIncludesRequiredFields(t *testing.T) {
+	got := structuredLogLine("config_load", "success", 12*time.Millisecond,
+		StructuredField{Key: "config_paths", Value: "2"})
+
+	want := "op=config_load status=success elapsed_ms=12 config_paths=2"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestStructuredLogLinePreservesFieldOrder(t *testing.T) {
+	got := structuredLogLine("config_load", "error", 3*time.Millisecond,
+		StructuredField{Key: "path", Value: "config.toml"},
+		StructuredField{Key: "error", Value: "decode_toml"})
+
+	want := "op=config_load status=error elapsed_ms=3 path=config.toml error=decode_toml"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Summary
- Added structured verbose logs for the config-load path using consistent fields: `op`, `status`, and `elapsed_ms`.
- Added a small shared formatter in CLI IO plus focused tests for log-line shape and field order.
- Documented how to view verbose logs in `ai-track-docs/logging.md`.
- Files/paths touched: components/chef-automate-collect/commands/cli_io.go, components/chef-automate-collect/commands/automate_config.go, components/chef-automate-collect/commands/cli_io_test.go, ai-track-docs/logging.md.

Test & Risk
- Focused validation command (from repo root):
  - cd components/chef-automate-collect && go test ./commands -run 'TestStructuredLogLine|TestRedactSecretForLog|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
  - Output:
    - === RUN   TestStructuredLogLineIncludesRequiredFields
    - --- PASS: TestStructuredLogLineIncludesRequiredFields (0.00s)
    - === RUN   TestStructuredLogLinePreservesFieldOrder
    - --- PASS: TestStructuredLogLinePreservesFieldOrder (0.00s)
    - PASS
    - ok github.com/chef/chef-workstation/components/chef-automate-collect/commands 0.215s
- Build command (from repo root):
  - cd components/chef-automate-collect && go build ./...
  - Result: success (no build errors)
- Risk: low (additive verbose logging only; runtime behavior unchanged).
- Rollback: git revert 72a62b8f

Track
- Level: crawl
- Exercise: 9-structured-logging
- Evidence: ai-track-docs/logging.md, components/chef-automate-collect/commands/automate_config.go, components/chef-automate-collect/commands/cli_io.go
