### PR TITLE
GHCP -- Walk: Ex2 Build and Test Baseline (Coverage Surfacing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 test_results/
 tags
 .DS_Store
+coverage.out
+coverage.html
 
 # ruby / bundler
 Gemfile.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,3 +2,53 @@ Workstation follows the contributing process detailed in the `chef` project's CO
 
 Please refer to CONTRIBUTING.md for the `chef` project: https://github.com/chef/chef/blob/main/CONTRIBUTING.md
 
+## Running Tests & Coverage Locally
+
+This repo contains two Go components, each with its own module and test suite.
+
+### `components/chef-automate-collect`
+
+```sh
+cd components/chef-automate-collect
+
+# Unit tests with coverage
+go test -cover -count=1 ./commands
+
+# Per-function coverage breakdown
+go test -coverprofile=coverage.out -count=1 ./commands
+go tool cover -func=coverage.out
+
+# Remove artifact after review
+rm coverage.out
+```
+
+> **Note:** Baseline coverage for `commands/` is intentionally low (~5%). The majority of command functions invoke external HTTP endpoints or process I/O that are not unit-testable without integration infrastructure. The covered surface is the pure-logic layer (env-var constants, config struct parsing, error mapping).
+
+### `components/main-chef-wrapper`
+
+```sh
+cd components/main-chef-wrapper
+
+# Unit tests (build-tag gated) with coverage
+go test -tags=unit -cover -count=1 ./cmd
+
+# Per-function coverage breakdown
+go test -tags=unit -coverprofile=coverage.out -count=1 ./cmd
+go tool cover -func=coverage.out
+
+# Remove artifact after review
+rm coverage.out
+```
+
+> **Baseline:** `cmd/` unit-tagged tests cover **~57%** of statements. Uncovered functions are passthrough command wrappers whose execution path requires a live Chef Infra Server.
+
+### Ruby / Omnibus specs
+
+```sh
+# Requires Ruby 2.7 + bundler
+bundle install
+bundle exec rake omnibus/verification/spec/ --trace
+```
+
+CI (`.github/workflows/unit.yml`) runs these specs and enforces a SimpleCov threshold of **79%** via `aki77/simplecov-report-action`.
+

--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -44,3 +44,60 @@ go test ./... -count=1
 
 - The deterministic test validates env var constants and checks for accidental duplicate values.
 - This gives a low-risk guardrail for the selected reusable module before changing config behavior elsewhere.
+
+---
+
+## Coverage
+
+*Added: Walk Ex2 – coverage surfacing baseline.*
+
+### Commands: `components/chef-automate-collect`
+
+```sh
+cd components/chef-automate-collect
+go test -cover -count=1 ./commands
+# → ok  ...commands  0.655s  coverage: 4.9% of statements
+
+# Per-function detail
+go test -coverprofile=coverage.out -count=1 ./commands && go tool cover -func=coverage.out
+rm coverage.out
+```
+
+| Package | Coverage | Notes |
+|---------|----------|-------|
+| `commands/` | **4.9%** | Low by design: most command bodies invoke external HTTP/IO not covered by unit tests. Pure-logic layer (env-var constants, error mapping) is covered. |
+
+### Commands: `components/main-chef-wrapper`
+
+```sh
+cd components/main-chef-wrapper
+go test -tags=unit -cover -count=1 ./cmd
+# → ok  ...cmd  0.528s  coverage: 56.9% of statements
+
+# Per-function detail
+go test -tags=unit -coverprofile=coverage.out -count=1 ./cmd && go tool cover -func=coverage.out
+rm coverage.out
+```
+
+| Package | Coverage | Notes |
+|---------|----------|-------|
+| `cmd/` (unit tag) | **56.9%** | Covers command wiring, flag registration, and `init()` blocks. Passthrough `RunE` wrappers that delegate to external executables are not reachable under unit tests. |
+
+### Ruby / Omnibus (CI only)
+
+CI enforces **≥ 79%** SimpleCov threshold via `.github/workflows/unit.yml`.
+Run locally with:
+```sh
+bundle exec rake omnibus/verification/spec/ --trace
+```
+
+### PR Coverage Snippet Template
+
+Include the following block in every PR description when code changes touch a Go package:
+
+```
+## Coverage
+- `components/chef-automate-collect/commands`: X.X% (baseline 4.9%)
+- `components/main-chef-wrapper/cmd`:          X.X% (baseline 56.9%)
+- Command: `go test -tags=unit -cover -count=1 ./cmd`
+```


### PR DESCRIPTION
## Summary
- Added a `## Running Tests & Coverage Locally` section to `CONTRIBUTING.md` with exact commands for both Go components and the Ruby/Omnibus suite — previously the file was a single-line redirect to another repo
- Extended `ai-track-docs/build-test.md` with a `## Coverage` section: per-package baselines, annotated tables, and a **PR Coverage Snippet Template** for future PRs
- Added `coverage.out` and `coverage.html` to `.gitignore` (these were untracked build artifacts)
- **Plan:** survey test runners → run coverage locally → document commands + baselines → add PR snippet template → commit

## Files/paths touched
- `CONTRIBUTING.md`
- `ai-track-docs/build-test.md`
- `.gitignore`

## Evidence
```
# chef-automate-collect
$ cd components/chef-automate-collect
$ go test -cover -count=1 ./commands
ok  github.com/chef/chef-workstation/components/chef-automate-collect/commands  0.655s  coverage: 4.9% of statements

# main-chef-wrapper
$ cd components/main-chef-wrapper
$ go test -tags=unit -cover -count=1 ./cmd
ok  github.com/chef/chef-workstation/components/main-chef-wrapper/cmd  0.528s  coverage: 56.9% of statements
```

## Coverage
| Component | Package | Coverage | Baseline |
|-----------|---------|----------|---------|
| chef-automate-collect | `commands/` | **4.9%** | established here |
| main-chef-wrapper | `cmd/` (unit tag) | **56.9%** | established here |
| Ruby/Omnibus | spec/ | ≥ 79% (CI-enforced) | pre-existing CI threshold |

> `chef-automate-collect` coverage is intentionally low: command bodies invoke external HTTP/IO unreachable by unit tests. The covered surface is pure-logic (env-var constants, config struct parsing, error mapping).

## Risk & Rollback
- Risk: low (doc + .gitignore only, no source code changed)
- Rollback: `git revert c182adf9`

## Review Focus
- Verify coverage commands run cleanly on your machine
- Confirm the PR snippet template in `build-test.md` matches the format you want future PRs to use
- Reviewer can run: `go test -tags=unit -cover -count=1 ./cmd` from `components/main-chef-wrapper`

## Track
- Level: Walk
- Exercise: Ex2