### PR TITLE
GHCP -- Walk: Ex1 Repo Orientation and Architecture Map

### DIFF
--- a/.github/workflows/validate-diagram.yml
+++ b/.github/workflows/validate-diagram.yml
@@ -1,0 +1,34 @@
+permissions:
+  contents: read
+
+name: Validate Architecture Diagram
+
+on:
+  push:
+    branches: main
+    paths:
+      - 'ai-track-docs/architecture.mmd'
+      - 'scripts/validate-diagram.sh'
+  pull_request:
+    branches: main
+    paths:
+      - 'ai-track-docs/architecture.mmd'
+      - 'scripts/validate-diagram.sh'
+
+jobs:
+  validate-diagram:
+    name: Mermaid diagram validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Mermaid CLI
+        run: npm install -g @mermaid-js/mermaid-cli
+
+      - name: Validate diagram
+        run: bash scripts/validate-diagram.sh

--- a/ai-track-docs/architecture.mmd
+++ b/ai-track-docs/architecture.mmd
@@ -1,22 +1,53 @@
 %% Chef Workstation – Architecture Diagram (Mermaid)
-%% Placeholder – refine during AI track architecture exercise.
+%% Updated: Walk Ex1 – nodes mapped to real file paths; dependency + data flows added.
 
 graph TD
     User["Developer / Operator"]
 
-    subgraph Chef Workstation Package
-        CLI["chef CLI<br/>(main-chef-wrapper)"]
-        Collect["chef-automate-collect"]
-        Gems["Bundled Ruby Gems"]
+    subgraph Wrapper ["main-chef-wrapper · components/main-chef-wrapper/"]
+        Main["main.go<br/>entry point · startup tasks<br/>createDotChef · createRubyEnv"]
+        Root["cmd/root.go<br/>Cobra root command"]
+        CmdLayer["cmd/ sub-commands<br/>capture · report · push · exec<br/>install · gem · generate · …"]
+        PlatformLib["platform-lib/<br/>ruby env JSON · version matching"]
     end
 
-    subgraph External
-        Infra["Chef Infra Server"]
-        Automate["Chef Automate"]
+    subgraph Collect ["chef-automate-collect · components/chef-automate-collect/"]
+        CollectMain["chef_automate_collect.go<br/>entry point"]
+        CollectCmds["commands/init_cli.go<br/>Cobra root: gen-config · show-config<br/>test-config · describe · report-new-rollout"]
+        AutomateCfg["commands/automate_config.go<br/>ConfigLoader · TOML · HTTP client<br/>POST /api/beta/cfgmgmt/rollouts/…"]
+        EnvVars["commands/environment_variables.go<br/>env-var name constants (no I/O)"]
     end
 
-    User -->|runs| CLI
-    CLI -->|sub-commands| Gems
-    CLI -->|telemetry| Collect
-    Collect -->|reports| Automate
-    CLI -->|converge / upload| Infra
+    subgraph GemsComp ["Gems · components/gems/"]
+        GemFiles["Gemfile · post-bundle-install.rb<br/>bundled Ruby tools"]
+    end
+
+    subgraph Packaging ["Packaging · omnibus/ + habitat/plan.sh"]
+        Omnibus["omnibus/<br/>Omnibus build definitions"]
+        Habitat["habitat/plan.sh<br/>Habitat plan"]
+    end
+
+    subgraph External ["External Services"]
+        Infra["Chef Infra Server<br/>REST API"]
+        Automate["Chef Automate<br/>REST /api/beta/cfgmgmt/rollouts/…"]
+    end
+
+    %% ── Dependency Flow ──────────────────────────────────────────────
+    Main -->|"imports cmd package"| Root
+    Main -->|"startup tasks"| PlatformLib
+    Root -->|"registers sub-commands"| CmdLayer
+    CollectMain -->|"calls commands.Execute()"| CollectCmds
+    CollectCmds -->|"uses ConfigLoader"| AutomateCfg
+    AutomateCfg -->|"reads env-var constants"| EnvVars
+
+    %% ── Invocation Flow (user entry points) ─────────────────────────
+    User -->|"chef cmd"| Main
+    User -->|"chef-automate-collect cmd"| CollectMain
+
+    %% ── Data Flow 1: CLI passthrough to Ruby tools → Infra Server ───
+    CmdLayer -->|"PassThroughCommand<br/>(exec / report / capture)"| GemFiles
+    GemFiles -->|"converge / upload / report"| Infra
+
+    %% ── Data Flow 2: Telemetry rollout → Chef Automate ──────────────
+    CmdLayer -.->|"telemetry trigger"| CollectMain
+    AutomateCfg -.->|"HTTP POST rollout (TLS)"| Automate

--- a/scripts/validate-diagram.sh
+++ b/scripts/validate-diagram.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# validate-diagram.sh – verify architecture.mmd renders without errors.
+# Usage: ./scripts/validate-diagram.sh
+#
+# Strategy:
+#   1. If mmdc (Mermaid CLI) is available, render to a temp PNG and check exit code.
+#   2. Otherwise fall back to a lightweight grep-based syntax check that verifies
+#      the required structural keywords are present.
+
+set -euo pipefail
+
+DIAGRAM="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/ai-track-docs/architecture.mmd"
+
+if [[ ! -f "$DIAGRAM" ]]; then
+  echo "ERROR: diagram not found at $DIAGRAM" >&2
+  exit 1
+fi
+
+echo "==> Validating $DIAGRAM"
+
+# ── Strategy 1: mmdc render ──────────────────────────────────────────
+if command -v mmdc >/dev/null 2>&1; then
+  echo "==> mmdc found – rendering diagram to temp file"
+  TMPOUT="$(mktemp /tmp/arch-render-XXXXXX.png)"
+  if mmdc -i "$DIAGRAM" -o "$TMPOUT" 2>&1; then
+    echo "==> mmdc render PASSED"
+    rm -f "$TMPOUT"
+    exit 0
+  else
+    echo "==> mmdc render failed; retrying with --no-sandbox Chromium args"
+    PUPPETEER_CFG="$(mktemp /tmp/mmdc-puppeteer-XXXXXX.json)"
+    cat >"$PUPPETEER_CFG" <<'EOF'
+{
+  "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+}
+EOF
+    if mmdc -p "$PUPPETEER_CFG" -i "$DIAGRAM" -o "$TMPOUT" 2>&1; then
+      echo "==> mmdc render PASSED (no-sandbox retry)"
+      rm -f "$TMPOUT" "$PUPPETEER_CFG"
+      exit 0
+    fi
+
+    echo "ERROR: mmdc render FAILED" >&2
+    rm -f "$TMPOUT" "$PUPPETEER_CFG"
+    exit 1
+  fi
+fi
+
+# ── Strategy 2: lightweight syntax checks ────────────────────────────
+echo "==> mmdc not found – running lightweight syntax checks"
+FAIL=0
+
+check() {
+  local desc="$1"
+  local pattern="$2"
+  if grep -qE "$pattern" "$DIAGRAM"; then
+    echo "  [PASS] $desc"
+  else
+    echo "  [FAIL] $desc (pattern: $pattern)" >&2
+    FAIL=1
+  fi
+}
+
+check "graph directive present"         "^graph (TD|LR|BT|RL)"
+check "at least one subgraph"           "^[[:space:]]*subgraph "
+check "at least one node label"         "\[\"[^\"]+\""
+check "at least one dependency arrow"   " -->"
+check "at least one data-flow arrow"    " -\.->"
+check "file path reference in node"     "components/"
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "==> Syntax checks PASSED"
+  exit 0
+else
+  echo "==> Syntax checks FAILED – fix diagram before merging" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Updated `ai-track-docs/architecture.mmd` from a placeholder to a fully mapped diagram: every node now includes its real repo path (`components/main-chef-wrapper/main.go`, `cmd/root.go`, `commands/automate_config.go`, etc.)
- Added three annotated flows: dependency flow (imports/registers), invocation flow (user entry points), and two data flows (CLI passthrough → Chef Infra Server; telemetry trigger → Automate HTTP POST via TLS)
- Added `scripts/validate-diagram.sh`: tries `mmdc` if installed, falls back to 6 grep-based syntax checks; exits non-zero on failure
- Added `.github/workflows/validate-diagram.yml`: installs `@mermaid-js/mermaid-cli` and runs the script on every PR that touches `ai-track-docs/`
- **Plan:** Inline above – map nodes → paths first, layer flows second, add CI validation last

## Files/paths touched
- `ai-track-docs/architecture.mmd`
- `scripts/validate-diagram.sh`
- `.github/workflows/validate-diagram.yml`

## Evidence
```
$ bash scripts/validate-diagram.sh
==> Validating .../ai-track-docs/architecture.mmd
==> mmdc not found – running lightweight syntax checks
  [PASS] graph directive present
  [PASS] at least one subgraph
  [PASS] at least one node label
  [PASS] at least one dependency arrow
  [PASS] at least one data-flow arrow
  [PASS] file path reference in node
==> Syntax checks PASSED
```
- Coverage: doc-only change; no source coverage delta

## Risk & Rollback
- Risk: low (doc + script only, no source code changed)
- Rollback: `git revert feda5260`

## Review Focus
- Confirm node labels correctly reflect actual file paths
- Run `bash scripts/validate-diagram.sh` locally to confirm green output
- Check `.github/workflows/validate-diagram.yml` path-filter triggers as expected

## Track
- Level: Walk
- Exercise: Ex1