### PR TITLE
GHCP -- Run: Ex10 CI/CD Baseline

### DIFF
--- a/.github/workflows/contract-rollout-validation.yml
+++ b/.github/workflows/contract-rollout-validation.yml
@@ -10,15 +10,21 @@ on:
       - 'components/main-chef-wrapper/cmd/push_contract_test.go'
       - '.github/workflows/contract-rollout-validation.yml'
   push:
+    branches: [ main ]
     paths:
       - 'components/main-chef-wrapper/cmd/push.go'
       - 'components/main-chef-wrapper/cmd/push_contract_test.go'
       - '.github/workflows/contract-rollout-validation.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rollout-contract-test:
     name: Rollout env contract
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: components/main-chef-wrapper

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -8,10 +8,15 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: Gitleaks workspace scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -19,7 +24,7 @@ jobs:
         run: |
           set -euo pipefail
           version="8.30.1"
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" -o /tmp/gitleaks.tgz
+          curl --fail --retry 3 --retry-delay 2 --retry-connrefused -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" -o /tmp/gitleaks.tgz
           tar -xzf /tmp/gitleaks.tgz -C /tmp
           chmod +x /tmp/gitleaks
           echo "/tmp" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Summary
- Implemented CI reliability improvements with minimal workflow changes.
- Added run cancellation for superseded commits via workflow `concurrency`.
- Added bounded execution via `timeout-minutes` to reduce hung-job friction.
- Hardened secret-scan download step with retry/fail-fast curl flags.

**Files touched:**
- `.github/workflows/contract-rollout-validation.yml`
- `.github/workflows/secret-scan.yml`

## CI Baseline Review

From recent runs (examples in same exercise stack):
- `Contract - Rollout Validation` ran on both `push` and `pull_request` for feature branches (duplicate runs per commit).
  - Example branch `learn/run/neha-p6-ex9` had both push and PR contract runs.
- Several jobs had no explicit timeout, so hangs could consume runner time and slow feedback.
- Secret-scan gitleaks download used a single-shot curl call with no retry behavior.

## Reliability Improvements Implemented

### 1) Remove duplicate contract runs on feature-branch pushes
File: `.github/workflows/contract-rollout-validation.yml`
- Changed `push` trigger to `branches: [ main ]`.
- Effect: feature branches get PR validation only, avoiding duplicate push+PR runs for same commit.

### 2) Cancel superseded in-progress runs
Files:
- `.github/workflows/contract-rollout-validation.yml`
- `.github/workflows/secret-scan.yml`

Added:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

Effect:
- New commits automatically cancel older in-progress runs for same workflow/PR ref.
- Reduces queue pressure and stale signal noise.

### 3) Bound job runtime and harden network step
Files:
- `.github/workflows/contract-rollout-validation.yml`
- `.github/workflows/secret-scan.yml`

Changes:
- Added `timeout-minutes: 10` to both jobs.
- Updated gitleaks download curl to:
  - `--fail`
  - `--retry 3`
  - `--retry-delay 2`
  - `--retry-connrefused`

Effect:
- Better resilience to transient network failures.
- Faster failure for persistent issues.
- Prevents unbounded hung jobs.

## Before / After Evidence

### Before (baseline)
- Duplicate contract runs observed for feature branches:
  - `Contract - Rollout Validation` on `push` and `pull_request` for same branch/changes.
- No explicit timeout for contract/secret-scan jobs.

### After (this PR branch)
- Workflow config now limits contract `push` to `main` only.
- Both workflows include concurrency cancellation and 10-minute timeouts.
- Secret scan download now has retry/fail-fast behavior.

### Pipeline status evidence
- CI for this PR branch is tracked in PR checks.
- `gh pr checks` output included in exercise evidence section.

## Rollback Plan

Rollback only contract workflow changes:
```sh
cd /Users/npansare/chef_workstation_repo/chef-workstation
git checkout learn/run/neha-p6-ex9 -- .github/workflows/contract-rollout-validation.yml
git add .github/workflows/contract-rollout-validation.yml
git commit -s -m "Rollback Ex10: revert contract workflow reliability changes"
```

Rollback only secret-scan workflow changes:
```sh
cd /Users/npansare/chef_workstation_repo/chef-workstation
git checkout learn/run/neha-p6-ex9 -- .github/workflows/secret-scan.yml
git add .github/workflows/secret-scan.yml
git commit -s -m "Rollback Ex10: revert secret-scan reliability changes"
```

Rollback full Ex10 commit:
```sh
cd /Users/npansare/chef_workstation_repo/chef-workstation
git revert 259940d2
git push origin learn/run/neha-p6-ex10
```

## ACCEPTANCE
- At least one reliability improvement implemented
- CI remains green
- Rollback plan documented
- Improvement impact explained with evidence
- Before/after comparison included

## Track
- Level: Run
- Exercise: Ex10
