### PR TITLE
GHCP -- Walk: Ex9 Observability Enhancement

### DIFF
--- a/ai-track-docs/logging.md
+++ b/ai-track-docs/logging.md
@@ -20,13 +20,30 @@ Required fields:
 Current structured logging path:
 
 - `ConfigLoader.Load()` in `components/chef-automate-collect/commands/automate_config.go`
+- `AutomateConfig.Test()` HTTP boundary in `components/chef-automate-collect/commands/automate_config.go`
 
 Example log lines:
 
 ```text
 op=config_load status=success elapsed_ms=4 config_paths=2
 op=config_load status=error elapsed_ms=1 path=/tmp/bad.toml error=decode_toml
+op=test_config_http status=success elapsed_ms=23 status_code=200
 ```
+
+## New Observability Hook (Walk Ex9)
+
+Instrumentation point:
+
+- `AutomateConfig.Test()` request to Automate test endpoint (`test-config` command).
+
+New structured event fields:
+
+- `op=test_config_http`
+- `status=success|error`
+- `elapsed_ms=<request duration>`
+- `status_code=<HTTP status code>` (present when a response is received)
+
+This gives operators a direct latency and outcome signal for the test-config network boundary without exposing secrets.
 
 ## How To View Logs
 
@@ -53,6 +70,19 @@ cd components/chef-automate-collect
 go run . test-config -v
 ```
 
+To verify format via tests:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run TestAutomateConfigTestEmitsStructuredHTTPLog -count=1 -v
+```
+
+Expected `-v` output includes a logged line containing:
+
+```text
+op=test_config_http status=success ... status_code=200
+```
+
 Because verbose output goes to `stderr`, you can separate it from normal output if needed:
 
 ```sh
@@ -67,3 +97,8 @@ go run . show-config -v 2>verbose.log
 - Do not include secrets in structured fields.
 - Prefer logging at boundary operations such as config loading, HTTP calls, and external command execution.
 - Use `CHEF_AC_STRUCTURED_LOGS=false` as a low-risk rollback toggle if a new structured log shape causes operator friction.
+
+## Where To View In Staging/Production
+
+When `test-config` is run with `-v`, the structured event is emitted to stderr by `chef-automate-collect`.
+In deployed environments, view this in command stderr logs (for example, CI step logs, container stderr stream, or host process logs that collect stderr).

--- a/components/chef-automate-collect/commands/automate_config.go
+++ b/components/chef-automate-collect/commands/automate_config.go
@@ -529,14 +529,17 @@ func (a *AutomateConfig) Test() error {
 	tr := httputils.NewDefaultTransport()
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: a.InsecureTLS}
 	httpClient := &http.Client{Transport: tr}
+	start := time.Now()
 
 	testURL, err := a.TestURL()
 	if err != nil {
+		emitTestConfigHTTPStructuredLog(start, "error", 0)
 		return err
 	}
 
 	req, err := http.NewRequest("POST", testURL.String(), nil)
 	if err != nil {
+		emitTestConfigHTTPStructuredLog(start, "error", 0)
 		return err
 	}
 
@@ -570,6 +573,7 @@ func (a *AutomateConfig) Test() error {
 
 	response, err := httpClient.Do(req)
 	if err != nil {
+		emitTestConfigHTTPStructuredLog(start, "error", 0)
 		return err
 	}
 	defer func() {
@@ -589,10 +593,22 @@ func (a *AutomateConfig) Test() error {
 	cliIO.verbose("\nEND HTTP RESPONSE BODY--------")
 
 	if response.StatusCode != 200 {
+		emitTestConfigHTTPStructuredLog(start, "error", response.StatusCode)
 		return mapTestConfigHTTPError(a.URL, response.StatusCode, string(bodyBytes))
 	}
 
+	emitTestConfigHTTPStructuredLog(start, "success", response.StatusCode)
+
 	return nil
+}
+
+func emitTestConfigHTTPStructuredLog(start time.Time, status string, statusCode int) {
+	fields := []StructuredField{}
+	if statusCode > 0 {
+		fields = append(fields, StructuredField{Key: "status_code", Value: fmt.Sprintf("%d", statusCode)})
+	}
+
+	cliIO.structuredVerbose("test_config_http", status, time.Since(start), fields...)
 }
 
 func mapTestConfigHTTPError(baseURL string, statusCode int, responseBody string) error {

--- a/components/chef-automate-collect/commands/automate_config_test.go
+++ b/components/chef-automate-collect/commands/automate_config_test.go
@@ -1,9 +1,87 @@
 package commands
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
+
+func captureStderrForTestConfig(t *testing.T) (func(), func() string) {
+	t.Helper()
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+
+	os.Stderr = w
+
+	restore := func() {
+		_ = w.Close()
+		os.Stderr = origStderr
+	}
+
+	readOutput := func() string {
+		b, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("failed to read stderr output: %v", err)
+		}
+		_ = r.Close()
+		return string(b)
+	}
+
+	return restore, readOutput
+}
+
+func TestAutomateConfigTestEmitsStructuredHTTPLog(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != TestCreateURLPath {
+			t.Fatalf("unexpected path: got %q want %q", r.URL.Path, TestCreateURLPath)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	c := &AutomateConfig{
+		URL:         server.URL,
+		authToken:   "test-token-not-secret",
+		InsecureTLS: true,
+	}
+
+	originalVerbose := cliIO.EnableVerbose
+	cliIO.EnableVerbose = true
+	defer func() {
+		cliIO.EnableVerbose = originalVerbose
+	}()
+
+	t.Setenv(StructuredLogsEnvVar, "true")
+
+	restore, readOutput := captureStderrForTestConfig(t)
+	err := c.Test()
+	restore()
+	output := readOutput()
+
+	if err != nil {
+		t.Fatalf("expected test-config request to succeed, got error: %v", err)
+	}
+
+	t.Logf("captured structured output: %s", strings.TrimSpace(output))
+
+	if !strings.Contains(output, "op=test_config_http") {
+		t.Fatalf("expected structured op field in output, got %q", output)
+	}
+	if !strings.Contains(output, "status=success") {
+		t.Fatalf("expected success status field in output, got %q", output)
+	}
+	if !strings.Contains(output, "status_code=200") {
+		t.Fatalf("expected status_code field in output, got %q", output)
+	}
+}
 
 func TestRedactSecretForLogRedactsNonEmptySecrets(t *testing.T) {
 	secret := "super-secret-token"


### PR DESCRIPTION
## Summary
- Added a new structured observability hook at the HTTP boundary in `AutomateConfig.Test()` (used by `test-config`).
- New event records request outcome and latency without exposing secrets.
- Added test coverage that verifies the structured event is emitted and includes expected fields.
- Updated logging docs with verification steps and where to view the new instrumentation in staging/production.
- Plan: identify boundary, add lightweight structured log hook, verify via local output + tests, document viewing instructions.

## Files/paths touched
- `components/chef-automate-collect/commands/automate_config.go`
- `components/chef-automate-collect/commands/automate_config_test.go`
- `ai-track-docs/logging.md`

## Evidence
Verification command:
```bash
cd components/chef-automate-collect
go test ./commands -run TestAutomateConfigTestEmitsStructuredHTTPLog -count=1 -v
```
Captured output includes:
```text
op=test_config_http status=success elapsed_ms=4 status_code=200
```
Regression check:
```bash
cd components/chef-automate-collect
go test ./commands -count=1
```
Result: PASS.

Coverage: Existing command package tests remain green; this change adds observability + tests only.

## Verification Instructions
Local:
- `cd components/chef-automate-collect && go run . test-config -v`
- Look at stderr for `op=test_config_http ... status_code=<code>`

Production/Staging:
- Run `chef-automate-collect test-config -v` in the target environment.
- View stderr logs (CI step logs, container stderr stream, or host process logs collecting stderr).
- Confirm presence of `op=test_config_http` event with `status`, `elapsed_ms`, and `status_code`.

## Risk & Rollback
- Risk: low
- Rollback: revert `ce60c401`

## Review Focus
- Confirm no secrets are added to structured fields.
- Confirm success/error paths both emit `test_config_http` with latency.
- Re-run verification command above and inspect emitted event.

## Track
- Level: Walk
- Exercise: Ex9
