### PR TITLE
Copilot Track - Crawl: 13 Feature Flag for Structured Logging

### DIFF
--- a/ai-track-docs/logging.md
+++ b/ai-track-docs/logging.md
@@ -8,6 +8,9 @@ This note covers the current structured logging added in `components/chef-automa
 
 The current structured log line format is emitted to `stderr` when verbose mode is enabled.
 
+Structured logging can be disabled by setting `CHEF_AC_STRUCTURED_LOGS=false`.
+If the variable is unset, or set to any other value, structured logging stays enabled.
+
 Required fields:
 
 - `op`: operation name
@@ -36,6 +39,13 @@ cd components/chef-automate-collect
 go run . show-config -v
 ```
 
+Show computed config with structured logs disabled:
+
+```sh
+cd components/chef-automate-collect
+CHEF_AC_STRUCTURED_LOGS=false go run . show-config -v
+```
+
 Test config and verbose logs:
 
 ```sh
@@ -56,3 +66,4 @@ go run . show-config -v 2>verbose.log
 - Add extra fields only when they help identify the failing resource or boundary.
 - Do not include secrets in structured fields.
 - Prefer logging at boundary operations such as config loading, HTTP calls, and external command execution.
+- Use `CHEF_AC_STRUCTURED_LOGS=false` as a low-risk rollback toggle if a new structured log shape causes operator friction.

--- a/components/chef-automate-collect/commands/cli_io.go
+++ b/components/chef-automate-collect/commands/cli_io.go
@@ -18,6 +18,15 @@ type CLIIO struct {
 	EnableVerbose bool
 }
 
+func structuredLoggingEnabled(lookupEnv func(string) (string, bool)) bool {
+	value, isSet := lookupEnv(StructuredLogsEnvVar)
+	if !isSet {
+		return true
+	}
+
+	return strings.TrimSpace(value) != "false"
+}
+
 func (c *CLIIO) msg(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, newlineify(format), args...)
 }
@@ -33,7 +42,7 @@ func (c *CLIIO) verbose(format string, args ...interface{}) {
 }
 
 func (c *CLIIO) structuredVerbose(op string, status string, elapsed time.Duration, fields ...StructuredField) {
-	if c.EnableVerbose {
+	if c.EnableVerbose && structuredLoggingEnabled(os.LookupEnv) {
 		c.msg(structuredLogLine(op, status, elapsed, fields...))
 	}
 }

--- a/components/chef-automate-collect/commands/cli_io_test.go
+++ b/components/chef-automate-collect/commands/cli_io_test.go
@@ -25,3 +25,33 @@ func TestStructuredLogLinePreservesFieldOrder(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, want)
 	}
 }
+
+func TestStructuredLoggingEnabledDefaultsOn(t *testing.T) {
+	got := structuredLoggingEnabled(func(string) (string, bool) {
+		return "", false
+	})
+
+	if !got {
+		t.Fatal("expected structured logging to be enabled when env var is unset")
+	}
+}
+
+func TestStructuredLoggingEnabledTurnsOff(t *testing.T) {
+	got := structuredLoggingEnabled(func(string) (string, bool) {
+		return "false", true
+	})
+
+	if got {
+		t.Fatal("expected structured logging to be disabled when env var is false")
+	}
+}
+
+func TestStructuredLoggingEnabledTurnsOn(t *testing.T) {
+	got := structuredLoggingEnabled(func(string) (string, bool) {
+		return "true", true
+	})
+
+	if !got {
+		t.Fatal("expected structured logging to be enabled when env var is true")
+	}
+}

--- a/components/chef-automate-collect/commands/environment_variables.go
+++ b/components/chef-automate-collect/commands/environment_variables.go
@@ -52,6 +52,11 @@ const (
 
 const (
 	// Reporting and source control behavior.
+	// Whether to enable structured verbose logs. If set to "false", structured
+	// logs are disabled. Any other value, or an unset variable, leaves them
+	// enabled.
+	StructuredLogsEnvVar = "CHEF_AC_STRUCTURED_LOGS"
+
 	// Whether to disable reporting new rollouts to Chef Automate. If set to
 	// "false," reports will be sent. If set to any other value, reports will not
 	// be sent.

--- a/components/chef-automate-collect/commands/environment_variables_test.go
+++ b/components/chef-automate-collect/commands/environment_variables_test.go
@@ -13,6 +13,7 @@ func TestEnvironmentVariableConstantsStable(t *testing.T) {
 		"NoRepoConfigEnvVar":            NoRepoConfigEnvVar,
 		"NoUserConfigEnvVar":            NoUserConfigEnvVar,
 		"NoSystemConfigEnvVar":          NoSystemConfigEnvVar,
+		"StructuredLogsEnvVar":          StructuredLogsEnvVar,
 		"DisableReportNewRolloutEnvVar": DisableReportNewRolloutEnvVar,
 		"GitRemoteNameEnvVar":           GitRemoteNameEnvVar,
 	}
@@ -27,6 +28,7 @@ func TestEnvironmentVariableConstantsStable(t *testing.T) {
 		"NoRepoConfigEnvVar":            "CHEF_AC_NO_REPO_CONFIG",
 		"NoUserConfigEnvVar":            "CHEF_AC_NO_USER_CONFIG",
 		"NoSystemConfigEnvVar":          "CHEF_AC_NO_SYSTEM_CONFIG",
+		"StructuredLogsEnvVar":          "CHEF_AC_STRUCTURED_LOGS",
 		"DisableReportNewRolloutEnvVar": "CHEF_AC_DISABLE_COLLECTOR",
 		"GitRemoteNameEnvVar":           "CHEF_AC_GIT_REMOTE_NAME",
 	}


### PR DESCRIPTION
Summary
- Added a small configuration toggle for structured verbose logging via `CHEF_AC_STRUCTURED_LOGS`.
- Default behavior remains unchanged: structured logs stay enabled unless the variable is explicitly set to `false`.
- Added ON/OFF tests and documented how to use the toggle in `ai-track-docs/logging.md`.
- Files/paths touched: components/chef-automate-collect/commands/environment_variables.go, components/chef-automate-collect/commands/environment_variables_test.go, components/chef-automate-collect/commands/cli_io.go, components/chef-automate-collect/commands/cli_io_test.go, ai-track-docs/logging.md.

Test & Risk
- Focused validation command (from repo root):
  - cd components/chef-automate-collect && go test ./commands -run 'TestStructuredLoggingEnabled|TestStructuredLogLine|TestRedactSecretForLog|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
  - Output includes:
    - `TestStructuredLoggingEnabledDefaultsOn` PASS
    - `TestStructuredLoggingEnabledTurnsOff` PASS
    - `TestStructuredLoggingEnabledTurnsOn` PASS
- Build command (from repo root):
  - cd components/chef-automate-collect && go build ./...
  - Result: success (no build errors)
- Risk: low (non-critical logging behavior only; default mode is unchanged, and the feature can be turned off explicitly).
- Rollback: git revert df6601c1

Track
- Level: crawl
- Exercise: 13-feature-flag-config-toggle
- Evidence: ai-track-docs/logging.md, components/chef-automate-collect/commands/cli_io.go, components/chef-automate-collect/commands/cli_io_test.go
