### PR TITLE
GHCP -- Walk: Ex13 Feature Flags / Config (Validated ON/OFF)

### DIFF
--- a/.github/workflows/feature-flag-structured-logs.yml
+++ b/.github/workflows/feature-flag-structured-logs.yml
@@ -1,0 +1,44 @@
+permissions:
+  contents: read
+
+name: Feature Flag Validation - Structured Logs
+
+on:
+  pull_request:
+    paths:
+      - 'components/chef-automate-collect/commands/cli_io.go'
+      - 'components/chef-automate-collect/commands/cli_io_test.go'
+      - 'components/chef-automate-collect/commands/environment_variables.go'
+      - '.github/workflows/feature-flag-structured-logs.yml'
+      - 'ai-track-docs/logging.md'
+  push:
+    branches: [ main ]
+    paths:
+      - 'components/chef-automate-collect/commands/cli_io.go'
+      - 'components/chef-automate-collect/commands/cli_io_test.go'
+      - 'components/chef-automate-collect/commands/environment_variables.go'
+      - '.github/workflows/feature-flag-structured-logs.yml'
+      - 'ai-track-docs/logging.md'
+
+jobs:
+  structured-logs-flag-on-off:
+    name: Structured logs flag=${{ matrix.structured_logs }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        structured_logs: ["true", "false"]
+    env:
+      CHEF_AC_STRUCTURED_LOGS: ${{ matrix.structured_logs }}
+    defaults:
+      run:
+        working-directory: components/chef-automate-collect
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: components/chef-automate-collect/go.mod
+
+      - name: Validate structured logging behavior for flag mode
+        run: go test ./commands -run TestStructuredVerboseHonorsProcessEnvToggle -count=1 -v

--- a/ai-track-docs/logging.md
+++ b/ai-track-docs/logging.md
@@ -45,6 +45,34 @@ New structured event fields:
 
 This gives operators a direct latency and outcome signal for the test-config network boundary without exposing secrets.
 
+## Feature Flag Lifecycle (Walk Ex13)
+
+Flag name:
+
+- `CHEF_AC_STRUCTURED_LOGS`
+
+Creation:
+
+- Introduced to provide a low-risk toggle for structured verbose logging output in `chef-automate-collect` commands.
+
+Default state:
+
+- **ON** when unset.
+
+How to enable:
+
+- Unset the variable, or set it to any value other than `false`.
+- Example: `CHEF_AC_STRUCTURED_LOGS=true`
+
+How to disable:
+
+- Set `CHEF_AC_STRUCTURED_LOGS=false`.
+
+Removal criteria:
+
+- Remove the flag only after all supported consumers have migrated to structured output and no operational workflow depends on legacy/no-structured-log behavior.
+- Before removal, run ON/OFF validation tests and announce deprecation in contributor docs/release notes.
+
 ## How To View Logs
 
 Run from the repository root.
@@ -75,6 +103,14 @@ To verify format via tests:
 ```sh
 cd components/chef-automate-collect
 go test ./commands -run TestAutomateConfigTestEmitsStructuredHTTPLog -count=1 -v
+```
+
+To validate ON/OFF flag behavior explicitly:
+
+```sh
+cd components/chef-automate-collect
+CHEF_AC_STRUCTURED_LOGS=true go test ./commands -run TestStructuredVerboseHonorsProcessEnvToggle -count=1 -v
+CHEF_AC_STRUCTURED_LOGS=false go test ./commands -run TestStructuredVerboseHonorsProcessEnvToggle -count=1 -v
 ```
 
 Expected `-v` output includes a logged line containing:

--- a/components/chef-automate-collect/commands/cli_io_test.go
+++ b/components/chef-automate-collect/commands/cli_io_test.go
@@ -1,9 +1,40 @@
 package commands
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
+
+func captureStderrForStructuredVerbose(t *testing.T) (func(), func() string) {
+	t.Helper()
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+
+	os.Stderr = w
+
+	restore := func() {
+		_ = w.Close()
+		os.Stderr = origStderr
+	}
+
+	readOutput := func() string {
+		b, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("failed to read stderr output: %v", err)
+		}
+		_ = r.Close()
+		return string(b)
+	}
+
+	return restore, readOutput
+}
 
 func BenchmarkStructuredLogLine(b *testing.B) {
 	fields := []StructuredField{
@@ -69,5 +100,39 @@ func TestStructuredLoggingEnabledTurnsOn(t *testing.T) {
 
 	if !got {
 		t.Fatal("expected structured logging to be enabled when env var is true")
+	}
+}
+
+func TestStructuredVerboseHonorsProcessEnvToggle(t *testing.T) {
+	originalVerbose := cliIO.EnableVerbose
+	cliIO.EnableVerbose = true
+	defer func() {
+		cliIO.EnableVerbose = originalVerbose
+	}()
+
+	restore, readOutput := captureStderrForStructuredVerbose(t)
+	cliIO.structuredVerbose(
+		"config_load",
+		"success",
+		5*time.Millisecond,
+		StructuredField{Key: "config_paths", Value: "1"},
+	)
+	restore()
+
+	output := strings.TrimSpace(readOutput())
+	value, isSet := os.LookupEnv(StructuredLogsEnvVar)
+	enabled := !isSet || strings.TrimSpace(value) != "false"
+
+	t.Logf("%s=%q enabled=%t output=%q", StructuredLogsEnvVar, value, enabled, output)
+
+	if enabled {
+		if !strings.Contains(output, "op=config_load") {
+			t.Fatalf("expected structured log output when flag is enabled, got %q", output)
+		}
+		return
+	}
+
+	if output != "" {
+		t.Fatalf("expected no structured output when flag is disabled, got %q", output)
 	}
 }


### PR DESCRIPTION
## Summary
- Reused existing feature flag `CHEF_AC_STRUCTURED_LOGS` and documented full lifecycle (creation, default, enable/disable, removal criteria).
- Added runtime ON/OFF validation test that checks emitted structured logs based on process env value.
- Added CI matrix workflow to validate both modes (`true` and `false`) automatically.
- Plan: identify existing safe flag, document lifecycle, validate ON/OFF locally and in CI matrix, include both outputs.

## Files/paths touched
- `.github/workflows/feature-flag-structured-logs.yml`
- `components/chef-automate-collect/commands/cli_io_test.go`
- `ai-track-docs/logging.md`

## Evidence
Local ON mode:
```bash
cd components/chef-automate-collect
CHEF_AC_STRUCTURED_LOGS=true go test ./commands -run TestStructuredVerboseHonorsProcessEnvToggle -count=1 -v
```
Output excerpt:
```text
CHEF_AC_STRUCTURED_LOGS="true" enabled=true output="op=config_load status=success elapsed_ms=5 config_paths=1"
PASS
```

Local OFF mode:
```bash
cd components/chef-automate-collect
CHEF_AC_STRUCTURED_LOGS=false go test ./commands -run TestStructuredVerboseHonorsProcessEnvToggle -count=1 -v
```
Output excerpt:
```text
CHEF_AC_STRUCTURED_LOGS="false" enabled=false output=""
PASS
```

Regression check:
```bash
cd components/chef-automate-collect
go test ./commands -count=1
```
Result: PASS.

Coverage: not required for this feature-flag lifecycle exercise.

## Flag Lifecycle
Flag: `CHEF_AC_STRUCTURED_LOGS`
- Default: ON when unset
- Enable: unset or set to non-`false` value
- Disable: set to `false`
- Removal: only after all supported consumers no longer require toggle behavior and deprecation is communicated

## Risk & Rollback
- Risk: low
- Rollback: revert `f391b778`

## Review Focus
- Confirm ON/OFF assertions reflect actual runtime behavior (not mocked lookup).
- Confirm CI matrix covers both flag states and is scoped to relevant paths.
- Confirm lifecycle guidance in `logging.md` is explicit and operationally safe.

## Track
- Level: Walk
- Exercise: Ex13
