### PR TITLE
GHCP -- Run: Ex6 Performance Touch-point

### DIFF
--- a/components/chef-automate-collect/commands/cli_io.go
+++ b/components/chef-automate-collect/commands/cli_io.go
@@ -71,7 +71,7 @@ func structuredLogLine(op string, status string, elapsed time.Duration, fields .
 
 func newlineify(s string) string {
 	if !strings.HasSuffix(s, "\n") {
-		return fmt.Sprintf("%s\n", s)
+		return s + "\n"
 	}
 	return s
 }

--- a/components/chef-automate-collect/commands/metadata_collectors.go
+++ b/components/chef-automate-collect/commands/metadata_collectors.go
@@ -95,11 +95,15 @@ func gitRemoteNameFromEnv(lookupEnv func(string) (string, bool)) string {
 	if value, envVarSet := lookupEnv(GitRemoteNameEnvVar); envVarSet {
 		trimmedValue := strings.TrimSpace(value)
 		if trimmedValue == "" {
-			cliIO.verbose("Found environment %s=%q, ignoring empty value and using default git remote %q", GitRemoteNameEnvVar, value, gitRemoteName)
+			if cliIO.EnableVerbose {
+				cliIO.verbose("Found environment %s=%q, ignoring empty value and using default git remote %q", GitRemoteNameEnvVar, value, gitRemoteName)
+			}
 			return gitRemoteName
 		}
 
-		cliIO.verbose("Found environment %s=%q, using this value to detect git URL", GitRemoteNameEnvVar, trimmedValue)
+		if cliIO.EnableVerbose {
+			cliIO.verbose("Found environment %s=%q, using this value to detect git URL", GitRemoteNameEnvVar, trimmedValue)
+		}
 		return trimmedValue
 	}
 


### PR DESCRIPTION
## Summary
- Applied low-risk micro-optimizations in the `components/chef-automate-collect/commands` subsystem.
- Kept scope strictly inside the target directory and avoided behavior changes.
- Captured benchmark before/after evidence with `go test -bench`.
- Included rollback steps.

**Files touched:**
- `components/chef-automate-collect/commands/metadata_collectors.go`
- `components/chef-automate-collect/commands/cli_io.go`

## Performance Touch-point Plan

| File | Change | Why low-risk |
|---|---|---|
| `metadata_collectors.go` | Gate verbose log calls with `if cliIO.EnableVerbose` before invoking variadic `cliIO.verbose(...)` | No behavior change when verbose enabled; avoids unnecessary allocations/work when verbose disabled |
| `cli_io.go` | Replace `fmt.Sprintf("%s\n", s)` with `s + "\n"` in `newlineify` | Equivalent output for all existing callers; simpler and cheaper operation |

## Benchmark Methodology
- Module: `components/chef-automate-collect`
- Package: `./commands`
- Command:
  ```
  go test ./commands -run '^$' -bench 'BenchmarkStructuredLogLine|BenchmarkGitRemoteNameFromEnv' -benchmem -count=8
  ```
- CPU: Apple M4 Pro

## Before / After Evidence

### BenchmarkGitRemoteNameFromEnv

| Sub-benchmark | Before | After | Delta |
|---|---:|---:|---:|
| `unset` | ~1.73 ns/op, 0 B/op, 0 allocs/op | ~1.76 ns/op, 0 B/op, 0 allocs/op | ~neutral |
| `whitespace` | ~13.2 ns/op, 16 B/op, 1 alloc/op | ~3.27 ns/op, 0 B/op, 0 alloc/op | ~75% faster, alloc removed |
| `trimmed_value` | ~13.4 ns/op, 16 B/op, 1 alloc/op | ~3.49 ns/op, 0 B/op, 0 alloc/op | ~74% faster, alloc removed |

### BenchmarkStructuredLogLine
- Before: ~55.7 ns/op, 128 B/op, 1 alloc/op
- After: ~55.8 ns/op, 128 B/op, 1 alloc/op
- Result: neutral (no regression).

## Troubleshooting Note
- An attempted `structuredLogLine` micro-optimization was measured and found slower; it was reverted.
- Final patch keeps only changes with measured gain or neutral behavior.

## Regression Check
- `go test ./commands` passes after optimization.

## ACCEPTANCE
- At least one measurable improvement implemented
- Before/after metrics captured
- No behavior regression introduced
- Evidence included in PR
- Rollback steps documented

## Risk & Rollback
- Risk: low
- Rollback:
  ```
  git revert b6731565
  git push origin learn/run/neha-p6-ex6
  ```

## Track
- Level: Run
- Exercise: Ex6
