### PR TITLE
GHCP -- Walk: Ex5 API/Contract Hardening (Boundary Contract Test)

### DIFF
--- a/.github/workflows/contract-rollout-validation.yml
+++ b/.github/workflows/contract-rollout-validation.yml
@@ -1,0 +1,34 @@
+permissions:
+  contents: read
+
+name: Contract - Rollout Validation
+
+on:
+  pull_request:
+    paths:
+      - 'components/main-chef-wrapper/cmd/push.go'
+      - 'components/main-chef-wrapper/cmd/push_contract_test.go'
+      - '.github/workflows/contract-rollout-validation.yml'
+  push:
+    paths:
+      - 'components/main-chef-wrapper/cmd/push.go'
+      - 'components/main-chef-wrapper/cmd/push_contract_test.go'
+      - '.github/workflows/contract-rollout-validation.yml'
+
+jobs:
+  rollout-contract-test:
+    name: Rollout env contract
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: components/main-chef-wrapper
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: components/main-chef-wrapper/go.mod
+
+      - name: Run rollout contract test
+        run: go test -tags=unit ./cmd -run TestValidateRolloutSetupContract -count=1 -v

--- a/components/main-chef-wrapper/cmd/push_contract_test.go
+++ b/components/main-chef-wrapper/cmd/push_contract_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStderrForRolloutValidation(t *testing.T) (func(), func() string) {
+	t.Helper()
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+
+	os.Stderr = w
+
+	restore := func() {
+		_ = w.Close()
+		os.Stderr = origStderr
+	}
+
+	readOutput := func() string {
+		b, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("failed to read stderr output: %v", err)
+		}
+		_ = r.Close()
+		return strings.TrimSpace(string(b))
+	}
+
+	return restore, readOutput
+}
+
+func setValidRolloutEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CHEF_AC_SERVER_URL", "https://example-chef-server")
+	t.Setenv("CHEF_AC_SERVER_USER", "test-user")
+	t.Setenv("CHEF_AC_AUTOMATE_URL", "https://example-automate")
+	t.Setenv("CHEF_AC_AUTOMATE_TOKEN", "token-value")
+}
+
+func TestValidateRolloutSetupContract(t *testing.T) {
+	t.Run("returns true when all required vars exist", func(t *testing.T) {
+		setValidRolloutEnv(t)
+
+		restore, readOutput := captureStderrForRolloutValidation(t)
+		got := ValidateRolloutSetup()
+		restore()
+		stderr := readOutput()
+
+		if !got {
+			t.Fatalf("expected rollout setup validation to pass when all vars are set")
+		}
+		if stderr != "" {
+			t.Fatalf("expected empty stderr when validation passes, got %q", stderr)
+		}
+	})
+
+	tests := []struct {
+		name         string
+		missingVar   string
+		expectStderr string
+	}{
+		{
+			name:         "missing CHEF_AC_SERVER_URL",
+			missingVar:   "CHEF_AC_SERVER_URL",
+			expectStderr: "ERROR: CHEF_AC_SERVER_URL environment variable must be set for rollout reporting",
+		},
+		{
+			name:         "missing CHEF_AC_SERVER_USER",
+			missingVar:   "CHEF_AC_SERVER_USER",
+			expectStderr: "ERROR: CHEF_AC_SERVER_USER environment variable must be set for rollout reporting",
+		},
+		{
+			name:         "missing CHEF_AC_AUTOMATE_URL",
+			missingVar:   "CHEF_AC_AUTOMATE_URL",
+			expectStderr: "ERROR: CHEF_AC_AUTOMATE_URL environment variable must be set for rollout reporting",
+		},
+		{
+			name:         "missing CHEF_AC_AUTOMATE_TOKEN",
+			missingVar:   "CHEF_AC_AUTOMATE_TOKEN",
+			expectStderr: "ERROR: CHEF_AC_AUTOMATE_TOKEN environment variable must be set for rollout reporting",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setValidRolloutEnv(t)
+			t.Setenv(tc.missingVar, "")
+
+			restore, readOutput := captureStderrForRolloutValidation(t)
+			got := ValidateRolloutSetup()
+			restore()
+			stderr := readOutput()
+
+			if got {
+				t.Fatalf("expected rollout setup validation to fail when %s is missing", tc.missingVar)
+			}
+			if stderr != tc.expectStderr {
+				t.Fatalf("contract mismatch for %s\nexpected: %q\nactual:   %q", tc.missingVar, tc.expectStderr, stderr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Added a boundary contract test for rollout validation in `components/main-chef-wrapper/cmd/push_contract_test.go`.
- Contract surface: `ValidateRolloutSetup()` behavior when required env vars are present/missing.
- Added CI workflow `.github/workflows/contract-rollout-validation.yml` to run this contract test automatically on relevant changes.
- Plan: (1) identify boundary lacking contract validation, (2) add deterministic contract assertions, (3) run locally, (4) integrate into CI.

## Files/paths touched
- `components/main-chef-wrapper/cmd/push_contract_test.go`
- `.github/workflows/contract-rollout-validation.yml`

## Evidence
- Tests/logs/metrics:
```bash
cd components/main-chef-wrapper
go test -tags=unit ./cmd -run TestValidateRolloutSetupContract -count=1 -v
```
Output summary:
- PASS: `returns true when all required vars exist`
- PASS: missing var cases for all four required rollout env vars
- PASS overall (`ok .../cmd`)
- Coverage: Contract test focused; no coverage baseline change required for this exercise.

## Contract Update Instructions
If rollout env requirements or error text intentionally change:
1. Update expected stderr strings and/or required variable cases in `components/main-chef-wrapper/cmd/push_contract_test.go`.
2. Re-run:
   - `cd components/main-chef-wrapper`
   - `go test -tags=unit ./cmd -run TestValidateRolloutSetupContract -count=1 -v`
3. Confirm CI `Contract - Rollout Validation` is green.

## Risk & Rollback
- Risk: low (test + workflow only)
- Rollback: revert `f3f9985e`

## Review Focus
- Verify contract assertions match current behavior of `ValidateRolloutSetup()`.
- Verify CI path filters are scoped and do not over-trigger.
- Reviewer command:
  - `cd components/main-chef-wrapper && go test -tags=unit ./cmd -run TestValidateRolloutSetupContract -count=1 -v`

## Track
- Level: Walk
- Exercise: Ex5
