### PR TITLE
GHCP -- Walk: Ex6 Performance Touch-point (Micro-Optimization with Evidence)

### DIFF
--- a/components/chef-automate-collect/commands/cli_io.go
+++ b/components/chef-automate-collect/commands/cli_io.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -48,17 +49,24 @@ func (c *CLIIO) structuredVerbose(op string, status string, elapsed time.Duratio
 }
 
 func structuredLogLine(op string, status string, elapsed time.Duration, fields ...StructuredField) string {
-	parts := []string{
-		fmt.Sprintf("op=%s", op),
-		fmt.Sprintf("status=%s", status),
-		fmt.Sprintf("elapsed_ms=%d", elapsed.Milliseconds()),
-	}
+	buf := strings.Builder{}
+	buf.Grow(32 + len(op) + len(status) + len(fields)*16)
+
+	buf.WriteString("op=")
+	buf.WriteString(op)
+	buf.WriteString(" status=")
+	buf.WriteString(status)
+	buf.WriteString(" elapsed_ms=")
+	buf.WriteString(strconv.FormatInt(elapsed.Milliseconds(), 10))
 
 	for _, field := range fields {
-		parts = append(parts, fmt.Sprintf("%s=%s", field.Key, field.Value))
+		buf.WriteByte(' ')
+		buf.WriteString(field.Key)
+		buf.WriteByte('=')
+		buf.WriteString(field.Value)
 	}
 
-	return strings.Join(parts, " ")
+	return buf.String()
 }
 
 func newlineify(s string) string {

--- a/components/chef-automate-collect/commands/cli_io_test.go
+++ b/components/chef-automate-collect/commands/cli_io_test.go
@@ -5,6 +5,22 @@ import (
 	"time"
 )
 
+func BenchmarkStructuredLogLine(b *testing.B) {
+	fields := []StructuredField{
+		{Key: "config_paths", Value: "3"},
+		{Key: "source", Value: "repo"},
+		{Key: "result", Value: "ok"},
+		{Key: "module", Value: "automate_config"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = structuredLogLine("config_load", "success", 37*time.Millisecond, fields...)
+	}
+}
+
 func TestStructuredLogLineIncludesRequiredFields(t *testing.T) {
 	got := structuredLogLine("config_load", "success", 12*time.Millisecond,
 		StructuredField{Key: "config_paths", Value: "2"})


### PR DESCRIPTION
## Summary
- Optimized the `structuredLogLine` hot path in `components/chef-automate-collect/commands/cli_io.go`.
- Replaced `fmt.Sprintf` + slice append + `strings.Join` with a pre-sized `strings.Builder` and direct writes.
- Added benchmark `BenchmarkStructuredLogLine` in `components/chef-automate-collect/commands/cli_io_test.go` to capture before/after evidence.
- Plan: identify hot formatter path, benchmark baseline, optimize safely, re-measure, and verify behavior with tests.

## Files/paths touched
- `components/chef-automate-collect/commands/cli_io.go`
- `components/chef-automate-collect/commands/cli_io_test.go`

## Evidence
- Baseline command:
```bash
cd components/chef-automate-collect
go test ./commands -run '^$' -bench BenchmarkStructuredLogLine -benchmem -count=5
```
Baseline summary (avg):
- `~462 ns/op`
- `680 B/op`
- `20 allocs/op`

- After command:
```bash
cd components/chef-automate-collect
go test ./commands -run '^$' -bench BenchmarkStructuredLogLine -benchmem -count=5
```
After summary (avg):
- `~57.9 ns/op`
- `128 B/op`
- `1 allocs/op`

Approximate improvement:
- Latency: ~87% faster
- Allocations: 20 -> 1 (~95% fewer)
- Bytes allocated: 680 -> 128 (~81% fewer)

Behavior regression checks:
```bash
cd components/chef-automate-collect
go test ./commands -run '^TestStructuredLogLine|TestStructuredLoggingEnabled' -count=1
go test ./commands -count=1
```
Both passed.

- Coverage: Not required for this performance touch-point; benchmark + tests provide safety evidence.

## Why This Is Safe
- Output contract is preserved by existing assertions in `TestStructuredLogLineIncludesRequiredFields` and `TestStructuredLogLinePreservesFieldOrder`.
- The optimization only changes string construction mechanics, not field order, field names, or gating logic.

## Risk & Rollback
- Risk: low
- Rollback: revert `68fe6457`

## Review Focus
- Confirm generated log line format is unchanged.
- Confirm benchmark harness is deterministic and focused.
- Re-run:
  - `cd components/chef-automate-collect && go test ./commands -run '^$' -bench BenchmarkStructuredLogLine -benchmem -count=5`

## Track
- Level: Walk
- Exercise: Ex6
