### PR TITLE
GHCP -- Walk: Ex10 CI/CD Baseline (CI Soft Gating)

### DIFF
--- a/.github/workflows/soft-evidence-summary.yml
+++ b/.github/workflows/soft-evidence-summary.yml
@@ -1,0 +1,65 @@
+permissions:
+  contents: read
+
+name: CI Soft Evidence Summary
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  soft-coverage-summary:
+    name: Soft coverage summary (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: components/main-chef-wrapper/go.mod
+
+      - name: Collect coverage evidence (non-blocking)
+        shell: bash
+        run: |
+          set +e
+
+          output="$(cd components/main-chef-wrapper && go test -tags=unit -cover -count=1 ./cmd 2>&1)"
+          cmd_exit=$?
+
+          coverage="$(printf "%s\n" "$output" | sed -n 's/.*coverage: \([0-9.]*%\) of statements.*/\1/p' | tail -1)"
+          if [[ -z "$coverage" ]]; then
+            coverage="N/A"
+          fi
+
+          if [[ $cmd_exit -eq 0 ]]; then
+            status="PASS"
+          else
+            status="SOFT-FAIL"
+          fi
+
+          {
+            echo "## Soft Gate Evidence"
+            echo
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Validation | main-chef-wrapper unit coverage |"
+            echo "| Status | ${status} (advisory) |"
+            echo "| Coverage | ${coverage} |"
+            echo "| Command | \`cd components/main-chef-wrapper && go test -tags=unit -cover -count=1 ./cmd\` |"
+            echo
+            echo "This job is intentionally non-blocking and provides evidence only."
+            echo
+            echo "### Command Output"
+            echo '```text'
+            printf "%s\n" "$output"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "=== SOFT GATE SUMMARY ==="
+          echo "status=${status} coverage=${coverage}"
+          printf "%s\n" "$output"
+
+          # Always succeed: this is advisory-only by design.
+          exit 0

--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -101,3 +101,37 @@ Include the following block in every PR description when code changes touch a Go
 - `components/main-chef-wrapper/cmd`:          X.X% (baseline 56.9%)
 - Command: `go test -tags=unit -cover -count=1 ./cmd`
 ```
+
+---
+
+## CI Soft Gating (Walk Ex10)
+
+Workflow: `.github/workflows/soft-evidence-summary.yml`
+
+Purpose:
+
+- Publish validation evidence in GitHub Actions Job Summary.
+- Stay advisory-only (non-blocking) even if the coverage command fails.
+
+Current soft gate metric:
+
+- `components/main-chef-wrapper/cmd` unit coverage using:
+	- `cd components/main-chef-wrapper && go test -tags=unit -cover -count=1 ./cmd`
+
+Where to view in CI:
+
+1. Open the **CI Soft Evidence Summary** workflow run.
+2. Open job **Soft coverage summary (advisory)**.
+3. Read the **Soft Gate Evidence** section in Job Summary.
+
+Local equivalent command:
+
+```sh
+cd components/main-chef-wrapper
+go test -tags=unit -cover -count=1 ./cmd
+```
+
+Expected behavior:
+
+- Job always passes by design.
+- Summary shows `Status=PASS` or `Status=SOFT-FAIL` and includes raw command output for reviewer context.


### PR DESCRIPTION
## Summary
- Added a non-blocking CI soft gate workflow that posts validation evidence to GitHub Job Summary.
- The job runs unit coverage for `components/main-chef-wrapper/cmd`, records status/coverage/command output, and **always exits 0** (advisory only).
- Documented where to view this evidence and the local equivalent command in `ai-track-docs/build-test.md`.
- Plan: identify CI insertion point, add advisory-only summary job, ensure it never blocks merges, trigger pipeline, include real run evidence.

## Files/paths touched
- `.github/workflows/soft-evidence-summary.yml`
- `ai-track-docs/build-test.md`

## Evidence
Triggered workflow run:
- Workflow: `CI Soft Evidence Summary`
- Run URL: `https://github.com/chef/chef-workstation/actions/runs/26226493154`
- Status: `completed / success`

Job log excerpt:
```text
=== SOFT GATE SUMMARY ===
status=PASS coverage=65.9%
...
coverage: 65.9% of statements
```

Summary output fields written by workflow:
- Validation target
- Advisory status (`PASS` or `SOFT-FAIL`)
- Coverage percentage
- Command executed
- Raw command output block

## CI Non-Blocking Guarantee
- The evidence step is explicitly advisory and ends with `exit 0`.
- Even if the coverage command fails, the job still publishes summary evidence and does not block merges.

## Instructions
Where to view evidence in CI:
1. Open workflow run **CI Soft Evidence Summary**.
2. Open job **Soft coverage summary (advisory)**.
3. Read **Soft Gate Evidence** in Job Summary.

Local equivalent:
```sh
cd components/main-chef-wrapper
go test -tags=unit -cover -count=1 ./cmd
```

## Risk & Rollback
- Risk: low
- Rollback: revert `18bdadf4`

## Review Focus
- Confirm advisory-only behavior is preserved.
- Confirm summary content remains readable and useful for reviewers.
- Confirm docs in `build-test.md` match workflow behavior.

## Track
- Level: Walk
- Exercise: Ex10
