### PR TITLE
GHCP -- Run: Ex8 Security and Secrets

### DIFF
--- a/ai-track-docs/security-secrets.md
+++ b/ai-track-docs/security-secrets.md
@@ -74,3 +74,34 @@ gitleaks detect --source . --no-git --config .gitleaks.toml
 Reason: this file contains a known non-production licensing acceptance fixture value required by workstation licensing configuration, not a developer credential.
 
 If this fixture changes, update the allowlist entry and rerun the local command above before opening a PR.
+
+## Main Chef Wrapper Security Hardening (Run Ex8)
+
+Scope: `components/main-chef-wrapper`
+
+### Fixes Applied
+
+1. Hardened rollout environment validation in `cmd/push.go`:
+- `CHEF_AC_SERVER_URL` and `CHEF_AC_AUTOMATE_URL` must be valid absolute `http/https` URLs.
+- `CHEF_AC_SERVER_USER` and `CHEF_AC_AUTOMATE_TOKEN` are trimmed and rejected if they contain newline characters.
+
+2. Hardened license feature flag file handling in `main.go`:
+- License marker path handling now uses a shared helper (`licenseFlagPath`).
+- Marker file creation now uses `os.OpenFile(..., 0o600)` and `.chef` directory creation uses `0o700`.
+- Write errors are checked instead of ignored.
+
+### Why This Matters
+
+- URL validation reduces risk of malformed/unexpected endpoint values being passed to rollout reporting.
+- Control-character rejection reduces risk of newline-based log/argument confusion.
+- Private file permissions for license marker reduce local secret/config exposure on multi-user systems.
+
+### Repeatable Scripted Verification
+
+Run from repo root:
+
+```sh
+bash components/main-chef-wrapper/security_hygiene_check.sh
+```
+
+This script reruns contract tests for rollout validation, reruns license file permission tests, and verifies hardened code patterns are still present.

--- a/components/main-chef-wrapper/cmd/push.go
+++ b/components/main-chef-wrapper/cmd/push.go
@@ -21,7 +21,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/chef/chef-workstation/components/main-chef-wrapper/dist"
 	"github.com/spf13/cobra"
@@ -52,8 +54,10 @@ https://docs.chef.io/policyfile/
 			if err != nil {
 				return err
 			}
+			serverURL := strings.TrimSpace(os.Getenv("CHEF_AC_SERVER_URL"))
+			serverUser := strings.TrimSpace(os.Getenv("CHEF_AC_SERVER_USER"))
 			allArgs := []string{"report-new-rollout", "-g", allArgs[1], "-l", allArgs[2],
-				"-s", os.Getenv("CHEF_AC_SERVER_URL"), "-u", os.Getenv("CHEF_AC_SERVER_USER")}
+				"-s", serverURL, "-u", serverUser}
 			return Runner.PassThroughCommand(dist.AutomateCollectExec, "", allArgs)
 		}
 		return Runner.PassThroughCommand(dist.WorkstationExec, "", os.Args[1:])
@@ -75,20 +79,56 @@ func isRollOutEnabled() bool {
 }
 
 func ValidateRolloutSetup() bool {
-	if os.Getenv("CHEF_AC_SERVER_URL") == "" {
+	serverURL := strings.TrimSpace(os.Getenv("CHEF_AC_SERVER_URL"))
+	if serverURL == "" {
 		fmt.Fprintln(os.Stderr, "ERROR:", "CHEF_AC_SERVER_URL environment variable must be set for rollout reporting")
 		return false
 	}
-	if os.Getenv("CHEF_AC_SERVER_USER") == "" {
+	if !validateHTTPURL("CHEF_AC_SERVER_URL", serverURL) {
+		return false
+	}
+
+	serverUser := strings.TrimSpace(os.Getenv("CHEF_AC_SERVER_USER"))
+	if serverUser == "" {
 		fmt.Fprintln(os.Stderr, "ERROR:", "CHEF_AC_SERVER_USER environment variable must be set for rollout reporting")
 		return false
 	}
-	if os.Getenv("CHEF_AC_AUTOMATE_URL") == "" {
+	if strings.ContainsAny(serverUser, "\r\n") {
+		fmt.Fprintln(os.Stderr, "ERROR:", "CHEF_AC_SERVER_USER must not contain newline characters")
+		return false
+	}
+
+	automateURL := strings.TrimSpace(os.Getenv("CHEF_AC_AUTOMATE_URL"))
+	if automateURL == "" {
 		fmt.Fprintln(os.Stderr, "ERROR:", "CHEF_AC_AUTOMATE_URL environment variable must be set for rollout reporting")
 		return false
 	}
-	if os.Getenv("CHEF_AC_AUTOMATE_TOKEN") == "" {
+	if !validateHTTPURL("CHEF_AC_AUTOMATE_URL", automateURL) {
+		return false
+	}
+
+	automateToken := strings.TrimSpace(os.Getenv("CHEF_AC_AUTOMATE_TOKEN"))
+	if automateToken == "" {
 		fmt.Fprintln(os.Stderr, "ERROR:", "CHEF_AC_AUTOMATE_TOKEN environment variable must be set for rollout reporting")
+		return false
+	}
+	if strings.ContainsAny(automateToken, "\r\n") {
+		fmt.Fprintln(os.Stderr, "ERROR:", "CHEF_AC_AUTOMATE_TOKEN must not contain newline characters")
+		return false
+	}
+
+	return true
+}
+
+func validateHTTPURL(varName, value string) bool {
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		fmt.Fprintf(os.Stderr, "ERROR: %s must be a valid absolute URL\n", varName)
+		return false
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		fmt.Fprintf(os.Stderr, "ERROR: %s must use http or https\n", varName)
 		return false
 	}
 

--- a/components/main-chef-wrapper/cmd/push_contract_test.go
+++ b/components/main-chef-wrapper/cmd/push_contract_test.go
@@ -105,4 +105,58 @@ func TestValidateRolloutSetupContract(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("rejects invalid rollout URL inputs", func(t *testing.T) {
+		setValidRolloutEnv(t)
+		t.Setenv("CHEF_AC_SERVER_URL", "not-a-url")
+
+		restore, readOutput := captureStderrForRolloutValidation(t)
+		got := ValidateRolloutSetup()
+		restore()
+		stderr := readOutput()
+
+		if got {
+			t.Fatal("expected invalid CHEF_AC_SERVER_URL to fail validation")
+		}
+		want := "ERROR: CHEF_AC_SERVER_URL must be a valid absolute URL"
+		if stderr != want {
+			t.Fatalf("expected %q, got %q", want, stderr)
+		}
+	})
+
+	t.Run("rejects non-http automate URL", func(t *testing.T) {
+		setValidRolloutEnv(t)
+		t.Setenv("CHEF_AC_AUTOMATE_URL", "ftp://example-automate")
+
+		restore, readOutput := captureStderrForRolloutValidation(t)
+		got := ValidateRolloutSetup()
+		restore()
+		stderr := readOutput()
+
+		if got {
+			t.Fatal("expected non-http scheme for CHEF_AC_AUTOMATE_URL to fail validation")
+		}
+		want := "ERROR: CHEF_AC_AUTOMATE_URL must use http or https"
+		if stderr != want {
+			t.Fatalf("expected %q, got %q", want, stderr)
+		}
+	})
+
+	t.Run("rejects token with newline characters", func(t *testing.T) {
+		setValidRolloutEnv(t)
+		t.Setenv("CHEF_AC_AUTOMATE_TOKEN", "token\nvalue")
+
+		restore, readOutput := captureStderrForRolloutValidation(t)
+		got := ValidateRolloutSetup()
+		restore()
+		stderr := readOutput()
+
+		if got {
+			t.Fatal("expected CHEF_AC_AUTOMATE_TOKEN containing newlines to fail validation")
+		}
+		want := "ERROR: CHEF_AC_AUTOMATE_TOKEN must not contain newline characters"
+		if stderr != want {
+			t.Fatalf("expected %q, got %q", want, stderr)
+		}
+	})
 }

--- a/components/main-chef-wrapper/main.go
+++ b/components/main-chef-wrapper/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -37,6 +38,8 @@ import (
 	"github.com/chef/chef-workstation/components/main-chef-wrapper/cmd"
 	homedir "github.com/mitchellh/go-homedir"
 )
+
+const licenseFlagFilename = "fbffb2ea48910514676e1b7a51c7248290ea958c"
 
 func doStartupTasks() error {
 	createDotChef()
@@ -161,25 +164,25 @@ func exists(path string) (bool, error) {
 
 // feature flag for license
 func checkLicenseFlag() {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal("Not able to resolve home directory")
+	}
 	if len(os.Args) > 3 && os.Args[1] == "license" && os.Args[2] == "enable" && os.Args[3] == "true" {
-		f, err := os.Create(filepath.Join(home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c"))
-		if err != nil {
+		if err := enableLicenseFlag(home); err != nil {
 			log.Fatal("Not able to enable chef")
 		}
-		defer f.Close()
-		f.Write([]byte(`true`))
 		log.Println("Now you can use chef commands using the license.")
 		os.Exit(0)
 	} else if len(os.Args) > 3 && os.Args[1] == "license" && os.Args[2] == "enable" && os.Args[3] == "false" {
-		err := os.Remove(filepath.Join(home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c"))
+		err := os.Remove(licenseFlagPath(home))
 		if err != nil {
 			log.Fatal("Not able to disable chef")
 		}
 		log.Println("License feature got disabled")
 		os.Exit(0)
 	} else if len(os.Args) > 2 && os.Args[1] == "license" {
-		info, _ := os.Stat(filepath.Join(home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c"))
+		info, _ := os.Stat(licenseFlagPath(home))
 		if info == nil {
 			log.Fatal("To use chef license feature you need to enable the license flag. \nTo enable it run `chef license enable true`")
 		}
@@ -188,14 +191,44 @@ func checkLicenseFlag() {
 }
 
 func featureEnabled() bool {
-	home, _ := os.UserHomeDir()
-	licensePath := filepath.Join(home, ".chef/fbffb2ea48910514676e1b7a51c7248290ea958c")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	licensePath := licenseFlagPath(home)
 	info, _ := os.Stat(licensePath)
 	if info != nil {
 		return true
 	} else {
 		return false
 	}
+}
+
+func licenseFlagPath(home string) string {
+	return filepath.Join(home, ".chef", licenseFlagFilename)
+}
+
+func enableLicenseFlag(home string) error {
+	flagDir := filepath.Join(home, ".chef")
+	if err := os.MkdirAll(flagDir, 0o700); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(licenseFlagPath(home), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Write([]byte("true")); err != nil {
+		return err
+	}
+
+	if err := f.Chmod(0o600); err != nil && !errors.Is(err, os.ErrPermission) {
+		return err
+	}
+
+	return nil
 }
 
 type Configuration struct {

--- a/components/main-chef-wrapper/main_test.go
+++ b/components/main-chef-wrapper/main_test.go
@@ -19,19 +19,21 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"github.com/chef/chef-workstation/components/main-chef-wrapper/cmd"
 	"github.com/spf13/cobra"
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
 )
+
 func NewRootCmd(in string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "chef",
-		Short: "chef",
+		Use:           "chef",
+		Short:         "chef",
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) (error) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), in)
 			return nil
 		},
@@ -62,6 +64,48 @@ func Test_ValidateRolloutSetup(t *testing.T) {
 	assert.Equal(t, got, true)
 }
 
+func TestLicenseFlagPathUsesChefSubdir(t *testing.T) {
+	home := filepath.Join("tmp", "home")
+	got := licenseFlagPath(home)
+	want := filepath.Join(home, ".chef", licenseFlagFilename)
+
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestEnableLicenseFlagWritesPrivateMarker(t *testing.T) {
+	home := t.TempDir()
+
+	if err := enableLicenseFlag(home); err != nil {
+		t.Fatalf("enableLicenseFlag failed: %v", err)
+	}
+
+	flagPath := licenseFlagPath(home)
+	content, err := os.ReadFile(flagPath)
+	if err != nil {
+		t.Fatalf("failed to read marker file: %v", err)
+	}
+	if string(content) != "true" {
+		t.Fatalf("expected marker content %q, got %q", "true", string(content))
+	}
+
+	fileInfo, err := os.Stat(flagPath)
+	if err != nil {
+		t.Fatalf("failed to stat marker file: %v", err)
+	}
+	if fileInfo.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected marker to be private (0600-style), got mode %o", fileInfo.Mode().Perm())
+	}
+
+	dirInfo, err := os.Stat(filepath.Join(home, ".chef"))
+	if err != nil {
+		t.Fatalf("failed to stat .chef dir: %v", err)
+	}
+	if dirInfo.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected .chef dir to be private (0700-style), got mode %o", dirInfo.Mode().Perm())
+	}
+}
 
 //******commenting out  code added by @shafique for time being (test of policy rollout)*********
 
@@ -98,7 +142,6 @@ func Test_ValidateRolloutSetup(t *testing.T) {
 //
 //}
 
-
 //func Test_getAction(t *testing.T) {
 //
 //	cmd := getAction("push")
@@ -123,6 +166,3 @@ func Test_ValidateRolloutSetup(t *testing.T) {
 //	assert.Equal(t, cmd, "policy-rollout")
 //
 //}
-
-
-

--- a/components/main-chef-wrapper/security_hygiene_check.sh
+++ b/components/main-chef-wrapper/security_hygiene_check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root/components/main-chef-wrapper"
+
+echo "Running rollout input validation contract tests..."
+go test ./cmd -run 'TestValidateRolloutSetupContract' -count=1
+
+echo "Running license flag hardening tests..."
+go test -vet=off . -run 'TestLicenseFlagPathUsesChefSubdir|TestEnableLicenseFlagWritesPrivateMarker' -count=1
+
+echo "Verifying hardened patterns are present..."
+grep -q 'os.OpenFile(licenseFlagPath(home), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)' main.go
+grep -q 'validateHTTPURL' cmd/push.go
+
+echo "Security hygiene checks passed."


### PR DESCRIPTION
## Summary
- Implemented multiple small security improvements in `components/main-chef-wrapper`.
- Added contract tests and a repeatable script to validate the hardening.
- Updated security guidance with rationale and scripted verification steps.

**Files touched:**
- `components/main-chef-wrapper/cmd/push.go`
- `components/main-chef-wrapper/cmd/push_contract_test.go`
- `components/main-chef-wrapper/main.go`
- `components/main-chef-wrapper/main_test.go`
- `components/main-chef-wrapper/security_hygiene_check.sh`
- `ai-track-docs/security-secrets.md`

## Security Review / Prioritization

Repository security alerts were reviewed via `gh api repos/chef/chef-workstation/dependabot/alerts`.

Given Ex8 scope constraints (single subsystem, no vendor/submodules), I prioritized low-risk, high-value code hardening in `components/main-chef-wrapper`:

1. Rollout env input validation hardening (`cmd/push.go`)
2. Secret-related local file permission hardening (`main.go`)
3. Scripted repeatable verification (`security_hygiene_check.sh`)

## Fixes Applied

### 1) Rollout input validation hardening
- `CHEF_AC_SERVER_URL` and `CHEF_AC_AUTOMATE_URL` now must be valid absolute URLs.
- Both URL vars are restricted to `http/https` schemes.
- `CHEF_AC_SERVER_USER` and `CHEF_AC_AUTOMATE_TOKEN` are trimmed and rejected when containing newline characters.
- Pass-through rollout args now use trimmed values.

Security value:
- Prevents malformed endpoint values from flowing into rollout reporting.
- Reduces control-character/newline abuse risk in env-sourced values.

### 2) License marker file permission hardening
- Introduced `licenseFlagPath(home)` helper to centralize marker path handling.
- Introduced `enableLicenseFlag(home)` helper:
  - Ensures `.chef` is created via `os.MkdirAll(..., 0o700)`.
  - Creates marker file via `os.OpenFile(..., 0o600)`.
  - Checks write errors explicitly.
- `featureEnabled()` now handles `os.UserHomeDir()` failure safely.

Security value:
- Reduces local disclosure risk by forcing private permissions for marker directory/file.
- Avoids silent write failures in feature-flag file creation.

### 3) Scripted / repeatable patch verification
- Added `components/main-chef-wrapper/security_hygiene_check.sh`.
- Script reruns security-focused tests and verifies hardened code patterns are present.

## Tests and Evidence

Focused tests run (post-change):
```
cd components/main-chef-wrapper
go test ./cmd -run TestValidateRolloutSetupContract -count=1
ok .../cmd

go test -vet=off . -run 'TestLicenseFlagPathUsesChefSubdir|TestEnableLicenseFlagWritesPrivateMarker' -count=1
ok .../main-chef-wrapper
```

Scripted verification run:
```
bash components/main-chef-wrapper/security_hygiene_check.sh
Running rollout input validation contract tests...
ok .../cmd
Running license flag hardening tests...
ok .../main-chef-wrapper
Verifying hardened patterns are present...
Security hygiene checks passed.
```

Side-effect review:
- `go test ./...` still reports the same pre-existing root-package vet findings seen in baseline branch `learn/run/neha-p6-ex7`.
- `cmd`, `integration`, and `lib` package test behavior remains passing.

## Documentation Update

Updated `ai-track-docs/security-secrets.md` with:
- Ex8 hardening summary
- rationale for each change
- repeatable script command for validation

## ACCEPTANCE
- At least one meaningful security improvement applied
- Security documentation updated
- Changes reviewed for side effects
- Evidence or justification included in PR
- Scripted or repeatable patch approach documented

## Risk & Rollback
- Risk: low (validation and file-permission hardening only)

Rollback specific change sets:

1) Rollout env validation hardening rollback:
```
cd /Users/npansare/chef_workstation_repo/chef-workstation
git checkout learn/run/neha-p6-ex7 -- components/main-chef-wrapper/cmd/push.go components/main-chef-wrapper/cmd/push_contract_test.go
git add components/main-chef-wrapper/cmd/push.go components/main-chef-wrapper/cmd/push_contract_test.go
git commit -s -m "Rollback Ex8: revert rollout env validation hardening"
```

2) License marker file hardening rollback:
```
cd /Users/npansare/chef_workstation_repo/chef-workstation
git checkout learn/run/neha-p6-ex7 -- components/main-chef-wrapper/main.go components/main-chef-wrapper/main_test.go
git add components/main-chef-wrapper/main.go components/main-chef-wrapper/main_test.go
git commit -s -m "Rollback Ex8: revert license marker file hardening"
```

3) Script/docs rollback:
```
cd /Users/npansare/chef_workstation_repo/chef-workstation
git checkout learn/run/neha-p6-ex7 -- ai-track-docs/security-secrets.md
git rm -f components/main-chef-wrapper/security_hygiene_check.sh
git add ai-track-docs/security-secrets.md
git commit -s -m "Rollback Ex8: revert security guidance and script"
```

Full rollback of Ex8 commit:
```
cd /Users/npansare/chef_workstation_repo/chef-workstation
git revert e5592f89
git push origin learn/run/neha-p6-ex8
```

## Track
- Level: Run
- Exercise: Ex8
