### PR TITLE
GHCP -- Walk: Ex14 Type Safety / Static Analysis (Scoped Gating)

### DIFF
--- a/.github/workflows/staticcheck-commands.yml
+++ b/.github/workflows/staticcheck-commands.yml
@@ -1,0 +1,39 @@
+permissions:
+  contents: read
+
+name: Static Analysis - commands strict
+
+on:
+  pull_request:
+    paths:
+      - 'components/chef-automate-collect/commands/**.go'
+      - '.github/workflows/staticcheck-commands.yml'
+      - 'ai-track-docs/static-analysis.md'
+  push:
+    branches: [ main ]
+    paths:
+      - 'components/chef-automate-collect/commands/**.go'
+      - '.github/workflows/staticcheck-commands.yml'
+      - 'ai-track-docs/static-analysis.md'
+
+jobs:
+  staticcheck-commands:
+    name: Staticcheck commands path
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: components/chef-automate-collect
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Staticcheck v0.7.0 requires modern Go, and commands tests use testing.B.Loop.
+          go-version: '1.26.x'
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
+
+      - name: Run strict staticcheck (scoped)
+        run: "$(go env GOPATH)/bin/staticcheck -tests=false ./commands"

--- a/ai-track-docs/static-analysis.md
+++ b/ai-track-docs/static-analysis.md
@@ -54,6 +54,21 @@ Reference:
 
 - `.vale.ini`
 
+### 6) Path-scoped strict static analysis (Walk Ex14)
+
+GitHub Actions workflow enforces `staticcheck` on one focused path:
+
+- target: `components/chef-automate-collect/commands`
+- workflow: `.github/workflows/staticcheck-commands.yml`
+
+This gate is intentionally scoped so unrelated code paths are not blocked.
+
+Suppression used:
+
+- File: `components/chef-automate-collect/commands/automate_config.go`
+- Check: `ST1005`
+- Rationale: error text is intentionally capitalized because it is user-facing CLI output and should remain consistent with existing command messaging.
+
 ## How To Run Locally
 
 Run from repository root.
@@ -84,8 +99,16 @@ bundle exec rake omnibus/verification/spec/ --trace
 cspell "**/*.{md,rb,go}"
 ```
 
+### Strict staticcheck for commands path
+
+```sh
+cd components/chef-automate-collect
+"$(go env GOPATH)/bin/staticcheck" ./commands
+```
+
 ## Notes
 
 - This exercise documents existing checks rather than introducing broad new lint gates.
 - The current baseline is mixed-language: Ruby lint/spec checks in CI and focused Go checks via local script.
 - If future work tightens linting, prefer scoped changes (single component or workflow path) to avoid noisy cross-repo regressions.
+- Walk Ex14 applies that principle by gating only the commands path with stricter static analysis.

--- a/components/chef-automate-collect/commands/automate_config.go
+++ b/components/chef-automate-collect/commands/automate_config.go
@@ -200,7 +200,6 @@ func (l *ConfigLoader) findRepoConfig() {
 	}
 	cliIO.verbose("found private config file %q", candidatePrivateConfigFilename)
 	l.RepoPrivateConfigPath = candidatePrivateConfigFilename
-	return
 }
 
 func (l *ConfigLoader) findUserConfig() {
@@ -234,7 +233,6 @@ func (l *ConfigLoader) findUserConfig() {
 	}
 	cliIO.verbose("found user config file %q", userConfigFilename)
 	l.UserConfigPath = userConfigFilename
-	return
 }
 
 func (l *ConfigLoader) findSystemConfig() {
@@ -278,7 +276,6 @@ func (l *ConfigLoader) findSystemConfig() {
 	}
 	cliIO.verbose("found system config file %q", candidateFilename)
 	l.SystemConfigPath = candidateFilename
-	return
 }
 
 func (p *PrivateConfig) ToConfig() *Config {
@@ -440,6 +437,7 @@ func newAutomateConfig(givenURL, token string) (*AutomateConfig, error) {
 		return nil, err
 	}
 	if cleanedURL.Scheme != "https" {
+		//lint:ignore ST1005 Keep leading capitalization for user-facing CLI consistency.
 		return nil, fmt.Errorf("Automate URL %q is invalid; must use \"https\" protocol", givenURL)
 	}
 	cleanedURL.Path = ""


### PR DESCRIPTION
## Summary
- Increased static analysis strictness for one scoped path: `components/chef-automate-collect/commands`.
- Added a path-scoped CI gate using `staticcheck` (workflow: `.github/workflows/staticcheck-commands.yml`).
- Fixed high-signal findings in `automate_config.go` (3 redundant returns).
- Added one documented suppression (`ST1005`) with rationale for user-facing CLI error text capitalization.
- Plan: run baseline staticcheck, fix high-signal findings, keep one intentional suppression with comment, add scoped CI enforcement, document rationale.

## Files/paths touched
- `.github/workflows/staticcheck-commands.yml`
- `components/chef-automate-collect/commands/automate_config.go`
- `ai-track-docs/static-analysis.md`

## Evidence
Baseline findings before fix:
- `S1023` at lines 203, 237, 281 (`redundant return statement`)
- `ST1005` at line 443 (`error strings should not be capitalized`)

Local strict gate validation:
```bash
cd components/chef-automate-collect
"$(go env GOPATH)/bin/staticcheck" ./commands
```
Result: no findings.

Regression check:
```bash
cd components/chef-automate-collect
go test ./commands -count=1
```
Result: PASS.

Coverage: not required for static analysis gating exercise.

## Suppressions and Rationale
Suppression kept (documented inline and in docs):
- File: `components/chef-automate-collect/commands/automate_config.go`
- Suppression: `//lint:ignore ST1005`
- Reason: this error text is intentionally user-facing CLI output and remains capitalized for consistency with existing operator messaging.

## Risk & Rollback
- Risk: low
- Rollback: revert `eda99b46`

## Review Focus
- Confirm staticcheck workflow is path-scoped and does not block unrelated code.
- Confirm only intended findings were fixed/suppressed.
- Confirm suppression rationale is explicit and narrow.

## Track
- Level: Walk
- Exercise: Ex14
