### PR TITLE
GHCP -- Walk: Ex8 Security and Secrets (Security Scan Improvement)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,24 @@
+permissions:
+  contents: read
+
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  gitleaks:
+    name: Gitleaks workspace scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ARGS: detect --source . --no-git --verbose

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,10 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install gitleaks CLI
+        run: |
+          set -euo pipefail
+          version="8.30.1"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" -o /tmp/gitleaks.tgz
+          tar -xzf /tmp/gitleaks.tgz -C /tmp
+          chmod +x /tmp/gitleaks
+          echo "/tmp" >> "$GITHUB_PATH"
+
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
-          GITLEAKS_CONFIG: .gitleaks.toml
-          GITLEAKS_ARGS: detect --source . --no-git --verbose
+        run: gitleaks detect --source . --no-git --config .gitleaks.toml --redact --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+title = "chef-workstation gitleaks config"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Known non-production licensing API key fixture used for workstation licensing acceptance tests"
+paths = [
+  '''components/main-chef-wrapper/dist/licensingConfig.json''',
+]
+regexes = [
+  '''yDblv75Xt84wULmc8qTM88a3Dr2OuuKxa6GDXxH5''',
+]

--- a/ai-track-docs/security-secrets.md
+++ b/ai-track-docs/security-secrets.md
@@ -46,3 +46,31 @@ cd components/chef-automate-collect
 go test ./commands -run 'TestRedactSecretForLog|TestGitRemoteNameFromEnv|TestEnvironmentVariableConstantsStable' -count=1 -v
 go build ./...
 ```
+
+## Secret Scanning Baseline (Walk Ex8)
+
+Lightweight repository scanning is now part of CI via:
+
+- `.github/workflows/secret-scan.yml`
+
+This workflow runs Gitleaks against the checked-out workspace (`detect --source . --no-git`) and fails the job when new findings are detected.
+
+### Local Command
+
+```sh
+gitleaks detect --source . --no-git --config .gitleaks.toml
+```
+
+### Findings Remediated
+
+- Replaced test-only key-like placeholder values in `components/main-chef-wrapper/main_test.go` with `test-token-not-secret`.
+
+### Justified Ignore
+
+`.gitleaks.toml` includes a narrow allowlist entry for:
+
+- `components/main-chef-wrapper/dist/licensingConfig.json`
+
+Reason: this file contains a known non-production licensing acceptance fixture value required by workstation licensing configuration, not a developer credential.
+
+If this fixture changes, update the allowlist entry and rerun the local command above before opening a PR.

--- a/components/main-chef-wrapper/main_test.go
+++ b/components/main-chef-wrapper/main_test.go
@@ -57,7 +57,7 @@ func Test_ValidateRolloutSetup(t *testing.T) {
 	os.Setenv("CHEF_AC_SERVER_URL", "http://testhost")
 	os.Setenv("CHEF_AC_SERVER_USER", "testuser")
 	os.Setenv("CHEF_AC_AUTOMATE_URL", "http://testhost2")
-	os.Setenv("CHEF_AC_AUTOMATE_TOKEN", "xyz123455677709u0")
+	os.Setenv("CHEF_AC_AUTOMATE_TOKEN", "test-token-not-secret")
 	got := cmd.ValidateRolloutSetup()
 	assert.Equal(t, got, true)
 }
@@ -74,7 +74,7 @@ func Test_ValidateRolloutSetup(t *testing.T) {
 //	// all are set except CHEF_AC_SERVER_URL
 //	os.Setenv("CHEF_AC_SERVER_USER", "testuser")
 //	os.Setenv("CHEF_AC_AUTOMATE_URL", "http://testhost2")
-//	os.Setenv("CHEF_AC_AUTOMATE_TOKEN", "xyz123455677709u0")
+//	os.Setenv("CHEF_AC_AUTOMATE_TOKEN", "test-token-not-secret")
 //	got = cmd.ValidateRolloutSetup()
 //	assert.Equal(t, got, false)
 //
@@ -118,7 +118,7 @@ func Test_ValidateRolloutSetup(t *testing.T) {
 //
 //	os.Setenv("CHEF_AC_SERVER_USER", "testuser")
 //	os.Setenv("CHEF_AC_AUTOMATE_URL", "http://testhost2")
-//	os.Setenv("CHEF_AC_AUTOMATE_TOKEN", "xyz123455677709u0")
+//	os.Setenv("CHEF_AC_AUTOMATE_TOKEN", "test-token-not-secret")
 //	cmd = getAction("push")
 //	assert.Equal(t, cmd, "policy-rollout")
 //


### PR DESCRIPTION
## Summary
- Added lightweight secret scanning to CI via Gitleaks workflow.
- Added `.gitleaks.toml` with a narrow, documented allowlist for one known non-production fixture value.
- Remediated scanner findings in tests by replacing key-like placeholder tokens.
- Updated security notes with scan process, local command, remediation, and allowlist rationale.
- Plan: evaluate current scanning, add CI scan step, remediate findings, document process and justified ignore.

## Files/paths touched
- `.github/workflows/secret-scan.yml`
- `.gitleaks.toml`
- `components/main-chef-wrapper/main_test.go`
- `ai-track-docs/security-secrets.md`

## Evidence
Baseline scan (before):
```bash
gitleaks detect --source . --no-git --report-format json --report-path /tmp/gitleaks_ex8.json
# leaks found: 4
```
Baseline findings summary:
- 3 findings in `components/main-chef-wrapper/main_test.go` (test token placeholder pattern)
- 1 finding in `components/main-chef-wrapper/dist/licensingConfig.json` (known non-production licensing fixture)

After remediation/config:
```bash
gitleaks detect --source . --no-git --config .gitleaks.toml --report-format json --report-path /tmp/gitleaks_ex8_after.json
# no leaks found
```

Security improvements made:
- Replaced test-only token values in `main_test.go` with `test-token-not-secret`.
- Added CI workflow to run scan on pull requests and main pushes.

Coverage: Not applicable (security configuration/test-data hygiene change).

## Risk & Rollback
- Risk: low
- Rollback: revert `0d4b1106`

## Justified Ignore
- `.gitleaks.toml` allowlists only `components/main-chef-wrapper/dist/licensingConfig.json` with a specific known fixture value.
- Justification: value is a non-production licensing acceptance fixture required by workstation licensing config, not a developer credential.

## Review Focus
- Confirm allowlist is narrow (single file + exact value) and not broad.
- Confirm CI workflow fails on future findings.
- Re-run locally:
  - `gitleaks detect --source . --no-git --config .gitleaks.toml`

## Track
- Level: Walk
- Exercise: Ex8
