### PR TITLE
Copilot Track - Crawl: 15 Resilience and Failure Tests

### DIFF
--- a/ai-track-docs/resilience.md
+++ b/ai-track-docs/resilience.md
@@ -1,0 +1,51 @@
+# Resilience Notes
+
+## Scope
+
+This note documents a small reliability improvement in `chef-automate-collect` config testing.
+
+## Improvement Implemented
+
+Path:
+
+- `components/chef-automate-collect/commands/automate_config.go`
+
+Change:
+
+- `AutomateConfig.Test()` now maps non-200 HTTP responses to returned errors.
+- It no longer exits the process directly inside the helper path.
+
+Why this helps:
+
+- Callers can handle errors consistently.
+- Failure behavior is easier to test and reason about.
+- The command still fails appropriately via normal error return handling.
+
+## Failure Behavior
+
+For non-200 responses, the mapped error now includes:
+
+- target URL
+- status code
+- optional response body snippet (trimmed and truncated)
+
+This gives enough context for troubleshooting without forcing process termination in lower-level code.
+
+## Tests Added
+
+- `TestMapTestConfigHTTPErrorWithoutBody`
+- `TestMapTestConfigHTTPErrorWithBodyTruncatesLongBody`
+
+Both are in:
+
+- `components/chef-automate-collect/commands/automate_config_test.go`
+
+## Validation Command
+
+Run from repository root:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run 'TestMapTestConfigHTTPError|TestRedactSecretForLog|TestStructuredLoggingEnabled|TestStructuredLogLine|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
+go build ./...
+```

--- a/components/chef-automate-collect/commands/automate_config.go
+++ b/components/chef-automate-collect/commands/automate_config.go
@@ -589,11 +589,24 @@ func (a *AutomateConfig) Test() error {
 	cliIO.verbose("\nEND HTTP RESPONSE BODY--------")
 
 	if response.StatusCode != 200 {
-		cliIO.msg("ERROR: request to %q failed with status code %d", a.URL, response.StatusCode)
-		os.Exit(1)
+		return mapTestConfigHTTPError(a.URL, response.StatusCode, string(bodyBytes))
 	}
 
 	return nil
+}
+
+func mapTestConfigHTTPError(baseURL string, statusCode int, responseBody string) error {
+	responseBody = strings.TrimSpace(responseBody)
+	if responseBody == "" {
+		return errors.Errorf("request to %q failed with status code %d", baseURL, statusCode)
+	}
+
+	const maxBodyChars = 200
+	if len(responseBody) > maxBodyChars {
+		responseBody = responseBody[:maxBodyChars] + "..."
+	}
+
+	return errors.Errorf("request to %q failed with status code %d: %s", baseURL, statusCode, responseBody)
 }
 
 func (p *PrivateAutomateConfig) ToConfig() *AutomateConfig {

--- a/components/chef-automate-collect/commands/automate_config_test.go
+++ b/components/chef-automate-collect/commands/automate_config_test.go
@@ -1,6 +1,9 @@
 package commands
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestRedactSecretForLogRedactsNonEmptySecrets(t *testing.T) {
 	secret := "super-secret-token"
@@ -19,5 +22,38 @@ func TestRedactSecretForLogKeepsEmptyValueEmpty(t *testing.T) {
 
 	if got != "" {
 		t.Fatalf("got %q, want empty string", got)
+	}
+}
+
+func TestMapTestConfigHTTPErrorWithoutBody(t *testing.T) {
+	err := mapTestConfigHTTPError("https://automate.example", 503, "")
+
+	if err == nil {
+		t.Fatal("expected an error for non-200 response")
+	}
+
+	want := "request to \"https://automate.example\" failed with status code 503"
+	if err.Error() != want {
+		t.Fatalf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestMapTestConfigHTTPErrorWithBodyTruncatesLongBody(t *testing.T) {
+	longBody := strings.Repeat("x", 300)
+	err := mapTestConfigHTTPError("https://automate.example", 500, longBody)
+
+	if err == nil {
+		t.Fatal("expected an error for non-200 response")
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "status code 500") {
+		t.Fatalf("expected status code in message, got %q", message)
+	}
+	if !strings.Contains(message, "...") {
+		t.Fatalf("expected truncated suffix in message, got %q", message)
+	}
+	if strings.Count(message, "x") < 200 {
+		t.Fatalf("expected truncated body content in message, got %q", message)
 	}
 }


### PR DESCRIPTION
Summary
- Added a minimal resilience improvement in the `test-config` HTTP path by mapping non-200 responses to returned errors instead of exiting directly.
- Added two failure-focused tests to validate behavior with and without response body content.
- Added a short behavior note in `ai-track-docs/resilience.md`.
- Files/paths touched: components/chef-automate-collect/commands/automate_config.go, components/chef-automate-collect/commands/automate_config_test.go, ai-track-docs/resilience.md.

Test & Risk
- Focused validation command (from repo root):
  - cd components/chef-automate-collect && go test ./commands -run 'TestMapTestConfigHTTPError|TestRedactSecretForLog|TestStructuredLoggingEnabled|TestStructuredLogLine|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
  - Output includes:
    - `TestMapTestConfigHTTPErrorWithoutBody` PASS
    - `TestMapTestConfigHTTPErrorWithBodyTruncatesLongBody` PASS
- Build command (from repo root):
  - cd components/chef-automate-collect && go build ./...
  - Result: success (no build errors)
- Risk: low (failure-path behavior improvement in non-critical config verification flow).
- Rollback: git revert d344e7e0

Track
- Level: crawl
- Exercise: 15-resilience-and-failure-tests
- Evidence: ai-track-docs/resilience.md, components/chef-automate-collect/commands/automate_config.go, components/chef-automate-collect/commands/automate_config_test.go
