### PR TITLE
GHCP -- Walk: Ex4 Documentation Sync (CONTRIBUTING and Onboarding)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,60 @@ Workstation follows the contributing process detailed in the `chef` project's CO
 
 Please refer to CONTRIBUTING.md for the `chef` project: https://github.com/chef/chef/blob/main/CONTRIBUTING.md
 
+## Walk Track Workflow (Plan-First, Evidence-Backed)
+
+Use this section for AI Track "Walk" exercises and small incremental refactors.
+
+### Branching Strategy (stacked PRs)
+
+Create each new exercise branch from the previous exercise branch so each PR shows a single logical delta.
+
+- Ex1: `learn/walk/neha-p6-ex1` based on the final crawl branch
+- Ex2: `learn/walk/neha-p6-ex2` based on Ex1
+- Ex3: `learn/walk/neha-p6-ex3` based on Ex2
+- ExN: based on Ex(N-1)
+
+PR base targets should follow the same chain:
+
+- Ex1 PR base: previous crawl branch (or `main` if requested)
+- ExN PR base: `learn/walk/neha-p6-ex(N-1)`
+
+### Plan-First Rule
+
+Before generating diffs, write a short implementation plan that includes:
+
+- files to change (2-4 files for tiny refactors)
+- reason for each change
+- expected behavior impact (usually none for refactors)
+- validation commands you will run
+
+### PR Expectations
+
+Keep PRs small, reversible, and evidence-backed.
+
+- Include plan summary in PR body
+- Include exact commands executed and short output summary
+- Include coverage percentage when the exercise requires it
+- Include risk and rollback (revert commit SHA)
+- Keep secrets out of prompts, logs, and commits
+- Exclude `vendor/` and submodule paths from edits
+- Use signed commits (`git commit -s`)
+
+Recommended title format:
+
+- `GHCP -- Walk: Ex<no> <short name>`
+
+### Copilot Usage For Walk Exercises
+
+When collaborating with Copilot, request this sequence explicitly:
+
+1. Propose a plan (files, reason, impact)
+2. Generate diffs file-by-file according to the plan
+3. Run tests/lint and summarize outputs
+4. Draft PR description with evidence and rollback details
+
+If a full suite fails due to known environment gaps, include the failure output and identify whether the failure is pre-existing or unrelated to the current diff.
+
 ## Running Tests & Coverage Locally
 
 This repo contains two Go components, each with its own module and test suite.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Chef Workstation installs everything you need to get started using Chef products
 
 We use Omnibus to describe our packaging. Please review [chef-workstation/omnibus/README.MD](https://github.com/chef/chef-workstation/tree/main/omnibus) for further details.
 
+## Contributor Walk Track Docs
+
+- Walk workflow guidance: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Copilot onboarding prompt: [ai-track-docs/onboarding-walk.md](ai-track-docs/onboarding-walk.md)
+
 ## Copyright and License
 
 Code released under the [Apache license](LICENSE). Images and any trademarked content are Copyright 2018 by [Chef Software, Inc.](https://www.chef.io).

--- a/ai-track-docs/onboarding-walk.md
+++ b/ai-track-docs/onboarding-walk.md
@@ -1,0 +1,59 @@
+# Walk Track Onboarding Prompt
+
+Paste the prompt below into Copilot Chat to start a Walk exercise with the expected workflow.
+
+```text
+You are helping with Chef Workstation AI Track "Walk" exercises.
+
+Follow these rules:
+1. Plan first, then diffs.
+2. Keep each exercise PR small and reversible.
+3. Use stacked branches and stacked PR bases:
+   - Ex1 based on previous crawl branch
+   - ExN based on Ex(N-1)
+4. Exclude vendor and submodules from edits.
+5. Do not include secrets in prompts, logs, or commits.
+6. Use signed commits.
+7. Run validation commands and include output summary in PR body.
+
+For this exercise, do the following in order:
+1. Inspect existing files and propose a short plan:
+   - files to change
+   - reason for each file
+   - expected behavior impact
+   - validation commands
+2. Generate diffs file-by-file according to the plan.
+3. Run tests/lint; report PASS/FAIL with key output.
+4. Open/update a draft PR using this template:
+
+Title: GHCP -- Walk: <ex#> <name>
+
+Summary
+- What changed and why
+- Plan: <inline summary>
+- Files/paths touched
+
+Evidence
+- Tests/logs/metrics: <commands + output summary>
+- Coverage: <percentage or contract evidence>
+
+Risk & Rollback
+- Risk: low/medium
+- Rollback: revert <commit SHA>
+
+Review Focus
+- Key areas for reviewer attention
+- Verification steps reviewer can run
+
+Track
+- Level: Walk
+- Exercise: <ex#>
+
+When tests fail, diagnose first and state whether the failure is pre-existing or caused by this diff.
+```
+
+## Quick Branch/PR Reference
+
+- Branch naming: `learn/walk/neha-p6-ex<no>`
+- Ex1 PR base: previous crawl branch (or `main` if requested)
+- ExN PR base: `learn/walk/neha-p6-ex<no-1>`


### PR DESCRIPTION
## Summary
- Added a Walk-specific workflow section to CONTRIBUTING with plan-first expectations, stacked branch/PR strategy, PR evidence requirements, and Copilot collaboration flow.
- Added a concise onboarding prompt at ai-track-docs/onboarding-walk.md that new contributors can paste directly into Copilot Chat.
- Linked both docs from README under a new Contributor Walk Track Docs section.
- Plan: (1) inspect CONTRIBUTING and README gaps, (2) add Walk section without replacing existing content, (3) add one-page onboarding prompt, (4) link docs in README.

## Files/paths touched
- CONTRIBUTING.md
- ai-track-docs/onboarding-walk.md
- README.md

## Evidence
- Tests/logs/metrics:
  - Doc-only change; no code path modified.
  - Verified rendered diff locally with:
    - git diff -- CONTRIBUTING.md README.md ai-track-docs/onboarding-walk.md
- Coverage: Not applicable (documentation-only PR).

## Risk & Rollback
- Risk: low
- Rollback: revert 02488dcb

## Review Focus
- Confirm Walk section in CONTRIBUTING is additive and does not conflict with upstream chef contributing model.
- Confirm onboarding prompt is concise and copy/paste ready for Copilot Chat.
- Confirm README links resolve to the new onboarding document and CONTRIBUTING guidance.

## Track
- Level: Walk
- Exercise: Ex4
