### PR TITLE
GHCP -- Run: Ex3 Tiny Refactor (behavior-preserving)

### DIFF
--- a/components/chef-automate-collect/commands/automate_config.go
+++ b/components/chef-automate-collect/commands/automate_config.go
@@ -87,6 +87,13 @@ func redactSecretForLog(secret string) string {
 	return "[REDACTED]"
 }
 
+func logConfigLoadError(start time.Time, path string, errorType string, err error, messageTemplate string) error {
+	cliIO.structuredVerbose("config_load", "error", time.Since(start),
+		StructuredField{Key: "path", Value: path},
+		StructuredField{Key: "error", Value: errorType})
+	return errors.Wrapf(err, messageTemplate, path)
+}
+
 func NewConfigLoader() *ConfigLoader {
 	c := &ConfigLoader{}
 	c.findRepoConfig()
@@ -124,17 +131,11 @@ func (l *ConfigLoader) Load() error {
 		configFromFile := &PrivateConfig{}
 		fileContent, err := ioutil.ReadFile(p)
 		if err != nil {
-			cliIO.structuredVerbose("config_load", "error", time.Since(start),
-				StructuredField{Key: "path", Value: p},
-				StructuredField{Key: "error", Value: "read_config"})
-			return errors.Wrapf(err, "failed to read config file %q", p)
+			return logConfigLoadError(start, p, "read_config", err, "failed to read config file %q")
 		}
 		err = toml.Unmarshal(fileContent, configFromFile)
 		if err != nil {
-			cliIO.structuredVerbose("config_load", "error", time.Since(start),
-				StructuredField{Key: "path", Value: p},
-				StructuredField{Key: "error", Value: "decode_toml"})
-			return errors.Wrapf(err, "cannot decode TOML content in %q", p)
+			return logConfigLoadError(start, p, "decode_toml", err, "cannot decode TOML content in %q")
 		}
 		cliIO.verbose("applying configuration from %q", p)
 		l.LoadedConfig.ApplyValuesFrom(configFromFile.ToConfig())

--- a/components/chef-automate-collect/commands/automate_config_test.go
+++ b/components/chef-automate-collect/commands/automate_config_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -247,10 +248,10 @@ func TestPrivateAutomateConfigToConfigConvertsProperly(t *testing.T) {
 
 func TestViableConfigPathsFiltersEmptyPaths(t *testing.T) {
 	loader := &ConfigLoader{
-		SystemConfigPath:    "/etc/automate.toml",
-		UserConfigPath:      "", // empty, should be filtered
-		RepoConfigPath:      ".automate/config.toml",
-		RepoPrivateConfigPath: "",  // empty, should be filtered
+		SystemConfigPath:      "/etc/automate.toml",
+		UserConfigPath:        "", // empty, should be filtered
+		RepoConfigPath:        ".automate/config.toml",
+		RepoPrivateConfigPath: "", // empty, should be filtered
 	}
 
 	result := loader.ViableConfigPaths()
@@ -263,5 +264,47 @@ func TestViableConfigPathsFiltersEmptyPaths(t *testing.T) {
 	}
 	if result[1] != ".automate/config.toml" {
 		t.Fatalf("expected second path %q, got %q", ".automate/config.toml", result[1])
+	}
+}
+
+func TestLogConfigLoadErrorEmitsStructuredLogAndWrapsError(t *testing.T) {
+	originalVerbose := cliIO.EnableVerbose
+	cliIO.EnableVerbose = true
+	defer func() {
+		cliIO.EnableVerbose = originalVerbose
+	}()
+
+	t.Setenv(StructuredLogsEnvVar, "true")
+
+	restore, readOutput := captureStderrForTestConfig(t)
+	start := time.Now()
+	testErr := errors.New("underlying read failure")
+	wrappedErr := logConfigLoadError(start, "/path/to/config.toml", "read_config", testErr, "failed to read config file %q")
+	restore()
+	output := readOutput()
+
+	// Verify structured log was emitted
+	if !strings.Contains(output, "op=config_load") {
+		t.Fatalf("expected op=config_load in output, got %q", output)
+	}
+	if !strings.Contains(output, "error") {
+		t.Fatalf("expected status=error in output, got %q", output)
+	}
+	if !strings.Contains(output, "read_config") {
+		t.Fatalf("expected error type 'read_config' in output, got %q", output)
+	}
+	if !strings.Contains(output, "/path/to/config.toml") {
+		t.Fatalf("expected path in output, got %q", output)
+	}
+
+	// Verify error was wrapped correctly
+	if wrappedErr == nil {
+		t.Fatal("expected a wrapped error")
+	}
+	if !strings.Contains(wrappedErr.Error(), "failed to read config file") {
+		t.Fatalf("expected wrapped message in error, got %q", wrappedErr.Error())
+	}
+	if !strings.Contains(wrappedErr.Error(), "/path/to/config.toml") {
+		t.Fatalf("expected path in error message, got %q", wrappedErr.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- Extracted `logConfigLoadError()` helper function to consolidate duplicated error logging + wrapping pattern.
- Refactored `ConfigLoader.Load()` to use the new helper at two error sites (config file read, TOML decode).
- Added test `TestLogConfigLoadErrorEmitsStructuredLogAndWrapsError` to verify helper behavior.
- Behavior is identical to before; code is cleaner and more maintainable.

**Files touched:**
- `components/chef-automate-collect/commands/automate_config.go` (helper extraction, 2 call sites updated)
- `components/chef-automate-collect/commands/automate_config_test.go` (added 1 test, 51 lines)

## Refactor Plan

| File | Change | Reason |
|---|---|---|
| automate_config.go | Extract `logConfigLoadError()` helper | DRY: remove duplicated structured error log + wrapping pattern (appeared 2x in Load() method) |
| automate_config.go | Update Load() method to use helper | Cleaner, more maintainable code; error handling intent is explicit |
| automate_config_test.go | Add TestLogConfigLoadErrorEmitsStructuredLogAndWrapsError | Verify new helper's behavior correctness |

**Expected impact:** 2 error handlers → 1 reusable helper; clearer intent; no behavior change.

## Evidence

**Before (duplicated pattern at lines 127-130 and 134-137):**
```go
if err != nil {
    cliIO.structuredVerbose("config_load", "error", time.Since(start),
        StructuredField{Key: "path", Value: p},
        StructuredField{Key: "error", Value: "read_config"})
    return errors.Wrapf(err, "failed to read config file %q", p)
}
// ... repeated again for TOML decode error ...
```

**After (consolidated into helper):**
```go
if err != nil {
    return logConfigLoadError(start, p, "read_config", err, "failed to read config file %q")
}
if err != nil {
    return logConfigLoadError(start, p, "decode_toml", err, "cannot decode TOML content in %q")
}
```

**Test results:**
```
ok  github.com/chef/chef-workstation/components/chef-automate-collect/commands  0.249s

Total passing tests: 25 (includes new TestLogConfigLoadErrorEmitsStructuredLogAndWrapsError)
```

**Regression check:** All 25 existing + new tests pass. No failures introduced.

**Delegation checklist completed:** yes

## Risk & Rollback
- Risk: low
- Rollback: `git revert ab7ac81c`
- Rollback commands:
  ```
  git revert ab7ac81c
  git push origin learn/run/neha-p6-ex3
  ```
- Behavior is unchanged; only error handler pattern extracted; fully reversible.

## Track
- Level: Run
- Exercise: Ex3