### PR TITLE
Copilot Track - Crawl: 10 CI Baseline Local Fallback

### DIFF
--- a/ai-track-docs/ci-baseline.md
+++ b/ai-track-docs/ci-baseline.md
@@ -1,0 +1,39 @@
+# CI Baseline
+
+## Current State
+
+The existing GitHub Actions workflow in `.github/workflows/unit.yml` runs Ruby verification (`bundle exec rake omnibus/verification/spec/ --trace`).
+
+That workflow does not provide a focused, repeatable validation path for the crawl-track changes in `components/chef-automate-collect`.
+
+## Local Fallback Script
+
+Use the local validation script at `scripts/run-crawl-checks.sh`.
+
+Run from the repository root:
+
+```sh
+./scripts/run-crawl-checks.sh
+```
+
+## What The Script Runs
+
+The script performs the current crawl-track checks for `chef-automate-collect`:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run 'TestStructuredLogLine|TestRedactSecretForLog|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
+go build ./...
+```
+
+## Expected Success Signal
+
+- Unit tests pass
+- `go build ./...` succeeds
+- Script ends with `==> Crawl checks passed`
+
+## Why This Exists
+
+- It gives contributors one copy/paste entry point for the Go slice touched in the crawl exercises.
+- It is narrower and faster than broad repo-wide validation.
+- It is suitable as a local fallback until CI includes an equivalent focused job for this component.

--- a/scripts/run-crawl-checks.sh
+++ b/scripts/run-crawl-checks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+component_dir="$repo_root/components/chef-automate-collect"
+
+if ! command -v go >/dev/null 2>&1; then
+	echo "go is required but was not found in PATH" >&2
+	exit 1
+fi
+
+echo "==> Running focused crawl checks for chef-automate-collect"
+
+cd "$component_dir"
+
+echo "==> go test ./commands"
+go test ./commands -run 'TestStructuredLogLine|TestRedactSecretForLog|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
+
+echo "==> go build ./..."
+go build ./...
+
+echo "==> Crawl checks passed"


### PR DESCRIPTION
Summary
- Added a repeatable local validation script for the crawl-track Go slice in `chef-automate-collect`.
- Documented the current CI baseline and the local fallback path in `ai-track-docs/ci-baseline.md`.
- Files/paths touched: scripts/run-crawl-checks.sh, ai-track-docs/ci-baseline.md.

Test & Risk
- Validation command (from repo root):
  - `./scripts/run-crawl-checks.sh`
- Output:
  - `==> Running focused crawl checks for chef-automate-collect`
  - `==> go test ./commands`
  - `PASS`
  - `ok github.com/chef/chef-workstation/components/chef-automate-collect/commands 0.229s`
  - `==> go build ./...`
  - `==> Crawl checks passed`
- Risk: low (additive script + documentation only; no runtime behavior changes).
- Rollback: `git revert 1c0033fb`

Track
- Level: crawl
- Exercise: 10-ci-baseline-local-fallback
- Evidence: ai-track-docs/ci-baseline.md, scripts/run-crawl-checks.sh
