### PR TITLE
GHCP -- Walk: Ex3 Tiny Refactor (behavior-preserving)

### DIFF
--- a/components/main-chef-wrapper/cmd/capture.go
+++ b/components/main-chef-wrapper/cmd/capture.go
@@ -18,9 +18,6 @@
 package cmd
 
 import (
-	"os"
-
-	"github.com/chef/chef-workstation/components/main-chef-wrapper/dist"
 	"github.com/spf13/cobra"
 )
 
@@ -36,9 +33,7 @@ Captures a node's state as a local chef-repo, which can then be used to
 converge locally.
 `,
 		DisableFlagParsing: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return Runner.PassThroughCommand(dist.AnalyzeExec, "", os.Args[1:])
-		},
+		RunE:               passThroughAnalyzeCommand,
 	}
 )
 

--- a/components/main-chef-wrapper/cmd/passthrough_helpers.go
+++ b/components/main-chef-wrapper/cmd/passthrough_helpers.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/chef/chef-workstation/components/main-chef-wrapper/dist"
+	"github.com/spf13/cobra"
+)
+
+func passThroughAnalyzeCommand(_ *cobra.Command, _ []string) error {
+	return Runner.PassThroughCommand(dist.AnalyzeExec, "", os.Args[1:])
+}
+
+func passThroughWorkstationCommand(_ *cobra.Command, _ []string) error {
+	return Runner.PassThroughCommand(dist.WorkstationExec, "", os.Args[1:])
+}

--- a/components/main-chef-wrapper/cmd/report.go
+++ b/components/main-chef-wrapper/cmd/report.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/chef/chef-workstation/components/main-chef-wrapper/dist"
 	"github.com/spf13/cobra"
@@ -44,9 +43,7 @@ upgrade compatibility errors and node cookbook usage.
 
 The result is written to file.`,
 		DisableFlagParsing: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return Runner.PassThroughCommand(dist.AnalyzeExec, "", os.Args[1:])
-		},
+		RunE:               passThroughAnalyzeCommand,
 	}
 
 	reportNodesCmd = &cobra.Command{
@@ -54,27 +51,21 @@ The result is written to file.`,
 		Short: "Generates a nodes-oriented report",
 		Long: `Generates a nodes-oriented report containing basic information about the node,
 any applied policies, and the cookbooks used during the most recent chef-client run`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return Runner.PassThroughCommand(dist.AnalyzeExec, "", os.Args[1:])
-		},
+		RunE: passThroughAnalyzeCommand,
 	}
 	uploadCmd = &cobra.Command{
 		Use:    "report upload LOCATION FILE",
 		Short:  fmt.Sprintf("Upload FILE to named LOCATION for %s to review", dist.CompanyName),
 		Args:   cobra.ExactArgs(2),
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return Runner.PassThroughCommand(dist.AnalyzeExec, "", os.Args[1:])
-		},
+		RunE:   passThroughAnalyzeCommand,
 	}
 	sessionCmd = &cobra.Command{
 		Use:    "session MINUTES",
 		Hidden: true,
 		Short:  fmt.Sprintf("Creates new access credentials to upload files to %s. Expires in MINUTES.", dist.CompanyName),
 		Args:   cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return Runner.PassThroughCommand(dist.WorkstationExec, "", os.Args[1:])
-		},
+		RunE:   passThroughWorkstationCommand,
 	}
 )
 


### PR DESCRIPTION
## Summary
- Refactored repeated passthrough RunE closures in command definitions into shared helpers to reduce duplication while preserving behavior.
- Kept scope intentionally small (3 files) and reversible.
- Plan (inline):
  1. Add shared helpers in components/main-chef-wrapper/cmd/passthrough_helpers.go.
  2. Replace inline closures in capture.go with helper.
  3. Replace inline closures in report.go with helper.
  4. Run tests + lint and record evidence.

## Files/paths touched
- components/main-chef-wrapper/cmd/passthrough_helpers.go
- components/main-chef-wrapper/cmd/capture.go
- components/main-chef-wrapper/cmd/report.go

## Evidence
- Tests/logs/metrics:
```bash
# changed package unit tests
cd components/main-chef-wrapper
go test -tags=unit ./cmd -count=1
# PASS

# integration tests documented by module
cd components/main-chef-wrapper
go test -tags=integration ./integration -count=1
# PASS

# wider module test sweep (shows pre-existing issue outside changed files)
cd components/main-chef-wrapper
go test ./... -count=1
# FAIL in main package only:
#   ./main.go:70:14: non-constant format string in call to log.Fatalf
#   ./main.go:91:14: non-constant format string in call to log.Fatalf
#   ./main_test.go:35:35: non-constant format string in call to fmt.Fprintf
# cmd/, integration/, and lib/ packages pass

# second module sweep (environment-related integration failure; unrelated to refactor)
cd components/chef-automate-collect
go test ./... -count=1
# FAIL in integration/help tests:
# exec: "chef-automate-collect_darwin_arm64": executable file not found in $PATH
# commands package passes

# lint baseline command
cd <repo-root>
bundle exec rake style
# FAIL: missing local gem dependency (chef-cli); requires bundle install
```
- Coverage: Not applicable for this refactor PR (behavior-preserving extraction only). Existing baseline coverage unchanged.

## Risk & Rollback
- Risk: low
- Rollback: revert 86bac326

## Review Focus
- Verify RunE behavior remains passthrough-only with os.Args[1:].
- Confirm no command target changed (AnalyzeExec vs WorkstationExec).
- Re-run:
  - cd components/main-chef-wrapper && go test -tags=unit ./cmd -count=1
  - cd components/main-chef-wrapper && go test -tags=integration ./integration -count=1

## Track
- Level: Walk
- Exercise: Ex3
