### PR TITLE
Ex13: feature flag helper for HTTP diagnostics

### DIFF
--- a/ai-track-docs/BACKLOG-EX12.md
+++ b/ai-track-docs/BACKLOG-EX12.md
@@ -1,89 +1,207 @@
-# Backlog EX12
+# Backlog EX12: Groomed and Prioritized
 
-This backlog is formatted to be easy to copy into Azure Boards or a similar tracker.
+Target subsystem: components/chef-automate-collect/commands
 
-## BL-001: Align Go toolchain baseline for chef-automate-collect
+Tracker access was not used in this exercise, so this file is the documented backlog artifact for PR attachment/reference.
 
-**Observation**
+## Prioritized Backlog Items
 
-`chef-automate-collect` still declares `go 1.14`, while recent local validation for this repo used a much newer Go toolchain.
+### EX12-BL-1 (P1): Remove raw config struct logging in merge path
 
-**Acceptance Criteria**
+Priority rationale: highest security-to-effort value, isolated code path, low regression risk.
 
-1. Confirm the minimum Go version used in CI and by supported contributor workflows.
-2. Either update `components/chef-automate-collect/go.mod` to the supported floor or document why `go 1.14` must remain.
-3. Record the decision in a contributor-facing doc so local setup and CI expectations match.
+Good first task: Yes (agent-friendly)
 
-**Code Links**
+Suggested owner: Agent or new team contributor
 
-- [components/chef-automate-collect/go.mod#L3](components/chef-automate-collect/go.mod#L3)
+Acceptance Criteria
 
-## BL-002: Add focused Go validation to CI for crawl-track checks
+1. Replace raw struct logging in ApplyValuesFrom with safe, field-specific logging.
+2. Ensure auth token values are never logged in cleartext from this merge path.
+3. Add or adjust a unit test that fails if token material appears in verbose output.
 
-**Observation**
+Code links
 
-The current GitHub Actions workflow runs Ruby verification only. The focused Go validation path for `chef-automate-collect` exists as a local script, but not as a CI job.
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L547)
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L548)
+- [components/chef-automate-collect/commands/automate_config_test.go](components/chef-automate-collect/commands/automate_config_test.go#L245)
 
-**Acceptance Criteria**
+### EX12-BL-2 (P1): Stop raw HTTP body/header verbose dumping in test-config path
 
-1. Add a CI job that runs the same focused checks as the local fallback script.
-2. Keep the job scoped to `chef-automate-collect` rather than widening to repo-wide Go validation.
-3. Document the CI job name and when contributors should use local fallback versus CI.
+Priority rationale: reduces accidental secret leakage in verbose logs while preserving troubleshooting value.
 
-**Code Links**
+Good first task: Yes (agent-friendly)
 
-- [.github/workflows/unit.yml#L16](.github/workflows/unit.yml#L16)
-- [.github/workflows/unit.yml#L26](.github/workflows/unit.yml#L26)
-- [scripts/run-crawl-checks.sh#L17](scripts/run-crawl-checks.sh#L17)
+Suggested owner: Agent or core maintainer
 
-## BL-003: Remove raw config struct logging from AutomateConfig merge path
+Acceptance Criteria
 
-**Observation**
+1. Replace raw response header/body dump with structured/sanitized log fields.
+2. Preserve status_code and operation-level diagnostics for failures.
+3. Add or adjust tests to ensure response body is not directly emitted to verbose logs by default.
 
-`ApplyValuesFrom` currently logs whole config structs with `%+v`, which is risky because the struct contains secret-bearing fields such as `authToken`.
+Code links
 
-**Acceptance Criteria**
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L621)
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L624)
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L638)
+- [components/chef-automate-collect/commands/automate_config_test.go](components/chef-automate-collect/commands/automate_config_test.go#L35)
 
-1. Replace raw struct dumping with safe, field-specific logging.
-2. Ensure no secret-bearing field values are written to verbose logs.
-3. Add a test proving secret values are not exposed through the replacement logging path.
+### EX12-BL-3 (P2): Add deterministic tests for false-toggles on config disable env vars
 
-**Code Links**
+Priority rationale: small test-only hardening with clear behavior contract.
 
-- [components/chef-automate-collect/commands/automate_config.go#L515](components/chef-automate-collect/commands/automate_config.go#L515)
-- [components/chef-automate-collect/commands/automate_config.go#L520](components/chef-automate-collect/commands/automate_config.go#L520)
+Good first task: Yes (team delegation-ready)
 
-## BL-004: Extend structured logging to HTTP config-test requests
+Suggested owner: Agent or QA-focused contributor
 
-**Observation**
+Acceptance Criteria
 
-Structured logs now exist for `config_load`, but the HTTP request path still emits ad hoc trace lines and raw response diagnostics.
+1. Add tests covering false vs non-false behavior for CHEF_AC_NO_REPO_CONFIG, CHEF_AC_NO_USER_CONFIG, and CHEF_AC_NO_SYSTEM_CONFIG.
+2. Validate that explicit false keeps loading enabled while any other set value disables loading.
+3. Keep test scope limited to config path discovery behavior.
 
-**Acceptance Criteria**
+Code links
 
-1. Add structured logs for the HTTP config-test boundary using consistent fields such as `op`, `status`, and `elapsed_ms`.
-2. Include a small set of safe extra fields such as host or response code.
-3. Avoid logging secret headers or raw sensitive body content by default.
+- [components/chef-automate-collect/commands/environment_variables.go](components/chef-automate-collect/commands/environment_variables.go#L42)
+- [components/chef-automate-collect/commands/environment_variables.go](components/chef-automate-collect/commands/environment_variables.go#L46)
+- [components/chef-automate-collect/commands/environment_variables.go](components/chef-automate-collect/commands/environment_variables.go#L50)
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L136)
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L206)
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L241)
 
-**Code Links**
+### EX12-BL-4 (P2): Enrich HTTP retry failure context with attempts and final status
 
-- [components/chef-automate-collect/commands/automate_config.go#L111](components/chef-automate-collect/commands/automate_config.go#L111)
-- [components/chef-automate-collect/commands/automate_config.go#L543](components/chef-automate-collect/commands/automate_config.go#L543)
-- [components/chef-automate-collect/commands/automate_config.go#L557](components/chef-automate-collect/commands/automate_config.go#L557)
+Priority rationale: medium effort, high diagnosability for transient failures.
 
-## BL-005: Replace or govern internal Go pseudo-versions
+Good first task: No (requires careful error-contract changes)
 
-**Observation**
+Suggested owner: Team maintainer
 
-The component depends on internal modules via pseudo-versions. That makes the dependency baseline harder to reason about and less predictable for release/backport work.
+Acceptance Criteria
 
-**Acceptance Criteria**
+1. Include attempt count in final error from doHTTPRequestWithResilience when retries are exhausted.
+2. Include final retryable status code context in error output while avoiding sensitive body/header data.
+3. Update existing resilience tests to assert the new error shape.
 
-1. Decide whether internal components should publish tags for dependency consumption.
-2. Replace long-lived pseudo-versions with tagged versions where the release process supports it.
-3. If tags are not yet feasible, document the policy for when pseudo-versions are allowed.
+Code links
 
-**Code Links**
+- [components/chef-automate-collect/commands/http_resilience.go](components/chef-automate-collect/commands/http_resilience.go#L20)
+- [components/chef-automate-collect/commands/http_resilience.go](components/chef-automate-collect/commands/http_resilience.go#L58)
+- [components/chef-automate-collect/commands/http_resilience.go](components/chef-automate-collect/commands/http_resilience.go#L68)
+- [components/chef-automate-collect/commands/http_resilience_test.go](components/chef-automate-collect/commands/http_resilience_test.go#L17)
 
-- [components/chef-automate-collect/go.mod#L7](components/chef-automate-collect/go.mod#L7)
-- [components/chef-automate-collect/go.mod#L8](components/chef-automate-collect/go.mod#L8)
+### EX12-BL-5 (P3): Escape structured log values for whitespace and separators
+
+Priority rationale: observability quality improvement for parsers and log tooling.
+
+Good first task: Yes (isolated utility-level change)
+
+Suggested owner: Agent
+
+Acceptance Criteria
+
+1. Ensure structured log values containing spaces or equals signs are safely encoded before emission.
+2. Preserve current required fields and field order.
+3. Add unit tests covering encoded output for representative edge values.
+
+Code links
+
+- [components/chef-automate-collect/commands/cli_io.go](components/chef-automate-collect/commands/cli_io.go#L51)
+- [components/chef-automate-collect/commands/cli_io.go](components/chef-automate-collect/commands/cli_io.go#L62)
+- [components/chef-automate-collect/commands/cli_io_test.go](components/chef-automate-collect/commands/cli_io_test.go#L45)
+
+## Prioritization and Delegation Summary
+
+Execution order
+
+1. EX12-BL-1
+2. EX12-BL-2
+3. EX12-BL-3
+4. EX12-BL-4
+5. EX12-BL-5
+
+Best first delegation tasks
+
+- EX12-BL-1
+- EX12-BL-2
+- EX12-BL-3
+- EX12-BL-5
+
+## Simulated Patch Plan (Delegation Example)
+
+Chosen item: EX12-BL-1
+
+### 1) Short patch plan
+
+1. Replace raw struct debug line in ApplyValuesFrom with explicit safe fields.
+2. Keep URL and InsecureTLS visibility, redact token presence as boolean indicator only.
+3. Add a focused verbose-log test that asserts token text never appears.
+4. Run focused unit tests in commands package.
+
+### 2) Files to change
+
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go)
+- [components/chef-automate-collect/commands/automate_config_test.go](components/chef-automate-collect/commands/automate_config_test.go)
+
+### 3) Simulated diff
+
+File: components/chef-automate-collect/commands/automate_config.go
+
+- cliIO.verbose("applying config %+v to existing %+v", *other, *a)
++ cliIO.verbose("applying config changes url_set=%t token_set=%t insecure_tls_set=%t", other.URL != "", other.authToken != "", other.InsecureTLS)
+
+File: components/chef-automate-collect/commands/automate_config_test.go
+
++ func TestApplyValuesFromDoesNotLogAuthToken(t *testing.T) {
++     // Arrange two configs with distinct tokens and verbose enabled.
++     // Capture stderr, call ApplyValuesFrom, assert token text is absent.
++ }
+
+### 4) Generate or adjust tests
+
+Add test coverage
+
+- Add TestApplyValuesFromDoesNotLogAuthToken in [components/chef-automate-collect/commands/automate_config_test.go](components/chef-automate-collect/commands/automate_config_test.go)
+
+Focused test command
+
+- go test ./commands -run TestApplyValuesFromDoesNotLogAuthToken -count=1
+
+### 5) Before and after evidence
+
+Before evidence
+
+- [components/chef-automate-collect/commands/automate_config.go](components/chef-automate-collect/commands/automate_config.go#L548) logs full structs with %+v, which can expose secret fields in verbose mode.
+
+After evidence (expected)
+
+- Verbose line contains only booleans for field presence and no raw token value.
+- New test fails on token leakage and passes on sanitized logging behavior.
+
+### 6) PR description draft (template)
+
+Title
+
+- Ex12: Backlog grooming artifact for chef-automate-collect commands
+
+Summary
+
+- Adds prioritized Ex12 backlog items for the target subsystem with acceptance criteria, code links, and delegation suitability.
+- Includes a simulated patch plan for EX12-BL-1 with files, diff sketch, tests, and evidence expectations.
+
+Changes
+
+- Updated [ai-track-docs/BACKLOG-EX12.md](ai-track-docs/BACKLOG-EX12.md)
+
+Validation
+
+- Doc-only change; no runtime behavior change.
+
+Risks
+
+- Low risk; planning artifact only.
+
+Follow-ups
+
+- Implement EX12-BL-1 as the first delegated patch.

--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -135,3 +135,33 @@ Expected behavior:
 
 - Job always passes by design.
 - Summary shows `Status=PASS` or `Status=SOFT-FAIL` and includes raw command output for reviewer context.
+
+---
+
+## Feature Flag Validation (Ex13)
+
+Target module: `components/chef-automate-collect/commands`
+
+Feature flag under test:
+
+- `CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS`
+
+ON/OFF mode tests:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run TestAutomateConfigTestHTTPVerboseDiagnosticsOffByDefault -count=1 -v
+go test ./commands -run TestAutomateConfigTestHTTPVerboseDiagnosticsOn -count=1 -v
+```
+
+Expected result:
+
+- OFF test passes and asserts HTTP response body dump is absent.
+- ON test passes and asserts HTTP response body dump is present.
+
+Captured evidence (May 22, 2026):
+
+- `=== RUN   TestAutomateConfigTestHTTPVerboseDiagnosticsOffByDefault`
+- `--- PASS: TestAutomateConfigTestHTTPVerboseDiagnosticsOffByDefault`
+- `=== RUN   TestAutomateConfigTestHTTPVerboseDiagnosticsOn`
+- `--- PASS: TestAutomateConfigTestHTTPVerboseDiagnosticsOn`

--- a/ai-track-docs/extending-environment-variables.md
+++ b/ai-track-docs/extending-environment-variables.md
@@ -33,3 +33,33 @@ go build ./...
 - Treat these constants as part of the external configuration surface.
 - Changing a constant value is a behavior change, not a refactor.
 - Prefer adding to an existing themed block rather than creating ad hoc grouping.
+
+## Ex13 Feature Flag Example
+
+Flag name pattern:
+
+- `CHEF_AC_FF_<BEHAVIOR_NAME>`
+
+Implemented flag:
+
+- `CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS`
+
+Purpose:
+
+- Controls verbose HTTP trace/response diagnostics in `AutomateConfig.Test`.
+- Keeps default behavior risk low for higher-impact logging changes by requiring explicit opt-in.
+
+Default state:
+
+- `false` (disabled unless set to `true`).
+
+Toggle mechanism:
+
+- Set `CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS=true` to enable verbose HTTP diagnostics.
+- Set `CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS=false` to disable.
+- Any invalid value falls back to the default (`false`).
+
+Rollback path:
+
+1. Immediate rollback: set `CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS=false` in the environment.
+2. Code rollback: revert the Ex13 feature-flag commit if complete removal is required.

--- a/components/chef-automate-collect/commands/automate_config.go
+++ b/components/chef-automate-collect/commands/automate_config.go
@@ -562,6 +562,7 @@ func (a *AutomateConfig) Test() error {
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: a.InsecureTLS}
 	httpClient := &http.Client{Transport: tr}
 	start := time.Now()
+	httpVerboseDiagnosticsEnabled := featureFlagEnabled(httpVerboseDiagnosticsFlag, os.LookupEnv, cliIO.verbose)
 
 	testURL, err := a.TestURL()
 	if err != nil {
@@ -572,6 +573,10 @@ func (a *AutomateConfig) Test() error {
 	host := testURL.Host
 	trace := &httptrace.ClientTrace{
 		DNSDone: func(d httptrace.DNSDoneInfo) {
+			if !httpVerboseDiagnosticsEnabled {
+				return
+			}
+
 			addrStrs := make([]string, len(d.Addrs))
 			for i, addr := range d.Addrs {
 				addrStrs[i] = addr.String()
@@ -589,6 +594,10 @@ func (a *AutomateConfig) Test() error {
 			cliIO.verbose("HTTP TRACE: %q resolved to %v", host, addrStrs)
 		},
 		GotConn: func(c httptrace.GotConnInfo) {
+			if !httpVerboseDiagnosticsEnabled {
+				return
+			}
+
 			cliIO.verbose("HTTP TRACE: connected to %q (reused: %t) (was idle: %t)",
 				c.Conn.RemoteAddr(), c.Reused, c.WasIdle)
 		},
@@ -618,12 +627,18 @@ func (a *AutomateConfig) Test() error {
 		return err
 	}
 
-	for k, v := range response.Header {
-		cliIO.verbose("HTTP RESPONSE HEADER %s: %s", k, strings.Join(v, ", "))
+	if httpVerboseDiagnosticsEnabled {
+		for k, v := range response.Header {
+			cliIO.verbose("HTTP RESPONSE HEADER %s: %s", k, strings.Join(v, ", "))
+		}
+		cliIO.verbose("HTTP RESPONSE BODY------------")
+		cliIO.verbose(string(bodyBytes))
+		cliIO.verbose("\nEND HTTP RESPONSE BODY--------")
 	}
-	cliIO.verbose("HTTP RESPONSE BODY------------")
-	cliIO.verbose(string(bodyBytes))
-	cliIO.verbose("\nEND HTTP RESPONSE BODY--------")
+
+	cliIO.structuredVerbose("feature_flag", "evaluated", 0,
+		StructuredField{Key: "flag", Value: httpVerboseDiagnosticsFlag.Name},
+		StructuredField{Key: "enabled", Value: fmt.Sprintf("%t", httpVerboseDiagnosticsEnabled)})
 
 	if response.StatusCode != 200 {
 		emitTestConfigHTTPStructuredLog(start, "error", response.StatusCode)

--- a/components/chef-automate-collect/commands/automate_config_test.go
+++ b/components/chef-automate-collect/commands/automate_config_test.go
@@ -85,6 +85,78 @@ func TestAutomateConfigTestEmitsStructuredHTTPLog(t *testing.T) {
 	}
 }
 
+func TestAutomateConfigTestHTTPVerboseDiagnosticsOffByDefault(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"token":"should-not-log"}`))
+	}))
+	defer server.Close()
+
+	c := &AutomateConfig{
+		URL:         server.URL,
+		authToken:   "test-token",
+		InsecureTLS: true,
+	}
+
+	originalVerbose := cliIO.EnableVerbose
+	cliIO.EnableVerbose = true
+	defer func() {
+		cliIO.EnableVerbose = originalVerbose
+	}()
+
+	t.Setenv(StructuredLogsEnvVar, "true")
+	t.Setenv(HTTPVerboseDiagnosticsEnvVar, "false")
+
+	restore, readOutput := captureStderrForTestConfig(t)
+	err := c.Test()
+	restore()
+	output := readOutput()
+
+	if err != nil {
+		t.Fatalf("expected test-config request to succeed, got error: %v", err)
+	}
+
+	if strings.Contains(output, "HTTP RESPONSE BODY------------") {
+		t.Fatalf("expected response body diagnostics to be disabled, got %q", output)
+	}
+}
+
+func TestAutomateConfigTestHTTPVerboseDiagnosticsOn(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"debug":"visible-when-flag-on"}`))
+	}))
+	defer server.Close()
+
+	c := &AutomateConfig{
+		URL:         server.URL,
+		authToken:   "test-token",
+		InsecureTLS: true,
+	}
+
+	originalVerbose := cliIO.EnableVerbose
+	cliIO.EnableVerbose = true
+	defer func() {
+		cliIO.EnableVerbose = originalVerbose
+	}()
+
+	t.Setenv(StructuredLogsEnvVar, "true")
+	t.Setenv(HTTPVerboseDiagnosticsEnvVar, "true")
+
+	restore, readOutput := captureStderrForTestConfig(t)
+	err := c.Test()
+	restore()
+	output := readOutput()
+
+	if err != nil {
+		t.Fatalf("expected test-config request to succeed, got error: %v", err)
+	}
+
+	if !strings.Contains(output, "HTTP RESPONSE BODY------------") {
+		t.Fatalf("expected response body diagnostics when feature flag is on, got %q", output)
+	}
+}
+
 func TestAutomateConfigTestRetriesTransientServerError(t *testing.T) {
 	hits := 0
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/components/chef-automate-collect/commands/cli_io.go
+++ b/components/chef-automate-collect/commands/cli_io.go
@@ -20,12 +20,7 @@ type CLIIO struct {
 }
 
 func structuredLoggingEnabled(lookupEnv func(string) (string, bool)) bool {
-	value, isSet := lookupEnv(StructuredLogsEnvVar)
-	if !isSet {
-		return true
-	}
-
-	return strings.TrimSpace(value) != "false"
+	return featureFlagEnabled(structuredLoggingFlag, lookupEnv, func(string, ...interface{}) {})
 }
 
 func (c *CLIIO) msg(format string, args ...interface{}) {

--- a/components/chef-automate-collect/commands/environment_variables.go
+++ b/components/chef-automate-collect/commands/environment_variables.go
@@ -56,6 +56,9 @@ const (
 	// logs are disabled. Any other value, or an unset variable, leaves them
 	// enabled.
 	StructuredLogsEnvVar = "CHEF_AC_STRUCTURED_LOGS"
+	// Feature flag that enables verbose HTTP response diagnostics in test-config.
+	// Defaults to disabled unless set to "true".
+	HTTPVerboseDiagnosticsEnvVar = "CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS"
 
 	// Whether to disable reporting new rollouts to Chef Automate. If set to
 	// "false," reports will be sent. If set to any other value, reports will not

--- a/components/chef-automate-collect/commands/environment_variables_test.go
+++ b/components/chef-automate-collect/commands/environment_variables_test.go
@@ -14,6 +14,7 @@ func TestEnvironmentVariableConstantsStable(t *testing.T) {
 		"NoUserConfigEnvVar":            NoUserConfigEnvVar,
 		"NoSystemConfigEnvVar":          NoSystemConfigEnvVar,
 		"StructuredLogsEnvVar":          StructuredLogsEnvVar,
+		"HTTPVerboseDiagnosticsEnvVar":  HTTPVerboseDiagnosticsEnvVar,
 		"DisableReportNewRolloutEnvVar": DisableReportNewRolloutEnvVar,
 		"GitRemoteNameEnvVar":           GitRemoteNameEnvVar,
 	}
@@ -29,6 +30,7 @@ func TestEnvironmentVariableConstantsStable(t *testing.T) {
 		"NoUserConfigEnvVar":            "CHEF_AC_NO_USER_CONFIG",
 		"NoSystemConfigEnvVar":          "CHEF_AC_NO_SYSTEM_CONFIG",
 		"StructuredLogsEnvVar":          "CHEF_AC_STRUCTURED_LOGS",
+		"HTTPVerboseDiagnosticsEnvVar":  "CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS",
 		"DisableReportNewRolloutEnvVar": "CHEF_AC_DISABLE_COLLECTOR",
 		"GitRemoteNameEnvVar":           "CHEF_AC_GIT_REMOTE_NAME",
 	}

--- a/components/chef-automate-collect/commands/feature_flags.go
+++ b/components/chef-automate-collect/commands/feature_flags.go
@@ -1,0 +1,42 @@
+package commands
+
+import "strings"
+
+type featureFlag struct {
+	Name           string
+	EnvVar         string
+	DefaultEnabled bool
+}
+
+func featureFlagEnabled(flag featureFlag, lookupEnv func(string) (string, bool), logf func(string, ...interface{})) bool {
+	rawValue, isSet := lookupEnv(flag.EnvVar)
+	if !isSet {
+		logf("feature flag %s (%s) unset; using default=%t", flag.Name, flag.EnvVar, flag.DefaultEnabled)
+		return flag.DefaultEnabled
+	}
+
+	value := strings.ToLower(strings.TrimSpace(rawValue))
+	switch value {
+	case "true":
+		logf("feature flag %s (%s) resolved=true from value %q", flag.Name, flag.EnvVar, rawValue)
+		return true
+	case "false":
+		logf("feature flag %s (%s) resolved=false from value %q", flag.Name, flag.EnvVar, rawValue)
+		return false
+	default:
+		logf("feature flag %s (%s) has invalid value %q; using default=%t", flag.Name, flag.EnvVar, rawValue, flag.DefaultEnabled)
+		return flag.DefaultEnabled
+	}
+}
+
+var structuredLoggingFlag = featureFlag{
+	Name:           "structured_logging",
+	EnvVar:         StructuredLogsEnvVar,
+	DefaultEnabled: true,
+}
+
+var httpVerboseDiagnosticsFlag = featureFlag{
+	Name:           "http_verbose_diagnostics",
+	EnvVar:         HTTPVerboseDiagnosticsEnvVar,
+	DefaultEnabled: false,
+}

--- a/components/chef-automate-collect/commands/feature_flags_test.go
+++ b/components/chef-automate-collect/commands/feature_flags_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import "testing"
+
+func TestFeatureFlagEnabledDefaultsWhenUnset(t *testing.T) {
+	flag := featureFlag{Name: "sample", EnvVar: "CHEF_AC_FF_SAMPLE", DefaultEnabled: false}
+	got := featureFlagEnabled(flag, func(string) (string, bool) {
+		return "", false
+	}, func(string, ...interface{}) {})
+
+	if got {
+		t.Fatal("expected default false when env var is unset")
+	}
+}
+
+func TestFeatureFlagEnabledResolvesTrue(t *testing.T) {
+	flag := featureFlag{Name: "sample", EnvVar: "CHEF_AC_FF_SAMPLE", DefaultEnabled: false}
+	got := featureFlagEnabled(flag, func(string) (string, bool) {
+		return " true ", true
+	}, func(string, ...interface{}) {})
+
+	if !got {
+		t.Fatal("expected true when env var is true")
+	}
+}
+
+func TestFeatureFlagEnabledResolvesFalse(t *testing.T) {
+	flag := featureFlag{Name: "sample", EnvVar: "CHEF_AC_FF_SAMPLE", DefaultEnabled: true}
+	got := featureFlagEnabled(flag, func(string) (string, bool) {
+		return "false", true
+	}, func(string, ...interface{}) {})
+
+	if got {
+		t.Fatal("expected false when env var is false")
+	}
+}
+
+func TestFeatureFlagEnabledFallsBackOnInvalidValue(t *testing.T) {
+	flag := featureFlag{Name: "sample", EnvVar: "CHEF_AC_FF_SAMPLE", DefaultEnabled: true}
+	got := featureFlagEnabled(flag, func(string) (string, bool) {
+		return "sometimes", true
+	}, func(string, ...interface{}) {})
+
+	if !got {
+		t.Fatal("expected default true when env var value is invalid")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a reusable feature-flag helper pattern for the chef-automate-collect commands module
- Introduce CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS to gate verbose HTTP response diagnostics in test-config flow
- Reuse the helper for structured logging flag evaluation to apply the pattern across the module
- Update docs with flag purpose, toggle semantics, rollback path, and ON/OFF validation commands

## Feature Flag Design
- Naming convention: CHEF_AC_FF_<BEHAVIOR_NAME>
- Implemented flag: CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS
- Default state: false (safe by default)
- Toggle mechanism: env var true/false, invalid values fall back to default

## Telemetry / Observability
- Added structured verbose event for flag evaluation in AutomateConfig.Test
- Existing structured logging infrastructure is used when enabled

## Validation Evidence (ON/OFF)
- go test ./commands -run TestAutomateConfigTestHTTPVerboseDiagnosticsOffByDefault -count=1 -v
- go test ./commands -run TestAutomateConfigTestHTTPVerboseDiagnosticsOn -count=1 -v
- Captured result: both tests PASS and assert OFF suppresses body dump while ON emits it

## Documentation
- ai-track-docs/extending-environment-variables.md
- ai-track-docs/build-test.md

## Rollback
1. Immediate rollback: set CHEF_AC_FF_HTTP_VERBOSE_DIAGNOSTICS=false
2. Code rollback: revert this commit
