### PR TITLE
Ex15: command resilience helper, failure tests, and ops runbook

### DIFF
--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -200,3 +200,36 @@ Captured evidence (May 22, 2026):
 - `staticcheck ./commands/...` returned no findings.
 - `go test ./commands -vet=all -run '^$'` returned `ok` with no tests to run.
 - `go test ./commands -count=1` returned `ok`.
+
+---
+
+## Resilience and Error Handling Validation (Ex15)
+
+Target folder: `components/chef-automate-collect/commands`
+
+Failure simulation tests:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run 'TestExecuteCommandWithResilience' -count=1 -v
+```
+
+Package validation:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -count=1
+go build ./...
+```
+
+Expected result:
+
+- Failure simulation tests pass for timeout, transient error retry, and retry exhaustion paths.
+- commands package tests and build pass.
+
+Captured evidence (May 22, 2026):
+
+- `--- PASS: TestExecuteCommandWithResilienceRetriesOnErrorThenSucceeds`
+- `--- PASS: TestExecuteCommandWithResilienceReturnsErrorAfterExhaustion`
+- `--- PASS: TestExecuteCommandWithResilienceHandlesTimeouts`
+- `ok .../commands` from package test run.

--- a/ai-track-docs/ops-runbook.md
+++ b/ai-track-docs/ops-runbook.md
@@ -1,0 +1,73 @@
+# Ops Runbook: Resilience Patterns
+
+## Scope
+
+This runbook covers Ex15 command resilience behavior in:
+
+- `components/chef-automate-collect/commands`
+
+## Feature Summary
+
+A timeout/backoff helper wraps external `git` command invocations used by rollout metadata collection.
+
+Applied call paths:
+
+1. `git rev-parse --git-dir`
+2. `git rev-list -1 HEAD ...`
+3. `git show -s --format=...`
+4. `git ls-remote --get-url ...`
+
+## Tuning Parameters
+
+Configured in `metadata_collectors.go` via `gitCommandResilienceOptions`:
+
+- `MaxAttempts` (default `3`)
+- `InitialBackoff` (default `150ms`)
+- `PerAttemptTimeout` (default `2s`)
+
+Backoff sequence with current defaults:
+
+- attempt 1 -> 2: `150ms`
+- attempt 2 -> 3: `300ms`
+
+## Failure Signals
+
+Typical log and error indicators:
+
+- wrapped command failure message including attempt count
+- `context deadline exceeded` for timeout-driven retries
+- final error return from metadata collection command path
+
+## Escalation Steps
+
+1. Confirm reproducibility with local command:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -run 'TestExecuteCommandWithResilience' -count=1 -v
+```
+
+2. Validate git command behavior outside the app in the affected repository:
+
+```sh
+git -C <repo-path> rev-parse --git-dir
+git -C <repo-path> ls-remote --get-url origin
+```
+
+3. If failures persist in production workflows:
+- collect logs and failing command context
+- reduce blast radius by temporarily lowering retries to 1 or increasing timeout to isolate timeout-vs-command errors
+- escalate to on-call maintainers with command output and environment details
+
+4. Open incident follow-up if repeated failures exceed operational threshold.
+
+## Rollback
+
+1. Immediate rollback path: revert Ex15 commit in rollout branch.
+2. Verify rollback by rerunning:
+
+```sh
+cd components/chef-automate-collect
+go test ./commands -count=1
+go build ./...
+```

--- a/ai-track-docs/resilience.md
+++ b/ai-track-docs/resilience.md
@@ -4,63 +4,77 @@
 
 This note documents Ex15 resilience improvements in `chef-automate-collect`.
 
+Target folder:
+
+- `components/chef-automate-collect/commands`
+
+## Current Behavior Before Ex15
+
+The following external `git` command call paths in `ReadGitMetadata()` had no timeout/backoff handling and failed immediately on transient command errors:
+
+1. `git rev-list -1 HEAD ...` commit lookup
+2. `git show -s --format=...` metadata extraction
+3. `git ls-remote --get-url ...` remote URL resolution
+
+Under failure, each path returned an error (or unknown SCM fallback for repo detection) without retrying transient conditions.
+
 ## Improvement Implemented
 
 Paths:
 
-- `components/chef-automate-collect/commands/http_resilience.go`
-- `components/chef-automate-collect/commands/automate_config.go`
-- `components/chef-automate-collect/commands/report_new_rollout.go`
+- `components/chef-automate-collect/commands/command_resilience.go`
+- `components/chef-automate-collect/commands/metadata_collectors.go`
+- `components/chef-automate-collect/commands/command_resilience_test.go`
+- `ai-track-docs/ops-runbook.md`
 
 Change:
 
-- Added a shared HTTP resilience helper with:
+- Added a shared command resilience helper with:
 	- bounded retry attempts
 	- exponential backoff between attempts
-	- per-attempt timeout via request context
-- Integrated helper at two external call sites:
-	- `AutomateConfig.Test()`
-	- `runReportNewRolloutCommand()` API call path
+	- per-attempt timeout via context
+- Applied helper to multiple external `git` call paths in `ReadGitMetadata()`:
+	- repo detection: `git rev-parse --git-dir`
+	- commit lookup: `git rev-list -1 HEAD ...`
+	- commit metadata extraction: `git show -s --format=...`
+	- remote URL lookup: `git ls-remote --get-url ...`
 
 Why this helps:
 
-- Transient server/network failures now get automatic retries.
-- Requests no longer risk hanging indefinitely per attempt.
-- Retry behavior is consistent across both call sites.
+- Transient external command failures now get automatic retries.
+- External command attempts are bounded by per-attempt timeout.
+- Retry behavior is now consistent across multiple git metadata collection paths.
 
 ## Tuning Parameters
 
 Current defaults (in code):
 
 - `MaxAttempts`: `3`
-- `InitialBackoff`: `200ms`
-- `PerAttemptTimeout`: `5s`
-- `RetryStatusCodes`: `500`, `502`, `503`, `504`
+- `InitialBackoff`: `150ms`
+- `PerAttemptTimeout`: `2s`
 
 The effective max retry wait time is exponential backoff:
 
-- attempt 1 -> attempt 2: `200ms`
-- attempt 2 -> attempt 3: `400ms`
+- attempt 1 -> attempt 2: `150ms`
+- attempt 2 -> attempt 3: `300ms`
 
-Total added wait from backoff is up to `600ms` (excluding request execution time).
+Total added wait from backoff is up to `450ms` (excluding per-attempt execution time).
 
 ## Failure Behavior
 
-- Retryable HTTP statuses (`500/502/503/504`) are retried up to max attempts.
-- Transport-level errors (including timeout-like errors) are retried up to max attempts.
-- Non-retryable statuses are returned immediately to existing status handling logic.
+- External command failures are retried up to max attempts.
+- Timeout-like command failures are retried up to max attempts.
+- On exhaustion, the final wrapped error is returned to existing handling logic.
 
 ## Tests Added
 
-- `TestDoHTTPRequestWithResilienceRetriesRetryableStatus`
-- `TestDoHTTPRequestWithResilienceRetriesTimeoutLikeErrors`
-- `TestDoHTTPRequestWithResilienceSetsPerAttemptTimeout`
-- `TestAutomateConfigTestRetriesTransientServerError`
+- `TestExecuteCommandWithResilienceRetriesOnErrorThenSucceeds`
+- `TestExecuteCommandWithResilienceReturnsErrorAfterExhaustion`
+- `TestExecuteCommandWithResilienceHandlesTimeouts`
 
 Locations:
 
-- `components/chef-automate-collect/commands/http_resilience_test.go`
-- `components/chef-automate-collect/commands/automate_config_test.go`
+- `components/chef-automate-collect/commands/command_resilience_test.go`
 
 ## Rollback Guidance
 
@@ -68,7 +82,7 @@ If this causes unexpected behavior in production:
 
 1. Revert the Ex15 commit on the branch/PR.
 2. Confirm previous behavior by running `go test ./commands -count=1` in `components/chef-automate-collect`.
-3. If needed, re-introduce only one call-site integration first (start with `AutomateConfig.Test()`) and iterate.
+3. If needed, re-introduce one call path at a time (start with `git ls-remote` lookup) and iterate.
 
 ## Validation Command
 
@@ -76,6 +90,7 @@ Run from repository root:
 
 ```sh
 cd components/chef-automate-collect
+go test ./commands -run 'TestExecuteCommandWithResilience' -count=1 -v
 go test ./commands -count=1
 go build ./...
 ```

--- a/components/chef-automate-collect/commands/command_resilience.go
+++ b/components/chef-automate-collect/commands/command_resilience.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type CommandResilienceOptions struct {
+	MaxAttempts       int
+	InitialBackoff    time.Duration
+	PerAttemptTimeout time.Duration
+	Sleep             func(time.Duration)
+}
+
+type commandExecutor func(ctx context.Context, name string, args ...string) (string, error)
+
+func executeCommandWithResilience(
+	executor commandExecutor,
+	name string,
+	args []string,
+	options CommandResilienceOptions,
+) (string, error) {
+	resolved := withCommandResilienceDefaults(options)
+	var lastErr error
+
+	for attempt := 1; attempt <= resolved.MaxAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), resolved.PerAttemptTimeout)
+		output, err := executor(ctx, name, args...)
+		cancel()
+
+		if err == nil {
+			return output, nil
+		}
+
+		lastErr = errors.Wrapf(err, "command %q failed on attempt %d", name, attempt)
+		if attempt < resolved.MaxAttempts {
+			delay := resolved.InitialBackoff * time.Duration(1<<(attempt-1))
+			resolved.Sleep(delay)
+		}
+	}
+
+	return "", lastErr
+}
+
+func withCommandResilienceDefaults(options CommandResilienceOptions) CommandResilienceOptions {
+	resolved := options
+	if resolved.MaxAttempts <= 0 {
+		resolved.MaxAttempts = 3
+	}
+	if resolved.InitialBackoff <= 0 {
+		resolved.InitialBackoff = 100 * time.Millisecond
+	}
+	if resolved.PerAttemptTimeout <= 0 {
+		resolved.PerAttemptTimeout = 2 * time.Second
+	}
+	if resolved.Sleep == nil {
+		resolved.Sleep = time.Sleep
+	}
+	return resolved
+}
+
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed == "" {
+			return "", err
+		}
+		return "", errors.Wrap(err, trimmed)
+	}
+
+	return string(out), nil
+}

--- a/components/chef-automate-collect/commands/command_resilience_test.go
+++ b/components/chef-automate-collect/commands/command_resilience_test.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecuteCommandWithResilienceRetriesOnErrorThenSucceeds(t *testing.T) {
+	attempts := 0
+	sleeps := 0
+
+	executor := func(context.Context, string, ...string) (string, error) {
+		attempts++
+		if attempts < 3 {
+			return "", errors.New("temporary failure")
+		}
+		return "ok", nil
+	}
+
+	output, err := executeCommandWithResilience(executor, "git", []string{"status"}, CommandResilienceOptions{
+		MaxAttempts:       3,
+		InitialBackoff:    1 * time.Millisecond,
+		PerAttemptTimeout: 50 * time.Millisecond,
+		Sleep: func(time.Duration) {
+			sleeps++
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if output != "ok" {
+		t.Fatalf("got %q, want %q", output, "ok")
+	}
+	if attempts != 3 {
+		t.Fatalf("got %d attempts, want 3", attempts)
+	}
+	if sleeps != 2 {
+		t.Fatalf("got %d sleeps, want 2", sleeps)
+	}
+}
+
+func TestExecuteCommandWithResilienceReturnsErrorAfterExhaustion(t *testing.T) {
+	executor := func(context.Context, string, ...string) (string, error) {
+		return "", errors.New("still failing")
+	}
+
+	_, err := executeCommandWithResilience(executor, "git", []string{"status"}, CommandResilienceOptions{
+		MaxAttempts:       2,
+		InitialBackoff:    1 * time.Millisecond,
+		PerAttemptTimeout: 50 * time.Millisecond,
+		Sleep:             func(time.Duration) {},
+	})
+
+	if err == nil {
+		t.Fatal("expected non-nil error after retries exhausted")
+	}
+	if !strings.Contains(err.Error(), "attempt 2") {
+		t.Fatalf("expected final attempt in error, got %q", err.Error())
+	}
+}
+
+func TestExecuteCommandWithResilienceHandlesTimeouts(t *testing.T) {
+	attempts := 0
+
+	executor := func(ctx context.Context, _ string, _ ...string) (string, error) {
+		attempts++
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	_, err := executeCommandWithResilience(executor, "git", []string{"status"}, CommandResilienceOptions{
+		MaxAttempts:       3,
+		InitialBackoff:    1 * time.Millisecond,
+		PerAttemptTimeout: 1 * time.Millisecond,
+		Sleep:             func(time.Duration) {},
+	})
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if attempts != 3 {
+		t.Fatalf("got %d attempts, want 3", attempts)
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected timeout context in error, got %q", err.Error())
+	}
+}

--- a/components/chef-automate-collect/commands/metadata_collectors.go
+++ b/components/chef-automate-collect/commands/metadata_collectors.go
@@ -8,15 +8,21 @@ import (
 	"os"
 	fpath "path/filepath"
 	"strings"
+	"time"
 
 	req "github.com/chef/automate/api/external/cfgmgmt/request"
-	c "github.com/chef/automate/lib/platform/command"
 )
 
 var SCMType_UNKNOWN_SCM = req.SCMType_name[int32(req.SCMType_UNKNOWN_SCM)]
 var SCMType_GIT = req.SCMType_name[int32(req.SCMType_GIT)]
 var SCMWebType_UNKNOWN_SCM_WEB = req.SCMWebType_name[int32(req.SCMWebType_UNKNOWN_SCM_WEB)]
 var SCMWebType_GITHUB = req.SCMWebType_name[int32(req.SCMWebType_GITHUB)]
+
+var gitCommandResilienceOptions = CommandResilienceOptions{
+	MaxAttempts:       3,
+	InitialBackoff:    150 * time.Millisecond,
+	PerAttemptTimeout: 2 * time.Second,
+}
 
 type RolloutMetadata struct {
 	policyLockPath   string
@@ -113,16 +119,16 @@ func gitRemoteNameFromEnv(lookupEnv func(string) (string, bool)) string {
 func (s *SCMMetadata) ReadGitMetadata() error {
 	gitDir := fpath.Dir(s.policyLockPath)
 
-	g := func(args ...string) c.Opt {
-		args = append([]string{"-C", gitDir}, args...)
-		return c.Args(args...)
+	runGit := func(args ...string) (string, error) {
+		fullArgs := append([]string{"-C", gitDir}, args...)
+		return executeCommandWithResilience(runCommand, "git", fullArgs, gitCommandResilienceOptions)
 	}
 
 	s.SCMType = "UNKNOWN_SCM"
 	s.SCMWebType = SCMWebType_UNKNOWN_SCM_WEB
 
 	// test if we are in a git directory, if we are not, exit and leave scmtype set to unknown
-	_, err := c.Output("git", g("rev-parse", "--git-dir"))
+	_, err := runGit("rev-parse", "--git-dir")
 	if err != nil {
 		return nil
 	}
@@ -133,7 +139,7 @@ func (s *SCMMetadata) ReadGitMetadata() error {
 	// that it was tracked in the past but was removed; in that case, the command
 	// `git rev-list -1 Policyfile.lock.json` still returns a commit.
 
-	_, err = c.Output("git", g("ls-files", "--error-unmatch", s.policyLockPath))
+	_, err = runGit("ls-files", "--error-unmatch", s.policyLockPath)
 	lockfileIsGitTracked := (err == nil)
 
 	var commitOutput string
@@ -141,11 +147,11 @@ func (s *SCMMetadata) ReadGitMetadata() error {
 	if lockfileIsGitTracked {
 		// get last commit to the lockfile:
 		//   git rev-list -1 HEAD "$file"
-		commitOutput, err = c.Output("git", g("rev-list", "-1", "HEAD", s.policyLockPath))
+		commitOutput, err = runGit("rev-list", "-1", "HEAD", s.policyLockPath)
 	} else {
 		// last commit to the repo:
 		//   git rev-list -1 HEAD
-		commitOutput, err = c.Output("git", g("rev-list", "-1", "HEAD"))
+		commitOutput, err = runGit("rev-list", "-1", "HEAD")
 	}
 	if err != nil {
 		return err
@@ -156,7 +162,7 @@ func (s *SCMMetadata) ReadGitMetadata() error {
 
 	// get the commit message
 	//   git show -s --format=%B "$commit"
-	commitMessageOut, err := c.Output("git", g("show", "-s", "--format=%B", commit))
+	commitMessageOut, err := runGit("show", "-s", "--format=%B", commit)
 	if err != nil {
 		return err
 	}
@@ -165,12 +171,12 @@ func (s *SCMMetadata) ReadGitMetadata() error {
 	// get the author/email:
 	//   git show -s --format=%an "$commit"
 	//   git show -s --format=%ae "$commit"
-	commiterNameOut, err := c.Output("git", g("show", "-s", "--format=%an", commit))
+	commiterNameOut, err := runGit("show", "-s", "--format=%an", commit)
 	if err != nil {
 		return err
 	}
 
-	commiterEmailOut, err := c.Output("git", g("show", "-s", "--format=%ae", commit))
+	commiterEmailOut, err := runGit("show", "-s", "--format=%ae", commit)
 	if err != nil {
 		return err
 	}
@@ -181,7 +187,7 @@ func (s *SCMMetadata) ReadGitMetadata() error {
 	gitRemoteName := gitRemoteNameFromEnv(os.LookupEnv)
 	// get the URL of the remote
 	//   git ls-remote --get-url $origin
-	originURLOut, err := c.Output("git", g("ls-remote", "--get-url", gitRemoteName))
+	originURLOut, err := runGit("ls-remote", "--get-url", gitRemoteName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Add a timeout/backoff resilience helper for external command execution in the commands module
- Apply the helper across multiple git external call paths in rollout metadata collection
- Add failure simulation tests for timeout, transient errors, and retry exhaustion
- Update resilience tuning docs and add an ops runbook with escalation and rollback

## Identified Unprotected Paths (Before)
1. git rev-list in metadata collection
2. git show metadata extraction calls
3. git ls-remote remote URL lookup

## Changes
- New helper: components/chef-automate-collect/commands/command_resilience.go
- Applied helper in ReadGitMetadata() in components/chef-automate-collect/commands/metadata_collectors.go
- New tests: components/chef-automate-collect/commands/command_resilience_test.go
- Updated tuning doc: ai-track-docs/resilience.md
- Added ops runbook: ai-track-docs/ops-runbook.md
- Added test evidence section: ai-track-docs/build-test.md

## Validation Evidence
- go test ./commands -run 'TestExecuteCommandWithResilience' -count=1 -v
- go test ./commands -count=1
- go build ./...

Observed results include passing tests for:
- TestExecuteCommandWithResilienceRetriesOnErrorThenSucceeds
- TestExecuteCommandWithResilienceReturnsErrorAfterExhaustion
- TestExecuteCommandWithResilienceHandlesTimeouts

## Tuning and Rollback
- Tuning parameters documented in ai-track-docs/resilience.md and ai-track-docs/ops-runbook.md
- Rollback path documented in both docs (commit revert and validation commands)
