### PR TITLE
GHCP -- Walk: Ex11 PR Hygiene and Review (PR Review Focus)

### DIFF
--- a/ai-track-docs/pr-hygiene.md
+++ b/ai-track-docs/pr-hygiene.md
@@ -94,3 +94,74 @@ Avoid vague messages like:
 - Put exact commands in a `Verification` section.
 - Include rollback even for low-risk docs or tooling changes.
 - Mention when Copilot was used to draft the PR content.
+
+## Walk PR Review Focus (Ex11)
+
+Use the following when drafting Walk PRs so reviewers can quickly validate the riskiest areas.
+
+### Review Focus Bullets (3-5)
+
+- Confirm the change is scoped to the intended files only and does not expand beyond the exercise goal.
+- Verify behavior-impact claims match the diff (for refactors/docs/tooling, check that runtime logic is unchanged unless explicitly stated).
+- Check that evidence commands in the PR body are reproducible and align with the touched component.
+- Validate that observability/security/CI changes are additive and have clear rollback.
+- Confirm no secrets or sensitive values are introduced in code, logs, or examples.
+
+### Reviewer Verification Steps
+
+Pick the commands relevant to the PR surface and include them verbatim in the PR body.
+
+```sh
+# main-chef-wrapper unit slice
+cd components/main-chef-wrapper
+go test -tags=unit ./cmd -count=1
+
+# chef-automate-collect command slice
+cd components/chef-automate-collect
+go test ./commands -count=1
+
+# repo-level soft evidence command used in CI advisory summary
+cd components/main-chef-wrapper
+go test -tags=unit -cover -count=1 ./cmd
+```
+
+### Rollback Pattern
+
+Always include a one-line rollback in PRs:
+
+```sh
+git revert <commit-sha>
+```
+
+### Final PR Text Template (Walk)
+
+```text
+Title: GHCP -- Walk: <ex#> <name>
+
+Summary
+- What changed and why
+- Plan: <inline summary>
+- Files/paths touched
+
+Evidence
+- Tests/logs/metrics: <commands + output summary>
+- Coverage: <percentage or contract evidence>
+
+Risk & Rollback
+- Risk: low/medium
+- Rollback: revert <commit SHA>
+
+Review Focus
+- Confirm <risk area 1>
+- Confirm <risk area 2>
+- Confirm <scope / safety claim>
+
+Verification Steps
+- <command 1>
+- <command 2>
+- <expected success signal>
+
+Track
+- Level: Walk
+- Exercise: <ex#>
+```


### PR DESCRIPTION
## Summary
- Added a Walk-focused PR hygiene section in `ai-track-docs/pr-hygiene.md` to improve review clarity and consistency.
- Introduced reusable review focus bullets, local verification steps, rollback pattern, and a final copy/paste Walk PR template.
- Plan: inspect existing PR guidance, add Walk-specific review/verification section, generate final PR text using template.

## Files/paths touched
- `ai-track-docs/pr-hygiene.md`

## Evidence
- Tests/logs/metrics: doc-only update; no runtime code or workflow behavior changed.
- Verification command used:
  - `git diff -- ai-track-docs/pr-hygiene.md`
- Coverage: not applicable (documentation-only exercise).

## Risk & Rollback
- Risk: low
- Rollback: revert `ddc95b92`

## Review Focus
- Confirm the new Walk section is additive and does not conflict with existing crawl guidance.
- Confirm review bullets are specific enough for small stacked PRs.
- Confirm verification steps are runnable and mapped to active components.
- Confirm rollback guidance remains one-command and easy to apply.

## Verification Steps
- `cat ai-track-docs/pr-hygiene.md` and confirm these headings exist:
  - `Walk PR Review Focus (Ex11)`
  - `Review Focus Bullets (3-5)`
  - `Reviewer Verification Steps`
  - `Final PR Text Template (Walk)`
- Confirm rollback command in template is present:
  - `git revert <commit-sha>`

## Track
- Level: Walk
- Exercise: Ex11
